### PR TITLE
Botones de cambio de estado

### DIFF
--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -412,7 +412,7 @@ export class GestorAgendasComponent implements OnInit {
             agenda = ag;
             // Actualizo la agenda global (modelo)
             this.agenda = ag;
-            if (this.showEditarAgendaPanel && agenda.estado !== 'publicada' && agenda.estado !== 'disponible' ) {
+            if (this.showEditarAgendaPanel && agenda.estado !== 'publicada' && agenda.estado !== 'disponible' && agenda.estado !== 'planificacion' ) {
                 this.plex.info('danger', '', 'No puedes editar la agenda selecionada.', 3000);
                 return;
             }
@@ -500,7 +500,6 @@ export class GestorAgendasComponent implements OnInit {
     actualizarEstadoEmit(estado) {
         // Se suspende una agenda completa
         // Se muestra la lista de pacientes y opción de enviarles SMS a discreción
-        debugger;
         if (estado === 'suspendida') {
             this.showTurnos = false;
             this.showEditarAgenda = false;

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -421,10 +421,9 @@ export class GestorAgendasComponent implements OnInit {
                 this.agendasSeleccionadas = [];
                 this.agendasSeleccionadas = [...this.agendasSeleccionadas, ag];
             } else {
-                let index;
-                if (this.estaSeleccionada(agenda)) {
+                let index = this.estaSeleccionada(agenda);
+                if (index >= 0) {
                     agenda.agendaSeleccionadaColor = 'success';
-                    index = this.agendasSeleccionadas.indexOf(agenda);
                     this.agendasSeleccionadas.splice(index, 1);
                     this.agendasSeleccionadas = [...this.agendasSeleccionadas];
                 } else {
@@ -466,7 +465,7 @@ export class GestorAgendasComponent implements OnInit {
     }
 
     estaSeleccionada(agenda: any) {
-        return this.agendasSeleccionadas.find(x => x.id === agenda._id);
+        return this.agendasSeleccionadas.findIndex(x => x.id === agenda._id);
     }
 
     setColorEstadoAgenda(agenda) {
@@ -499,9 +498,9 @@ export class GestorAgendasComponent implements OnInit {
     }
 
     actualizarEstadoEmit(estado) {
-
         // Se suspende una agenda completa
         // Se muestra la lista de pacientes y opción de enviarles SMS a discreción
+        debugger;
         if (estado === 'suspendida') {
             this.showTurnos = false;
             this.showEditarAgenda = false;

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -328,13 +328,13 @@ export class GestorAgendasComponent implements OnInit {
         this.editaAgenda = agenda;
 
         if (this.editaAgenda.estado === 'planificacion') {
-            this.showGestorAgendas = false;
             this.showEditarAgenda = true;
+            this.showGestorAgendas = false;
             this.showEditarAgendaPanel = false;
         } else {
             this.showGestorAgendas = true;
-            this.showEditarAgenda = false;
             this.showEditarAgendaPanel = true;
+            this.showEditarAgenda = false;
             this.showTurnos = false;
         }
         this.showAgregarNotaAgenda = false;
@@ -412,6 +412,10 @@ export class GestorAgendasComponent implements OnInit {
             agenda = ag;
             // Actualizo la agenda global (modelo)
             this.agenda = ag;
+            if (this.showEditarAgendaPanel && agenda.estado !== 'publicada' && agenda.estado !== 'disponible' ) {
+                this.plex.info('danger', '', 'No puedes editar la agenda selecionada.', 3000);
+                return;
+            }
 
             if (!multiple) {
                 this.agendasSeleccionadas = [];

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.html
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.html
@@ -75,10 +75,10 @@
                             <th class="text-right estado">Estado</th>
                         </thead>
                         <tbody>
-                            <tr *ngFor="let agenda of agendas; let i=index" class="hover" [ngClass]="{'bg-inverse text-white': estaSeleccionada(this.agenda)}">
+                            <tr *ngFor="let agenda of agendas; let i=index" class="hover" [ngClass]="{'bg-inverse text-white': estaSeleccionada(this.agenda) >= 0}">
                                 <td (click)="verAgenda(agenda, true, $event)">
-                                    <i *ngIf="estaSeleccionada(agenda)" class="mdi mdi-checkbox-marked"></i>
-                                    <i *ngIf="!estaSeleccionada(agenda)" class="mdi mdi-checkbox-blank-outline"></i>
+                                    <i *ngIf="estaSeleccionada(agenda) >= 0" class="mdi mdi-checkbox-marked"></i>
+                                    <i *ngIf="!(estaSeleccionada(agenda) >= 0)" class="mdi mdi-checkbox-blank-outline"></i>
                                 </td>
                                 <td (click)="verAgenda(agenda, false, $event)">
                                     <div class="datos-agenda">{{agenda.horaInicio | date: 'EEE' | uppercase }} {{agenda.horaInicio | date: 'dd/MM/yyyy'}}

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -71,42 +71,16 @@ export class BotonesAgendaComponent implements OnInit {
                 'estado': estado
             };
 
-            this.serviceAgenda.patch(agenda.id, patch).subscribe(resultado => {
+            this.serviceAgenda.patch(agenda.id, patch).subscribe((resultado: any) => {
                 // Si son múltiples, esperar a que todas se actualicen
+                agenda.estado = resultado.estado;
                 if (alertCount === 0) {
                     if (this.cantidadSeleccionadas === 1) {
-
-                        if (estado === 'prePausada' && agenda.prePausada === 'publicada') {
-                            this.plex.confirm('¿Publicar Agenda?').then((confirmado) => {
-                                if (!confirmado) {
-                                    return false;
-                                }
-                                this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                                this.actualizarEstadoEmit.emit(estado);
-                            });
-                        } else {
-                            this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                            this.actualizarEstadoEmit.emit(estado);
-                        }
-
-
+                        this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
+                        this.actualizarEstadoEmit.emit(estado);
                     } else {
-                        if (estado === 'prePausada') {
-                            this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado');
-                        } else {
-                            if (estado === 'prePausada' && agenda.prePausada === 'publicada') {
-                                this.plex.confirm('¿Publicar Agendas?').then((confirmado) => {
-                                    if (!confirmado) {
-                                        return false;
-                                    }
-                                    this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                                    this.actualizarEstadoEmit.emit(estado);
-                                });
-                            } else {
-                                this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                                this.actualizarEstadoEmit.emit(estado);
-                            }
-                        }
+                        this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
+                        this.actualizarEstadoEmit.emit(estado);
                     }
                     alertCount++;
                 }
@@ -116,7 +90,7 @@ export class BotonesAgendaComponent implements OnInit {
 
     // Actualiza estado de las Agendas seleccionadas
     actualizarEstado(estado) {
-
+        debugger;
         switch (estado) {
             case 'publicada':
                 this.plex.confirm('¿Publicar Agenda?').then((confirmado) => {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -90,7 +90,6 @@ export class BotonesAgendaComponent implements OnInit {
 
     // Actualiza estado de las Agendas seleccionadas
     actualizarEstado(estado) {
-        debugger;
         switch (estado) {
             case 'publicada':
                 this.plex.confirm('¿Publicar Agenda?').then((confirmado) => {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -190,7 +190,17 @@ export class RevisionAgendaComponent implements OnInit {
             nombre: event.query
         };
         if (event.query) {
-            this.serviceCie10.get(query).subscribe(event.callback);
+            this.serviceCie10.get(query).subscribe((datos) => {
+                debugger;
+                this.diagnosticos.forEach(elem => {
+                    let index = datos.findIndex((item) => item.codigo === elem.codificacion.codigo );
+                    if (index >= 0) {
+                        datos.splice(index, 1);
+                    }
+                });
+
+                event.callback(datos);
+            });
         } else {
             event.callback([]);
         }

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -191,7 +191,6 @@ export class RevisionAgendaComponent implements OnInit {
         };
         if (event.query) {
             this.serviceCie10.get(query).subscribe((datos) => {
-                debugger;
                 this.diagnosticos.forEach(elem => {
                     let index = datos.findIndex((item) => item.codigo === elem.codificacion.codigo );
                     if (index >= 0) {


### PR DESCRIPTION
- Arreglamos errores en los botones de cambio de estado.
- La desselección de agendas tenía un error. 
- Evitar agregar códigos CIE10 duplicados en revisar agenda.