### PR TITLE
controles cuando el paciente no posee documento

### DIFF
--- a/src/app/components/paciente/paciente-create-update.component.ts
+++ b/src/app/components/paciente/paciente-create-update.component.ts
@@ -351,11 +351,11 @@ export class PacienteCreateUpdateComponent implements OnInit {
             } else {
                 if (this.seleccion.direccion[0].ubicacion) {
                     if (this.seleccion.direccion[0].ubicacion.provincia !== null) {
-                        (this.seleccion.direccion[0].ubicacion.provincia.nombre === 'Neuquén') ? this.viveProvNeuquen = true : this.viveProvNeuquen = false;
+                        (this.seleccion.direccion[0].ubicacion.provincia.nombre === 'Neuquén') ? this.viveProvNeuquen = true: this.viveProvNeuquen = false;
                         this.loadLocalidades(this.seleccion.direccion[0].ubicacion.provincia);
                     }
                     if (this.seleccion.direccion[0].ubicacion.localidad !== null) {
-                        (this.seleccion.direccion[0].ubicacion.localidad.nombre === 'Neuquén') ? this.viveEnNeuquen = true : this.viveEnNeuquen = false;
+                        (this.seleccion.direccion[0].ubicacion.localidad.nombre === 'Neuquén') ? this.viveEnNeuquen = true: this.viveEnNeuquen = false;
                         this.loadBarrios(this.seleccion.direccion[0].ubicacion.localidad);
                     }
                 }
@@ -503,7 +503,9 @@ export class PacienteCreateUpdateComponent implements OnInit {
 
             let operacionPac: Observable < IPaciente > ;
             // generamos pacientes temporales a partir de las nuevas relaciones
-            await this.crearTemporales(pacienteGuardar);
+            if (pacienteGuardar.documento) {
+                await this.crearTemporales(pacienteGuardar);
+            }
             operacionPac = this.pacienteService.save(pacienteGuardar);
             operacionPac.subscribe(result => {
                 if (result) {
@@ -523,12 +525,10 @@ export class PacienteCreateUpdateComponent implements OnInit {
                                 this.pacienteService.patch(rel.referencia, {
                                     'op': 'deleteRelacion',
                                     'dto': dto
-                                }).subscribe(result2 => {
-                                });
+                                }).subscribe(result2 => {});
                             }
                         });
                     }
-
                     // agregamos las relaciones opuestas
                     if (pacienteGuardar.relaciones && pacienteGuardar.relaciones.length > 0) {
                         pacienteGuardar.relaciones.forEach(rel => {
@@ -542,14 +542,13 @@ export class PacienteCreateUpdateComponent implements OnInit {
                                 referencia: pacienteGuardar.id,
                                 nombre: pacienteGuardar.nombre,
                                 apellido: pacienteGuardar.apellido,
-                                documento: pacienteGuardar.documento
+                                documento: pacienteGuardar.documento ? pacienteGuardar.documento : ''
                             };
                             if (rel.referencia) {
                                 this.pacienteService.patch(rel.referencia, {
                                     'op': 'updateRelacion',
                                     'dto': dto
-                                }).subscribe(result2 => {
-                                });
+                                }).subscribe(result2 => {});
                             }
                         });
                     }
@@ -718,12 +717,17 @@ export class PacienteCreateUpdateComponent implements OnInit {
     }
     preSave(valid) {
         if (valid.formValid) {
-            this.disableGuardar = true;
-            this.verificaPacienteRepetido().then((resultado) => {
-                if (!resultado) {
-                    this.save(valid);
-                }
-            });
+            if (this.pacienteModel.documento) {
+                this.verificaPacienteRepetido().then((resultado) => {
+                    if (!resultado) {
+                        this.save(valid);
+                        this.disableGuardar = true;
+                    };
+                });
+            } else {
+                this.save(valid);
+                this.disableGuardar = true;
+            }
         } else {
             this.plex.alert('Debe completar los datos obligatorios');
         }


### PR DESCRIPTION
- Verificamos en el model del paciente si tiene documento, para que no intente realizar matcheos.
- Evitamos la generación de temporales relacionados si el paciente no posee documento.