### PR TITLE
fix deteccion conflicto clonar agenda

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/clonar-agenda.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/clonar-agenda.ts
@@ -193,7 +193,7 @@ export class ClonarAgendaComponent implements OnInit {
                         dia.estado = 'conflicto';
                     }
                 }
-                if (agenda.espacioFisico) {
+                if (agenda.espacioFisico && this.agenda.espacioFisico) {
                     if (agenda.espacioFisico.id === this.agenda.espacioFisico.id) {
                         agenda.conflictoEF = 1;
                         dia.estado = 'conflicto';

--- a/src/app/components/usuario/arbolPermisos.html
+++ b/src/app/components/usuario/arbolPermisos.html
@@ -1,5 +1,5 @@
 <plex-accordion *ngIf="item.child">
-    <plex-panel (toggle)="expand($event)" >
+    <plex-panel (toggle)="expand($event)">
         <div plex-accordion-title>
             {{item.title}}
             <span *ngIf="allModule">(todos)</span>
@@ -15,10 +15,11 @@
     <plex-bool [(ngModel)]="state" *ngIf="item.type === 'boolean'" label="{{item.title}}" type="slide"> </plex-bool>
 
     <div *ngIf="item.type !== 'boolean'">
-        <h5>
+        <!-- El seleccionar todos para prestaciones se quita segun requerimientos -->
+        <!-- <h5>
             {{item.title}}
             <plex-bool [(ngModel)]="all" label="Seleccionar todos" type="slide"> </plex-bool>
-        </h5>
+        </h5> -->
         <plex-select [multiple]="true" [readonly]="all" [(ngModel)]="seleccionados" (getData)="loadData(item.type, $event)" placeholder="Selecciones los elementos con permios"
             (change)="selectChange()" name="plexSelect"></plex-select>
     </div>


### PR DESCRIPTION
- Ahora al clonar marca correctamente los conflictos encontrados.

- Va adjunto el cambio requerido en gestión de pacientes: no permite mas "seleccionar todos" para las prestaciones.