### PR TITLE
Mejora paciente turno

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -929,6 +929,7 @@ export class DarTurnosComponent implements OnInit {
                         documento: this.paciente.documento,
                         apellido: this.paciente.apellido,
                         nombre: this.paciente.nombre,
+                        fechaNacimiento: this.paciente.fechaNacimiento,
                         telefono: this.telefono,
                         carpetaEfectores: this.paciente.carpetaEfectores
                     };

--- a/src/app/components/turnos/dashboard/solicitud-turno-ventanilla/solicitud-turno-ventanilla.component.ts
+++ b/src/app/components/turnos/dashboard/solicitud-turno-ventanilla/solicitud-turno-ventanilla.component.ts
@@ -117,9 +117,17 @@ export class SolicitudTurnoVentanillaComponent implements OnInit {
     }
 
     loadOrganizacion(event) {
-        this.servicioOrganizacion.get({}).subscribe(organizaciones => {
-            event.callback(organizaciones);
-        });
+        if (event.query) {
+            let query = {
+                nombre: event.query
+            };
+            this.servicioOrganizacion.get(query).subscribe(resultado => {
+                event.callback(resultado);
+            });
+        }
+        // this.servicioOrganizacion.get({}).subscribe(organizaciones => {
+        //     event.callback(organizaciones);
+        // });
     }
 
     // loadProfesionales(event) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -111,6 +111,7 @@ export class RevisionAgendaComponent implements OnInit {
             documento: this.paciente.documento,
             apellido: this.paciente.apellido,
             nombre: this.paciente.nombre,
+            fechaNacimiento: this.paciente.fechaNacimiento,
             telefono: telefono
         };
         if (this.turnoSeleccionado) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -112,7 +112,8 @@ export class RevisionAgendaComponent implements OnInit {
             apellido: this.paciente.apellido,
             nombre: this.paciente.nombre,
             fechaNacimiento: this.paciente.fechaNacimiento,
-            telefono: telefono
+            telefono: telefono,
+            carpetaEfectores: this.paciente.carpetaEfectores
         };
         if (this.turnoSeleccionado) {
             this.turnoSeleccionado.paciente = pacienteTurno;

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -42,18 +42,6 @@ export class TurnosComponent implements OnInit {
                     // Si el turno está disponible pero ya paso la hora
                     if (turno.estado === 'disponible' && this.delDia && turno.horaInicio < this.hoy) {
                         this.arrayDelDia[i]--;
-                    } else {
-                        if (turno.estado === 'asignado') {
-                            this.servicePaciente.getById(turno.paciente.id).subscribe((paciente) => {
-                                if (paciente && (paciente.id)) {  // && paciente.carpetaEfectores
-                                    let carpetaEfector = null;
-                                    carpetaEfector = paciente.carpetaEfectores.filter((data) => {
-                                        return (data.organizacion.id === this.auth.organizacion.id);
-                                    });
-                                    turno.paciente.carpetaEfectores = carpetaEfector;
-                                }
-                            });
-                        }
                     }
                 });
             }

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -43,21 +43,6 @@ export class TurnosComponent implements OnInit {
                     if (turno.estado === 'disponible' && this.delDia && turno.horaInicio < this.hoy) {
                         this.arrayDelDia[i]--;
                     }
-                    // esto no va mas. Cuando se actualiza MPI va a buscar los turnos pendientes del paciente y actualiza los datos.
-
-                    // else {
-                    //     if (turno.estado === 'asignado') {
-                    //         this.servicePaciente.getById(turno.paciente.id).subscribe((paciente) => {
-                    //             if (paciente && (paciente.id)) {  // && paciente.carpetaEfectores
-                    //                 let carpetaEfector = null;
-                    //                 carpetaEfector = paciente.carpetaEfectores.filter((data) => {
-                    //                     return (data.organizacion.id === this.auth.organizacion.id);
-                    //                 });
-                    //                 turno.paciente.carpetaEfectores = carpetaEfector;
-                    //             }
-                    //         });
-                    //     }
-                    // }
                 });
             }
         }


### PR DESCRIPTION
- dejamos de hacer un get para c/ paciente cada vez que seleccionamos una agenda, en cambio hacemos una actualización de los turnos asignados a un paciente cuando éste se modifica.

- Al dar el turno, enviamos también la fecha de nacimiento del paciente para que ésta quede guardada en el turno