### PR TITLE
Mejora código

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -758,7 +758,7 @@ export class DarTurnosComponent implements OnInit {
     // a partir del documento y del efector
     obtenerCarpetaPaciente(paciente) {
 
-        this.carpetaEfector = { organizacion: this.auth.organizacion, nroCarpeta: '' };
+        this.carpetaEfector = { organizacion: { nombre: this.auth.organizacion, id: this.auth.organizacion.id }, nroCarpeta: '' };
         // Verifico que tenga nro de carpeta de Historia clínica en el efector
         if (this.paciente.carpetaEfectores && this.paciente.carpetaEfectores.length > 0) {
             this.carpetaEfector = this.paciente.carpetaEfectores.find((data) => {

--- a/src/app/components/turnos/dar-turnos/dar-turnos.html
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.html
@@ -282,7 +282,7 @@
                                                 <plex-select *ngIf="!turno.tipoPrestacion" label="Tipo de prestación" [(ngModel)]="turnoTipoPrestacion" [data]="bloque.tipoPrestaciones"
                                                     name="turnoTipoPrestacion"></plex-select>
                                                 <plex-phone label="Número de celular" [(ngModel)]="telefono" (change)="cambiarTelefono()" name="telefono"></plex-phone>
-                                                <plex-text *ngIf="carpetaEfector" label="Nro Carpeta" name="nroCarpeta" [(ngModel)]="carpetaEfector.nroCarpeta"></plex-text>
+                                                <plex-text *ngIf="carpetaEfector" (change)="cambiarCarpeta()" label="Nro Carpeta" name="nroCarpeta" [(ngModel)]="carpetaEfector.nroCarpeta"></plex-text>
                                             </div>
                                         </div>
                                         <hr>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/listar-turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/listar-turnos.component.ts
@@ -31,21 +31,6 @@ export class ListarTurnosComponent implements OnInit {
         this.turnosAsignados = (turnos).filter((turno) => {
             return (turno.paciente && turno.paciente.id) && (turno.estado === 'asignado' || turno.estado === 'suspendido');
         });
-        for (let t = 0; t < this.turnosAsignados.length; t++) {
-            // let params = { documento: this.turnos[t].paciente.documento, organizacion: this.auth.organizacion.id };
-            this.servicePaciente.getById(this.turnosAsignados[t].paciente.id).subscribe((paciente) => {
-                if (paciente && paciente.carpetaEfectores) {
-                    let carpetaEfector = null;
-                    carpetaEfector = paciente.carpetaEfectores.filter((data) => {
-                        return (data.organizacion.id === this.auth.organizacion.id);
-                    });
-                    if (this.turnosAsignados[t] && this.turnosAsignados[t].paciente) {
-                        this.turnosAsignados[t].paciente = paciente;
-                        this.turnosAsignados[t].paciente.carpetaEfectores = carpetaEfector;
-                    }
-                }
-            });
-        }
     }
     get agenda(): any {
         return this._agenda;

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -111,6 +111,7 @@ export class RevisionAgendaComponent implements OnInit {
             documento: this.paciente.documento,
             apellido: this.paciente.apellido,
             nombre: this.paciente.nombre,
+            fechaNacimiento: this.paciente.fechaNacimiento,
             telefono: telefono
         };
         if (this.turnoSeleccionado) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -112,7 +112,8 @@ export class RevisionAgendaComponent implements OnInit {
             apellido: this.paciente.apellido,
             nombre: this.paciente.nombre,
             fechaNacimiento: this.paciente.fechaNacimiento,
-            telefono: telefono
+            telefono: telefono,
+            carpetaEfectores: this.paciente.carpetaEfectores
         };
         if (this.turnoSeleccionado) {
             this.turnoSeleccionado.paciente = pacienteTurno;

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -330,7 +330,7 @@ export class RevisionAgendaComponent implements OnInit {
 
         if (this.turnoSeleccionado.tipoPrestacion) {
             this.serviceTurno.put(datosTurno).subscribe(resultado => {
-                this.plex.toast('success', 'Información', 'El turno fue actualizado', 1);
+                this.plex.toast('success', 'Información', 'El turno fue actualizado');
                 this.cerrarAsistencia();
                 this.cerrarCodificacion();
                 this.turnoSeleccionado = null;

--- a/src/app/components/turnos/gestor-agendas/operaciones-turnos/carpeta-paciente.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-turnos/carpeta-paciente.component.ts
@@ -21,10 +21,18 @@ export class CarpetaPacienteComponent implements OnInit {
     autorizado: any;
     permisosRequeridos = 'turnos:agenda:puedeEditarCarpeta';
 
-    pacienteTurno: IPaciente;
+    pacienteTurno: any;
     carpetaPaciente = {
         organizacion: {
             id: this.auth.organizacion.id,
+            nombre: this.auth.organizacion.nombre
+        },
+        nroCarpeta: ''
+    };
+
+    carpetaSave = {
+        organizacion: {
+            _id: this.auth.organizacion.id,
             nombre: this.auth.organizacion.nombre
         },
         nroCarpeta: ''
@@ -54,7 +62,7 @@ export class CarpetaPacienteComponent implements OnInit {
                     if (indiceCarpeta === -1) {
                         // Si no hay carpeta en el paciente MPI, buscamos la carpeta en colección carpetaPaciente, usando el nro. de documento
                         this.servicioPaciente.getNroCarpeta({ documento: this.turnoSeleccionado.paciente.documento, organizacion: this.auth.organizacion.id }).subscribe(carpeta => {
-                            if (carpeta) {
+                            if (carpeta.nroCarpeta) {
                                 this.carpetaPaciente = carpeta;
                             }
                         });
@@ -65,13 +73,13 @@ export class CarpetaPacienteComponent implements OnInit {
     }
 
     guardarCarpetaPaciente() {
-
         if (this.carpetaPaciente.nroCarpeta !== '') {
+            this.carpetaSave.nroCarpeta = this.carpetaPaciente.nroCarpeta;
             let indiceCarpeta = this.pacienteTurno.carpetaEfectores.findIndex(x => x.organizacion.id === this.auth.organizacion.id);
             if (indiceCarpeta > -1) {
-                this.pacienteTurno.carpetaEfectores[indiceCarpeta] = this.carpetaPaciente;
+                this.pacienteTurno.carpetaEfectores[indiceCarpeta] = this.carpetaSave;
             } else {
-                this.pacienteTurno.carpetaEfectores.push(this.carpetaPaciente);
+                this.pacienteTurno.carpetaEfectores.push(this.carpetaSave);
             }
             this.servicioPaciente.patch(this.turnoSeleccionado.paciente.id, { op: 'updateCarpetaEfectores', carpetaEfectores: this.pacienteTurno.carpetaEfectores }).subscribe(resultadoCarpeta => {
                 this.guardarCarpetaEmit.emit(true);

--- a/src/app/components/turnos/gestor-agendas/operaciones-turnos/carpeta-paciente.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-turnos/carpeta-paciente.component.ts
@@ -43,13 +43,15 @@ export class CarpetaPacienteComponent implements OnInit {
                 // Traer las carpetas del paciente que haya en MPI
                 this.servicioPaciente.getById(this.turnoSeleccionado.paciente.id).subscribe(paciente => {
                     this.pacienteTurno = paciente;
+                    let indiceCarpeta = -1;
                     if (paciente.carpetaEfectores.length > 0) {
                         // Filtramos y traemos sólo la carpeta de la organización actual
-                        let indiceCarpeta = paciente.carpetaEfectores.findIndex(x => x.organizacion.id === this.auth.organizacion.id);
+                        indiceCarpeta = paciente.carpetaEfectores.findIndex(x => x.organizacion.id === this.auth.organizacion.id);
                         if (indiceCarpeta > -1) {
                             this.carpetaPaciente = paciente.carpetaEfectores[indiceCarpeta];
                         }
-                    } else {
+                    }
+                    if (indiceCarpeta === -1) {
                         // Si no hay carpeta en el paciente MPI, buscamos la carpeta en colección carpetaPaciente, usando el nro. de documento
                         this.servicioPaciente.getNroCarpeta({ documento: this.turnoSeleccionado.paciente.documento, organizacion: this.auth.organizacion.id }).subscribe(carpeta => {
                             if (carpeta) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-turnos/carpeta-paciente.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-turnos/carpeta-paciente.html
@@ -11,12 +11,9 @@
                 {{turnoSeleccionado.paciente | paciente}}
             </span>
         </div>
-        <div class="col-12" *ngIf="carpetaPaciente">
+        <div class="col-12">
             <plex-text label="Número de Carpeta" name="nroCarpeta" [(ngModel)]="carpetaPaciente.nroCarpeta">
             </plex-text>
-        </div>
-        <div class="col-12" *ngIf="!carpetaPaciente">
-            Cargando...
         </div>
     </div>
     <hr>

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -18,6 +18,7 @@ import * as moment from 'moment';
 })
 
 export class TurnosComponent implements OnInit {
+    carpetasPaciente: any;
     private _agenda: IAgenda;
     // Parámetros
     @Input('agenda')
@@ -43,6 +44,12 @@ export class TurnosComponent implements OnInit {
                     if (turno.estado === 'disponible' && this.delDia && turno.horaInicio < this.hoy) {
                         this.arrayDelDia[i]--;
                     }
+                    if (turno.paciente && turno.paciente.carpetaEfectores && turno.paciente.carpetaEfectores.length > 0) {
+                        this.carpetasPaciente = turno.paciente.carpetaEfectores.filter((elem) => {
+                            return (elem.organizacion.nombre === this.auth.organizacion.nombre);
+                        });
+                    }
+
                 });
             }
         }

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -19,7 +19,7 @@ import * as moment from 'moment';
 
 export class TurnosComponent implements OnInit {
     private _agenda: IAgenda;
-    public nombreOrganizacion = this.auth.organizacion.nombre;
+    public idOrganizacion = this.auth.organizacion.id;
     // Parámetros
     @Input('agenda')
     set agenda(value: any) {

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -18,8 +18,8 @@ import * as moment from 'moment';
 })
 
 export class TurnosComponent implements OnInit {
-    carpetasPaciente: any;
     private _agenda: IAgenda;
+    public nombreOrganizacion = this.auth.organizacion.nombre;
     // Parámetros
     @Input('agenda')
     set agenda(value: any) {
@@ -44,12 +44,6 @@ export class TurnosComponent implements OnInit {
                     if (turno.estado === 'disponible' && this.delDia && turno.horaInicio < this.hoy) {
                         this.arrayDelDia[i]--;
                     }
-                    if (turno.paciente && turno.paciente.carpetaEfectores && turno.paciente.carpetaEfectores.length > 0) {
-                        this.carpetasPaciente = turno.paciente.carpetaEfectores.filter((elem) => {
-                            return (elem.organizacion.nombre === this.auth.organizacion.nombre);
-                        });
-                    }
-
                 });
             }
         }

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -151,7 +151,7 @@
                                 <span *ngIf="turno?.paciente?.id && turno.paciente.documento === ''">
                                     <br>Sin documento (temporal)
                                 </span>
-                                <span *ngIf="carpetasPaciente">
+                                <span *ngIf="turno.estado ==='asignado' && carpetasPaciente">
                                     | Nro Carpeta
                                     <span *ngFor="let carpeta of carpetasPaciente | slice:0:1;">{{ carpeta.nroCarpeta }}</span>
                                 </span>

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -153,7 +153,7 @@
                                 </span>
                                 <span *ngIf="turno.estado ==='asignado' && turno.paciente.carpetaEfectores">
                                     <span *ngFor="let carpeta of turno.paciente.carpetaEfectores">
-                                        <span *ngIf="carpeta.organizacion.nombre == nombreOrganizacion && carpeta.nroCarpeta!==null"> | Nro Carpeta {{carpeta.nroCarpeta}} </span>
+                                        <span *ngIf="carpeta.organizacion?._id == idOrganizacion && carpeta.nroCarpeta!==null"> | Nro Carpeta {{carpeta.nroCarpeta}} </span>
                                     </span>
                                 </span>
                             </small>

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -151,9 +151,9 @@
                                 <span *ngIf="turno?.paciente?.id && turno.paciente.documento === ''">
                                     <br>Sin documento (temporal)
                                 </span>
-                                <span *ngIf="turno?.paciente?.id && turno.paciente.carpetaEfectores?.length > 0 && turno.paciente.carpetaEfectores[0].nroCarpeta !== ''">
+                                <span *ngIf="carpetasPaciente">
                                     | Nro Carpeta
-                                    <span *ngFor="let carpeta of turno.paciente.carpetaEfectores | slice:0:1;">{{ carpeta.nroCarpeta }}</span>
+                                    <span *ngFor="let carpeta of carpetasPaciente | slice:0:1;">{{ carpeta.nroCarpeta }}</span>
                                 </span>
                             </small>
                             <small class="text-warning" *ngIf="turno.tipoTurno === 'profesional' && turno.estado === 'asignado'">(autocitado)</small>

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -151,9 +151,10 @@
                                 <span *ngIf="turno?.paciente?.id && turno.paciente.documento === ''">
                                     <br>Sin documento (temporal)
                                 </span>
-                                <span *ngIf="turno.estado ==='asignado' && carpetasPaciente">
-                                    | Nro Carpeta
-                                    <span *ngFor="let carpeta of carpetasPaciente | slice:0:1;">{{ carpeta.nroCarpeta }}</span>
+                                <span *ngIf="turno.estado ==='asignado' && turno.paciente.carpetaEfectores">
+                                    <span *ngFor="let carpeta of turno.paciente.carpetaEfectores">
+                                        <span *ngIf="carpeta.organizacion.nombre == nombreOrganizacion && carpeta.nroCarpeta!==null"> | Nro Carpeta {{carpeta.nroCarpeta}} </span>
+                                    </span>
                                 </span>
                             </small>
                             <small class="text-warning" *ngIf="turno.tipoTurno === 'profesional' && turno.estado === 'asignado'">(autocitado)</small>

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -119,18 +119,6 @@ export class PuntoInicioComponent implements OnInit {
                             });
                             // asignamos la prestacion al turno
                             turno['prestacion'] = this.prestaciones[indexPrestacion];
-                            // TODO:: buscamos los datos de los pacientes en agendas No se si es correcto q por cada paciente consulte la api
-                            // if (turno.estado === 'asignado' && (!turno.paciente.carpetaEfectores || turno.paciente.carpetaEfectores.length <= 0)) {
-                            //     this.servicePaciente.getById(turno.paciente.id).subscribe((paciente) => {
-                            //         if (paciente && (paciente.id)) {
-                            //             let carpetaEfector = null;
-                            //             carpetaEfector = paciente.carpetaEfectores.filter((carpeta) => {
-                            //                 return (carpeta.organizacion.id === this.auth.organizacion.id);
-                            //             });
-                            //             turno.paciente.carpetaEfectores = [carpetaEfector];
-                            //         }
-                            //     });
-                            // }
                         });
                     });
 
@@ -149,7 +137,7 @@ export class PuntoInicioComponent implements OnInit {
             }
 
             this.agendasOriginales = JSON.parse(JSON.stringify(this.agendas));
-            
+
             // buscamos las que estan fuera de agenda para poder listarlas:
             // son prestaciones sin turno creadas en la fecha seleccionada en el filtro
             this.fueraDeAgenda = this.prestaciones.filter(p => (!p.solicitud.turno &&


### PR DESCRIPTION
- Borramos el getById de c/paciente en la agenda, que ya no es necesario en base a los cambios realizados en el PR 117 (API)

- Fix en la lectura/modificación de nroCarpeta para pacientes que tienen carpeta en más de un efector (complementa pr 120 en api )

- Fix plex toast revisión agenda
