### PR TITLE
Se agrega propiedad en angular-cli.json para omitir que muestre las d…

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -42,7 +42,10 @@
     },
     "defaults": {
         "styleExt": "css",
-        "prefixInterfaces": false
+        "prefixInterfaces": false,
+        "build": {
+            "showCircularDependencies": false
+        }
     },
     "lint": [{
         "files": "src/**/*.ts",


### PR DESCRIPTION
Bueno, resulta que desde hace un tiempo angular-cli.json viene con esa propiedad por defecto en true, el listado de propiedades está en: https://github.com/angular/angular-cli/wiki/angular-cli

El warning es claramente porque en rup.component.ts se importan los componentes (ej peso), y luego cada uno de estos componentes a su vez importan  también rup.component.ts

La 'solución' berreta es pasar esa propiedad showCircularDependencies en false y listo.

La solución copada no se me ocurrió, por eso mando este pull request :joy:

