### PR TITLE
Error doble click en MPI

### DIFF
--- a/src/app/components/paciente/paciente-search.component.ts
+++ b/src/app/components/paciente/paciente-search.component.ts
@@ -204,7 +204,11 @@ export class PacienteSearchComponent implements OnInit, OnDestroy {
     /**
      * Busca paciente cada vez que el campo de busca cambia su valor
      */
-    public buscar() {
+    public buscar($event) {
+        /* Error en Plex, ejecuta un change cuando el input pierde el foco porque detecta que cambia el valor */
+        if ($event.type) {
+            return;
+        }
         // Cancela la búsqueda anterior
         if (this.timeoutHandle) {
             window.clearTimeout(this.timeoutHandle);

--- a/src/app/components/paciente/paciente-search.html
+++ b/src/app/components/paciente/paciente-search.html
@@ -6,7 +6,7 @@
                 <header>
                     <div class="page-title">Buscar un paciente</div>
                 </header>
-                <plex-text [(ngModel)]="textoLibre" (change)="buscar()" [autoFocus]="autoFocus" prefix="<i class='mdi mdi-barcode-scan'></i>"
+                <plex-text [(ngModel)]="textoLibre" (change)="buscar($event)" [autoFocus]="autoFocus" prefix="<i class='mdi mdi-barcode-scan'></i>"
                     placeholder="Escanee un documento digital, o escriba un documento/apellido/nombre">
                 </plex-text>
                 <!--Loader-->

--- a/src/app/components/turnos/dashboard/paciente-search-turnos.component.ts
+++ b/src/app/components/turnos/dashboard/paciente-search-turnos.component.ts
@@ -58,9 +58,14 @@ export class PacienteSearchTurnosComponent extends PacienteSearchComponent {
         this.sinResultados.emit(false);
     }
 
-    public buscar() {
+    public buscar($event) {
+        /* Error en Plex, ejecuta un change cuando el input pierde el foco porque detecta que cambia el valor */
+        if ($event.type) {
+            return;
+        }
+
         this.pacienteSeleccionado = null;
-        super.buscar();
+        super.buscar({});
         if (!this.resultado || this.resultado.length === 0) {
             this.mostrarNuevo = true;
             this.sinResultados.emit(true);

--- a/src/app/components/turnos/dashboard/paciente-search-turnos.html
+++ b/src/app/components/turnos/dashboard/paciente-search-turnos.html
@@ -3,7 +3,7 @@
         <!--Panel central-->
         <div class="col">
             <plex-box type="primary">
-                <plex-text [(ngModel)]="textoLibre" (change)="buscar()" [autoFocus]="autoFocus" prefix="<i class='mdi mdi-account-card-details'></i>"
+                <plex-text [(ngModel)]="textoLibre" (change)="buscar($event)" [autoFocus]="autoFocus" prefix="<i class='mdi mdi-account-card-details'></i>"
                     placeholder="Ingrese un paciente o escanee un DNI">
                 </plex-text>
                 <!--Loader-->

--- a/src/app/modules/rup/components/elementos/adjuntarDocumeto.ts
+++ b/src/app/modules/rup/components/elementos/adjuntarDocumeto.ts
@@ -36,7 +36,7 @@ export class AdjuntarDocumentoComponent extends RUPComponent implements OnInit {
 
     }
 
-    changeListener($event) : void {
+    changeListener($event): void {
         this.readThis($event.target);
     }
 


### PR DESCRIPTION
plex-input emite un evento **change** cuando el input pierde el foco. Por lo cual estaba lanzando una nueva búsqueda de pacientes y refrescaba la pantalla. 

Por suerte, como argumento llega un objeto Event y prevenimos _por ahora_ la búsqueda. 
