### PR TITLE
Botones citas

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -198,7 +198,7 @@ export class BotonesAgendaComponent implements OnInit {
 
     puedoEditar() {
         return this.agendasSeleccionadas.filter((agenda) => {
-            return agenda.estado === 'asistenciaCerrada' || agenda.estado === 'codificada' || agenda.estado === 'pausada' || agenda.estado === 'suspendida';
+            return agenda.estado === 'pendienteAuditoria' || agenda.estado === 'codificada' || agenda.estado === 'pausada' || agenda.estado === 'suspendida';
         }).length <= 0;
     }
 
@@ -229,7 +229,7 @@ export class BotonesAgendaComponent implements OnInit {
 
     puedoPausar() {
         return this.agendasSeleccionadas.filter((agenda) => {
-            return agenda.estado === 'planificacion' || agenda.estado === 'pausada' || agenda.estado === 'suspendida' || agenda.estado === 'codificada' || agenda.estado === 'asistenciaCerrada';
+            return agenda.estado === 'planificacion' || agenda.estado === 'pausada' || agenda.estado === 'suspendida' || agenda.estado === 'codificada' || agenda.estado === 'pendienteAuditoria';
         }).length <= 0;
     }
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -259,7 +259,7 @@ export class RevisionAgendaComponent implements OnInit {
                 'estado': this.estadoPendienteAuditoria.id
             };
             this.serviceAgenda.patch(this._agenda.id, patch).subscribe(resultado => {
-                this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Asistencia Cerrada');
+                this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Pendiente Auditoria');
                 // this.enableAsistenciaCerrada = false;
                 // this.enableCodificada = true;
             });

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -246,13 +246,12 @@ export class RevisionAgendaComponent implements OnInit {
         turnoSinVerificar = listaTurnos.find(t => {
             return (t && t.paciente && t.paciente.id && !t.asistencia && t.estado !== 'suspendido');
         });
-        if (turnoSinVerificar) {
-            // this.plex.alert('No se puede cerrar la asistencia debido a que existen turnos que no fueron verificados', 'Cerrar Asistencia');
-        } else {
-            // Se cambia de estado la agenda a asistenciaCerrada
+        if (!turnoSinVerificar) {
+            // TODO!!!
+            // Se cambia de estado la agenda a pendienteAuditoria
             let patch = {
-                'op': this.estadoPendienteAuditoria.id,
-                'estado': this.estadoPendienteAuditoria.id
+                'op': 'pendienteAuditoria',
+                'estado': 'pendienteAuditoria'
             };
             this.serviceAgenda.patch(this._agenda.id, patch).subscribe(resultado => {
                 this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Pendiente Auditoria');

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -39,8 +39,6 @@ export class RevisionAgendaComponent implements OnInit {
         this.estadoCodificado = this.estadosAgendaArray.find(e => {
             return e.nombre === 'Auditada';
         });
-        this.enableAsistenciaCerrada = (!(this._agenda.estado === this.estadoPendienteAuditoria.id)) && (!(this._agenda.estado === this.estadoCodificado.id));
-        this.enableCodificada = (this._agenda.estado === this.estadoPendienteAuditoria.id);
     }
     get agenda(): any {
         return this._agenda;
@@ -65,8 +63,6 @@ export class RevisionAgendaComponent implements OnInit {
     turnoTipoPrestacion: any = null;
     pacientesSearch = false;
     diagnosticos = [];
-    enableCodificada = false;
-    enableAsistenciaCerrada = true;
     public showRegistrosTurno = false;
     public seleccion = null;
     public esEscaneado = false;
@@ -260,8 +256,6 @@ export class RevisionAgendaComponent implements OnInit {
             };
             this.serviceAgenda.patch(this._agenda.id, patch).subscribe(resultado => {
                 this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Pendiente Auditoria');
-                // this.enableAsistenciaCerrada = false;
-                // this.enableCodificada = true;
             });
         }
     }
@@ -292,8 +286,6 @@ export class RevisionAgendaComponent implements OnInit {
             };
             this.serviceAgenda.patch(this._agenda.id, patch).subscribe(resultado => {
                 this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Auditada');
-                this.enableAsistenciaCerrada = false;
-                this.enableCodificada = false;
             });
         }
 

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -162,7 +162,7 @@ export class TurnosComponent implements OnInit {
     }
 
     agendaNoCerrada() {
-        return this.agenda.estado !== 'pendienteAuditoria' && this.agenda.estado !== 'codificada';
+        return this.agenda.estado !== 'pendienteAuditoria' && this.agenda.estado !== 'pendienteAsistencia' && this.agenda.estado !== 'codificada' && this.agenda.estado !== 'auditada';
     }
 
     tienenPacientes() {
@@ -245,7 +245,6 @@ export class TurnosComponent implements OnInit {
     }
 
     actualizarBotones() {
-
         this.botones = {
             // Dar asistencia: el turno está con paciente asignado, sin asistencia ==> pasa a estar con paciente asignado, con asistencia
             darAsistencia: this.agendaNoCerrada() && this.tienenPacientes() && this.agendaNoSuspendida() && (this.noTienenAsistencia() && this.ningunoConEstado('suspendido')) && this.agendaHoy(),

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -162,7 +162,7 @@ export class TurnosComponent implements OnInit {
     }
 
     agendaNoCerrada() {
-        return this.agenda.estado !== 'asistenciaCerrada' && this.agenda.estado !== 'codificada';
+        return this.agenda.estado !== 'pendienteAuditoria' && this.agenda.estado !== 'codificada';
     }
 
     tienenPacientes() {


### PR DESCRIPTION
- Fix en botones de turnos de agendas cerradas ( se mostraban opciones para liberar turno, turno doble, etc) https://trello.com/c/H3JVfqYB/91-operaciones-de-turnos-en-agendas-con-estado-auditada

- Actualizamos los chequeos de estado de agenda, según el nuevo enum. de estados

- Queda pendiente un TODO para cambiar el estado de una agenda, a pendienteAuditoria, cuando se da asistencia a todos los turnos.