### PR TITLE
Funcion para buscar en la HUDS en el servicio de prestaciones

### DIFF
--- a/src/app/modules/rup/components/elementos/seguimientoDelPeso.component.ts
+++ b/src/app/modules/rup/components/elementos/seguimientoDelPeso.component.ts
@@ -28,21 +28,22 @@ export class SeguimientoDelPesoComponent extends RUPComponent implements OnInit 
             const conceptIds = this.elementoRUP.conceptosBuscar.map(concepto => concepto.conceptId);
 
             // buscamos
-            this.prestacionesService.getRegistrosEjecucion(this.paciente.id, conceptIds).subscribe(prestaciones => {
+            this.prestacionesService.getRegistrosHuds(this.paciente.id, conceptIds).subscribe(prestaciones => {
 
                 if (prestaciones.length) {
 
                     // armamos array de resultados
-                    this.pesos = prestaciones.map(prestacion => {
-                        let registro = prestacion.ejecucion.registros.filter(p => { return conceptIds.indexOf(p.concepto.conceptId) > -1; });
-                        return ({
-                            // fecha: prestacion.ejecucion.fecha,
-                            fecha: prestacion.ejecucion.fecha,
-                            registro: registro[0],
-                            profesional: registro[0].createdBy,
-                            prestacion: prestacion.solicitud.tipoPrestacion.term
-                        });
-                    });
+                    // this.pesos = prestaciones.map(prestacion => {
+                    //     let registro = prestacion.ejecucion.registros.filter(p => { return conceptIds.indexOf(p.concepto.conceptId) > -1; });
+                    //     return ({
+                    //         // fecha: prestacion.ejecucion.fecha,
+                    //         fecha: prestacion.ejecucion.fecha,
+                    //         registro: registro[0],
+                    //         profesional: registro[0].createdBy,
+                    //         prestacion: prestacion.solicitud.tipoPrestacion.term
+                    //     });
+                    // });
+                    this.pesos = prestaciones;
 
                     // ordenamos los pesos por fecha
                     this.pesos.sort(function (a, b) {
@@ -101,8 +102,12 @@ export class SeguimientoDelPesoComponent extends RUPComponent implements OnInit 
                 xAxes: [{
                     type: 'time',
                     time: {
-                        unit: 'month',
-                        tooltipFormat: 'DD/MM/YYYY'
+                        min: moment(data[0].fecha).subtract(0.5, 'days'),
+                        max: moment(data[data.length - 1].fecha).add(0.5, 'days'),
+                        unit: 'day',
+                        tooltipFormat: 'DD/MM/YYYY',
+                        unitStepSize: 0.5,
+                        round: 'hour',
                         // displayFormats: {
                         //     'millisecond': 'MMM DD',
                         //     'second': 'MMM DD',
@@ -124,7 +129,7 @@ export class SeguimientoDelPesoComponent extends RUPComponent implements OnInit 
                         let text = [];
                         tooltipItems.forEach(function (tooltipItem) {
                             text.push('Profesional: ' + data[tooltipItem.index].profesional.nombreCompleto);
-                            text.push('Prestación: ' + data[tooltipItem.index].prestacion);
+                            text.push('Prestación: ' + data[tooltipItem.index].tipoPrestacion.term);
                         });
 
                         return text;

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -408,20 +408,27 @@ export class PrestacionesService {
         return this.server.get(url, opt);
     }
 
-    getRegistrosEjecucion(idPaciente: string, conceptIds: any[]) {
+    /**
+     * Buscar en la HUDS de un paciente los registros que coincidan con los conceptIds
+     *
+     * @param {string} idPaciente Paciente a buscar
+     * @param {any[]} conceptIds Array de conceptId de SNOMED que deseo buscar
+     * @returns {any[]} Prestaciones del paciente que coincidan con los conceptIds
+     * @memberof PrestacionesService
+     */
+    getRegistrosHuds(idPaciente: string, conceptIds: any[]) {
         let opt = {
             params: {
-                'idPaciente': idPaciente,
-                'ordenFechaEjecucion': true,
-                'conceptsIdEjecucion': conceptIds,
+                'conceptIds': conceptIds,
             },
             options: {
                 showError: true
             }
         };
 
-        return this.server.get(this.prestacionesUrl, opt);
+        return this.server.get(this.prestacionesUrl + '/huds/' + idPaciente, opt);
     }
+
     /**
      * Metodo post. Inserta un objeto nuevo.
      * @param {any} prestacion Recibe solicitud RUP con paciente
@@ -472,10 +479,10 @@ export class PrestacionesService {
                 tipoPrestacion: snomedConcept,
                 // profesional logueado
                 profesional:
-                    {
-                        id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
-                        apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
-                    },
+                {
+                    id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
+                    apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
+                },
                 // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre },
                 registros: []
@@ -493,10 +500,10 @@ export class PrestacionesService {
                 tipoPrestacion: snomedConcept,
                 // profesional logueado
                 profesional:
-                    {
-                        id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
-                        apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
-                    },
+                {
+                    id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
+                    apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
+                },
                 // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre },
                 registros: []
@@ -520,10 +527,10 @@ export class PrestacionesService {
                 tipoPrestacion: snomedConcept,
                 // profesional logueado
                 profesional:
-                    {
-                        id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
-                        apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
-                    },
+                {
+                    id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
+                    apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
+                },
                 // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre },
                 registros: []


### PR DESCRIPTION
Nuevo método en prestaciones.service.ts que busca en las prestaciones del paciente un determinado de conjunto de conceptId. Utiliza un nuevo end point (/prestaciones/huds/idPaciente).

Extra: Se agrego máximo y mínimo en el eje X para el átomo de seguimiento de peso.

Nota: Es necesario hacer checkout en la API sobre el branch _buscar-en-huds_.