### PR TITLE
Rup pi agendas multi prestaciones

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -89,17 +89,17 @@ export class PuntoInicioComponent implements OnInit {
                 fechaDesde: moment(this.fecha).isValid() ? moment(this.fecha).startOf('day').toDate() : new Date(),
                 fechaHasta: moment(this.fecha).isValid() ? moment(this.fecha).endOf('day').toDate() : new Date(),
                 organizacion: this.auth.organizacion.id,
-                estados: ['disponible', 'publicada'],
+                estados: ['disponible', 'publicada', 'pendienteAsistencia', 'pendienteAuditoria'],
                 tieneTurnosAsignados: true,
                 tipoPrestaciones: this.auth.getPermissions('rup:tipoPrestacion:?')
             }),
             // Prestaciones
             this.servicioPrestacion.get({
-                fechaDesde: this.fecha,
+                fechaDesde: this.fecha ? this.fecha : new Date(),
                 fechaHasta: new Date(),
-                organizacion: this.auth.organizacion.id
+                organizacion: this.auth.organizacion.id,
                 // TODO: filtrar por las prestaciones permitidas, pero la API no tiene ningún opción
-                // this.auth.getPermissions('rup:tipoPrestacion:?')
+                // tiposPrestaciones: this.auth.getPermissions('rup:tipoPrestacion:?')
             })
         ).subscribe(data => {
             this.agendas = data[0];

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.html
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.html
@@ -7,10 +7,8 @@
                     <div class="clearfix">
                         <div class="page-title float-left">Punto de inicio | Consultorio</div>
                         <div class="float-right">
-                            <plex-button title="Mostrar sólo mis agendas" icon="mdi mdi-calendar-multiple-check" [type]="(soloMisAgendas) ? 'primary' : 'default'"
-                                (click)="soloMisAgendas = true; filtrar()"></plex-button>
-                            <plex-button title="Mostrar todas las agendas" icon="mdi mdi-asterisk" [type]="(!soloMisAgendas) ? 'primary' : 'default'"
-                                (click)="soloMisAgendas = false; filtrar()"></plex-button>
+                            <plex-button title="Mostrar sólo mis agendas" icon="mdi mdi-calendar-multiple-check" [type]="(soloMisAgendas) ? 'primary' : 'default'" (click)="soloMisAgendas = true; filtrar()"></plex-button>
+                            <plex-button title="Mostrar todas las agendas" icon="mdi mdi-asterisk" [type]="(!soloMisAgendas) ? 'primary' : 'default'" (click)="soloMisAgendas = false; filtrar()"></plex-button>
                         </div>
                     </div>
 
@@ -24,8 +22,7 @@
                             <plex-text [(ngModel)]="paciente" (change)="filtrar()" label="Buscar paciente"></plex-text>
                         </div>
                         <div class="col-6">
-                            <plex-select [(ngModel)]="prestacionSeleccion" name="nombrePrestacion" label="Filtrar por prestación" [data]="tiposPrestacion"
-                                labelField="term" (change)="filtrar()">
+                            <plex-select [(ngModel)]="prestacionSeleccion" name="nombrePrestacion" label="Filtrar por prestación" [data]="tiposPrestacion" labelField="term" (change)="filtrar()">
                             </plex-select>
                         </div>
                     </div>
@@ -52,8 +49,7 @@
 
                         <ng-container *ngIf="agendas.length">
                             <ng-container *ngFor="let agenda of agendas; let i=index">
-                                <tr class="hover" [ngClass]="{'bg-inverse text-white': agendaSeleccionada == agenda}" (click)="cargarTurnos(this.agenda)"
-                                    *ngIf="agenda.estado === 'disponible' || getCantidadPacientes(agenda)">
+                                <tr class="hover" [ngClass]="{'bg-inverse text-white': agendaSeleccionada == agenda}" (click)="cargarTurnos(this.agenda)" *ngIf="agenda.estado === 'disponible' || getCantidadPacientes(agenda)">
 
                                     <td>
                                         <div>{{agenda.horaInicio | date: 'HH:mm'}} a {{agenda.horaFin | date: 'HH:mm'}} hs
@@ -111,8 +107,7 @@
                     <div class="row">
                         <div class="col-12">
                             <ng-container>
-                                {{ agendaSeleccionada.horaInicio | date: 'EEE' }} {{ agendaSeleccionada.horaInicio | date: 'dd/MM/yyyy'}}, {{ agendaSeleccionada.horaInicio
-                                | date: 'HH:mm'}} a {{ agendaSeleccionada.horaFin | date: 'HH:mm'}} hs
+                                {{ agendaSeleccionada.horaInicio | date: 'EEE' }} {{ agendaSeleccionada.horaInicio | date: 'dd/MM/yyyy'}}, {{ agendaSeleccionada.horaInicio | date: 'HH:mm'}} a {{ agendaSeleccionada.horaFin | date: 'HH:mm'}} hs
                                 <div *ngFor="let tipoPrestacion of agendaSeleccionada.tipoPrestaciones">{{tipoPrestacion.nombre}}</div>
 
                                 <div *ngIf="agendaSeleccionada.nota" class="alert alert-info">
@@ -126,8 +121,7 @@
                     <table *ngFor="let bloque of agendaSeleccionada.bloques" class="table table-striped">
                         <thead *ngIf="bloque.descripcion">
                             <tr>
-                                <th *ngIf="!agendaSeleccionada.nominalizada" colspan="4">{{bloque.descripcion}} de {{ bloque.horaInicio | date: 'HH:mm'}} a {{ bloque.horaFin | date:
-                                    'HH:mm'}} hs
+                                <th *ngIf="!agendaSeleccionada.nominalizada" colspan="4">{{bloque.descripcion}} de {{ bloque.horaInicio | date: 'HH:mm'}} a {{ bloque.horaFin | date: 'HH:mm'}} hs
                                 </th>
                                 <th *ngIf="agendaSeleccionada.nominalizada" colspan="4">{{bloque.descripcion}}
                                 </th>
@@ -197,14 +191,13 @@
                                             </plex-button>
 
 
-                                            <plex-button *ngIf="turno.estado !== 'suspendido' && turno.paciente && !turno.prestacion && tienePermisos(turno.tipoPrestacion, turno.prestacion)"
-                                                label="INICIAR PRESTACIÓN" type="success btn-sm" (click)="iniciarPrestacion(turno.paciente, bloque.tipoPrestaciones[0], turno.id)"></plex-button>
+                                            <plex-button *ngIf="turno.estado !== 'suspendido' && turno.paciente && !turno.prestacion && tienePermisos(turno.tipoPrestacion, turno.prestacion)" label="INICIAR PRESTACIÓN" type="success btn-sm" (click)="iniciarPrestacion(turno.paciente, turno.tipoPrestacion, turno.id)"></plex-button>
 
-                                            <plex-button *ngIf="turno.paciente && turno.estado !== 'suspendido' && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'ejecucion' && tienePermisos(turno.tipoPrestacion,turno.prestacion)"
-                                                label="VER REGISTROS" type="primary btn-sm" (click)="routeTo('ejecucion', turno.prestacion.id)"></plex-button>
+                                            <plex-button *ngIf="turno.paciente && turno.estado !== 'suspendido' && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'ejecucion' && tienePermisos(turno.tipoPrestacion,turno.prestacion)" label="VER REGISTROS"
+                                                type="primary btn-sm" (click)="routeTo('ejecucion', turno.prestacion.id)"></plex-button>
 
-                                            <plex-button *ngIf="turno.paciente && turno.estado !== 'suspendido' && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'validada' && tienePermisos(turno.tipoPrestacion,turno.prestacion)"
-                                                label="VER RESÚMEN" type="success btn-sm" (click)="routeTo('validacion', turno.prestacion.id)"></plex-button>
+                                            <plex-button *ngIf="turno.paciente && turno.estado !== 'suspendido' && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'validada' && tienePermisos(turno.tipoPrestacion,turno.prestacion)" label="VER RESÚMEN" type="success btn-sm"
+                                                (click)="routeTo('validacion', turno.prestacion.id)"></plex-button>
 
                                         </ng-container>
                                     </td>
@@ -285,14 +278,13 @@
                                             <ng-container *ngIf="sobreturno.tipoPrestacion && sobreturno.paciente?.id">
                                                 <plex-button (click)="routeTo('vista', sobreturno.paciente.id)" label="VER HUDS" type="primary btn-sm">
                                                 </plex-button>
-                                                <plex-button *ngIf="sobreturno.estado !== 'suspendido' && sobreturno.paciente && !sobreturno.prestacion && tienePermisos(sobreturno.tipoPrestacion)"
-                                                    label="INICIAR PRESTACIÓN" type="success btn-sm" (click)="iniciarPrestacion(sobreturno.paciente, sobreturno.tipoPrestacion, sobreturno.id)"></plex-button>
+                                                <plex-button *ngIf="sobreturno.estado !== 'suspendido' && sobreturno.paciente && !sobreturno.prestacion && tienePermisos(sobreturno.tipoPrestacion)" label="INICIAR PRESTACIÓN" type="success btn-sm" (click)="iniciarPrestacion(sobreturno.paciente, sobreturno.tipoPrestacion, sobreturno.id)"></plex-button>
 
-                                                <plex-button *ngIf="sobreturno.paciente && sobreturno.estado !== 'suspendido' && sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'ejecucion' && tienePermisos(sobreturno.tipoPrestacion)"
-                                                    label="Ver Registros" type="primary btn-sm" (click)="routeTo('ejecucion', sobreturno.prestacion.id)"></plex-button>
+                                                <plex-button *ngIf="sobreturno.paciente && sobreturno.estado !== 'suspendido' && sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'ejecucion' && tienePermisos(sobreturno.tipoPrestacion)" label="Ver Registros"
+                                                    type="primary btn-sm" (click)="routeTo('ejecucion', sobreturno.prestacion.id)"></plex-button>
 
-                                                <plex-button *ngIf="sobreturno.paciente && sobreturno.estado !== 'suspendido' && sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'validada' && tienePermisos(sobreturno.tipoPrestacion)"
-                                                    label="Ver Resúmen" type="success btn-sm" (click)="routeTo('validacion', sobreturno.prestacion.id)"></plex-button>
+                                                <plex-button *ngIf="sobreturno.paciente && sobreturno.estado !== 'suspendido' && sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'validada' && tienePermisos(sobreturno.tipoPrestacion)" label="Ver Resúmen"
+                                                    type="success btn-sm" (click)="routeTo('validacion', sobreturno.prestacion.id)"></plex-button>
 
                                             </ng-container>
                                         </td>
@@ -350,12 +342,10 @@
                                     <plex-button (click)="routeTo('vista', prestacion.paciente.id)" label="VER HUDS" type="primary btn-sm">
                                     </plex-button>
 
-                                    <plex-button *ngIf="prestacion.estados[prestacion.estados.length - 1].tipo === 'ejecucion'" (click)="routeTo('ejecucion', prestacion.id)"
-                                        label="VER REGISTROS" type="primary btn-sm">
+                                    <plex-button *ngIf="prestacion.estados[prestacion.estados.length - 1].tipo === 'ejecucion'" (click)="routeTo('ejecucion', prestacion.id)" label="VER REGISTROS" type="primary btn-sm">
                                     </plex-button>
 
-                                    <plex-button *ngIf="prestacion.estados[prestacion.estados.length - 1].tipo === 'validada'" (click)="routeTo('validacion', prestacion.id)"
-                                        label="VER RESUMEN" type="primary btn-sm">
+                                    <plex-button *ngIf="prestacion.estados[prestacion.estados.length - 1].tipo === 'validada'" (click)="routeTo('validacion', prestacion.id)" label="VER RESUMEN" type="primary btn-sm">
                                     </plex-button>
 
                                 </td>

--- a/src/app/modules/rup/components/elementos/temperatura.html
+++ b/src/app/modules/rup/components/elementos/temperatura.html
@@ -5,7 +5,7 @@
     <span>Temperatura</span> {{registro.valor}} °C
 </p>
 
-<p *ngIf="mensaje.texto">
+<p *ngIf="mensaje?.texto">
     <span class="badge-{{mensaje.class}}">
     {{mensaje.texto}}
     </span>

--- a/src/app/modules/rup/components/elementos/tensionDiastolica.html
+++ b/src/app/modules/rup/components/elementos/tensionDiastolica.html
@@ -5,7 +5,7 @@
     <span>Tensión Diastólica</span> {{registro.valor}} mmHG
 </p>
 
-<p *ngIf="mensaje.texto">
+<p *ngIf="mensaje?.texto">
     <span class="badge-{{mensaje.class}}">
     {{mensaje.texto}}
     </span>

--- a/src/app/modules/rup/components/elementos/tensionSistolica.html
+++ b/src/app/modules/rup/components/elementos/tensionSistolica.html
@@ -5,8 +5,8 @@
     <span>Tensión Sistólica</span> {{registro.valor}} mmHG
 </p>
 
-<p *ngIf="mensaje.texto">
+<p *ngIf="mensaje?.texto">
     <span class="badge-{{mensaje.class}}">
-    {{mensaje.texto}}
+        {{mensaje.texto}}
     </span>
 </p>


### PR DESCRIPTION
- Al iniciar prestaciones desde le punto de inicio de RUP tomar el tipo de prestación del turno y no del bloque dado que los bloques pueden tener mas de un tipo de prestación.
- Agregar en la búsqueda de agendas aquellas que estén pendientes de Asistencia o Auditoria 