### PR TITLE
agrego sexo en el paciente que se guarda en el turno

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -745,6 +745,7 @@ export class DarTurnosComponent implements OnInit {
                         apellido: this.paciente.apellido,
                         nombre: this.paciente.nombre,
                         fechaNacimiento: this.paciente.fechaNacimiento,
+                        sexo: this.paciente.sexo,
                         telefono: this.telefono,
                         carpetaEfectores: this.paciente.carpetaEfectores
                     };

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/listar-turnos.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/listar-turnos.html
@@ -86,7 +86,7 @@
                                 <small [ngClass]="{'text-danger': turno.estado === 'suspendido'}" *ngIf="turno && turno.estado === 'suspendido'">Suspendido</small>
                             </td>
                             <td>
-                                <small *ngIf="turno?.paciente?.id && turno?.paciente?.edad">{{ turno.paciente.fechaNacimiento | date: 'dd/MM/yyyy' }}</small>
+                                <small *ngIf="turno?.paciente?.id && turno?.paciente?.fechaNacimiento">{{ turno.paciente.fechaNacimiento | date: 'dd/MM/yyyy' }}</small>
                             </td>
                             <td>
                                 <small *ngIf="turno?.paciente?.id && turno?.paciente?.sexo">{{ turno.paciente | sexo }}</small>

--- a/src/app/interfaces/turnos/ITurno.ts
+++ b/src/app/interfaces/turnos/ITurno.ts
@@ -11,7 +11,9 @@ export interface ITurno {
         nombre: String,
         apellido: String,
         documento: String,
+        fechaNacimiento: Date,
         telefono: String,
+        sexo: String
     };
     tipoPrestacion: ITipoPrestacion;
     idPrestacionPaciente: String;


### PR DESCRIPTION
Se corrige la impresión de planilla de consultorios para que muestre la fecha de nacimiento y el sexo del paciente. 