### PR TITLE
Rup fix asignar turno

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
@@ -676,10 +676,8 @@ export class PrestacionEjecucionComponent implements OnInit {
 
         this.servicioPrestacion.patch(this.prestacion.id, params).subscribe(prestacionEjecutada => {
             this.plex.toast('success', 'Prestacion guardada correctamente', 'Prestacion guardada', 100);
-
             // Si existe un turno y una agenda asociada, y existe un concepto que indica que el paciente no concurrió a la consulta...
-            if (this.idAgenda && this.prestacion.ejecucion.registros.filter(x => this.servicioPrestacion.conceptosNoConcurrio.find(y => y === x.concepto.conceptId)).length > 0) {
-
+            if (this.idAgenda && this.servicioPrestacion.prestacionPacienteAusente(this.prestacion)) {
                 // Se hace un patch en el turno para indicar que el paciente no asistió (turno.asistencia = "noAsistio")
                 let cambios = {
                     op: 'noAsistio',
@@ -1013,7 +1011,7 @@ export class PrestacionEjecucionComponent implements OnInit {
      * busca los grupos de la busqueda guiada a los que pertenece un concepto
      * @param {IConcept} concept
      */
-    matchinBusquedaGuiada (concept) {
+    matchinBusquedaGuiada(concept) {
         let results = [];
         this.grupos_guida.forEach(data => {
             if (data.conceptIds.indexOf(concept.conceptId) >= 0) {

--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
@@ -229,7 +229,7 @@ export class PrestacionValidacionComponent implements OnInit {
                     this.frecuentesProfesionalService.updateFrecuentes(this.auth.profesional.id, frecuentesProfesional).subscribe(frecuentes => { });
 
                     // Cargar el mapeo de snomed a cie10 para las prestaciones que vienen de agendas
-                    if (this.prestacion.solicitud.turno) {
+                    if (this.prestacion.solicitud.turno && !this.servicioPrestacion.prestacionPacienteAusente(this.prestacion)) {
                         this.servicioAgenda.patchCodificarTurno({ 'op': 'codificarTurno', 'turnos': [this.prestacion.solicitud.turno] }).subscribe(salida => { });
                     }
 

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -333,8 +333,10 @@ export class PuntoInicioComponent implements OnInit {
 
 
     routeTo(action, id) {
-        let agenda = this.agendaSeleccionada ? this.agendaSeleccionada : null;
-        localStorage.setItem('idAgenda', agenda.id);
+        if (this.agendaSeleccionada && this.agendaSeleccionada !== 'fueraAgenda') {
+            let agenda = this.agendaSeleccionada ? this.agendaSeleccionada : null;
+            localStorage.setItem('idAgenda', agenda.id);
+        }
         this.router.navigate(['rup/' + action + '/', id]);
     }
 

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -656,8 +656,6 @@ export class PrestacionesService {
         } else {
             return null;
         }
-
-
     }
 
     /**
@@ -676,6 +674,24 @@ export class PrestacionesService {
         return this.conceptosTurneables.find(x => {
             return x.conceptId === concepto.conceptId;
         });
+    }
+
+    /**
+     * Devuelve true si se cargo en la prestación algun concepto que representa la ausencia del paciente
+     *
+     * @param {any} prestacion prestación en ejecución
+     * @returns  {boolean}
+     * @memberof BuscadorComponent
+     */
+    public prestacionPacienteAusente(prestacion) {
+        let filtroRegistros = null;
+        filtroRegistros = prestacion.ejecucion.registros.filter(x => this.conceptosNoConcurrio.find(y => y === x.concepto.conceptId));
+        if (filtroRegistros && filtroRegistros.length > 0) {
+            return true;
+        } else {
+            return false;
+        }
+
     }
 
     /**

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -559,8 +559,7 @@ export class PrestacionesService {
         return this.post(prestacion);
     }
 
-    validarPrestacion(prestacion, planes, conceptosTurneables): Observable<any> {
-
+    validarPrestacion(prestacion, planes): Observable<any> {
         let planesCrear = [];
         if (planes.length) {
 
@@ -580,7 +579,7 @@ export class PrestacionesService {
 
                     // Controlemos que se trata de una prestación turneable.
                     // Solo creamos prestaciones pendiente para conceptos turneables
-                    let existeConcepto = conceptosTurneables.find(c => c.conceptId === conceptoSolicitud.conceptId);
+                    let existeConcepto = this.conceptosTurneables.find(c => c.conceptId === conceptoSolicitud.conceptId);
                     if (existeConcepto) {
                         // creamos objeto de prestacion
                         let nuevaPrestacion = this.inicializarPrestacion(prestacion.paciente, conceptoSolicitud, 'validacion');
@@ -632,6 +631,25 @@ export class PrestacionesService {
         delete prestacionCopia._id;
 
         return this.server.post(this.prestacionesUrl, prestacionCopia);
+    }
+
+    /**
+     * Devuelve un listado de prestaciones planificadas desde una prestación origen
+     *
+     * @param {any} idPrestacion id de la prestacion origen
+     * @returns  {array} listado de prestaciones planificadas
+     * @memberof BuscadorComponent
+     */
+    public getPlanes(idPrestacion, idPaciente) {
+        let prestacionPlanes = [];
+        if (this.cache[idPaciente]) {
+            prestacionPlanes = this.cache[idPaciente].filter(p => p.estados[p.estados.length - 1].tipo === 'pendiente' && p.solicitud.prestacionOrigen === idPrestacion);
+            return prestacionPlanes;
+        } else {
+            return null;
+        }
+
+
     }
 
     /**


### PR DESCRIPTION
En la validacion: cuando se rompe la validación y se vuelve a validar no se veia el boton de asignar turno.
Fitrar las prestaciones con el concepto "no concurrio ..... " para que no se envien a codificar al momento de validar