### PR TITLE
Aproximación de hora en crearAgenda

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
@@ -491,12 +491,12 @@ export class PlanificarAgendaComponent implements OnInit {
 
     aproximar(date: Date) {
         let m = date.getMinutes();
-        let remaider = m % 15;
+        let remaider = m % 5;
         if (remaider !== 0) {
-            if (remaider < 7) {
+            if (remaider < 3) {
                 date.setMinutes(m - remaider);
             } else {
-                date.setMinutes(m + (15 - remaider));
+                date.setMinutes(m + (5 - remaider));
             }
         }
     }


### PR DESCRIPTION
@andes/red-tics 

Estimados, la intención de este PR es modificar la función de aproximación de la hora cuando creamos la agenda :calendar:  . (en lugar de redondear de a 15' que lo haga de a 5')
Como esto fue hecho inicialmente en #9 , estaría bueno asegurarnos que no entre en conflicto con algún requerimiento.

besos y abrazos