### PR TITLE
modo completo en false oculta también el header

### DIFF
--- a/src/app/components/paciente/paciente-search.html
+++ b/src/app/components/paciente/paciente-search.html
@@ -3,7 +3,7 @@
         <!--Panel central-->
         <div class="col">
             <plex-box>
-                <header>
+                <header *ngIf="modoCompleto">
                     <div class="page-title">Buscar un paciente</div>
                 </header>
                 <plex-text [(ngModel)]="textoLibre" (change)="buscar($event)" [autoFocus]="autoFocus" prefix="<i class='mdi mdi-barcode-scan'></i>"


### PR DESCRIPTION
@andes/red-tics 

- La idea es: Cuando el paciente search está en [modoCompleto]=false ocultar también el header. 

hay algún problema con este cambio?
