### PR TITLE
Revision agenda

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -167,6 +167,7 @@ import { MapaEspacioFisicoComponent } from './components/turnos/configuracion/ma
 import { SuspenderAgendaComponent } from './components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component';
 import { ArancelamientoFormComponent } from './components/turnos/dashboard/arancelamiento-form.component';
 import { AutocitarTurnoAgendasComponent } from './components/turnos/autocitar/autocitar.component';
+import { BuscadorCie10Component } from './components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.component';
 
 
 // ... RUP
@@ -348,7 +349,7 @@ let RUPComponentsArray = [
         PacienteCreateUpdateComponent, PacienteDetalleComponent, PacienteSearchComponent, DashboardComponent,
         MapsComponent, EdadPipe, ProfesionalPipe, FromNowPipe, FechaPipe, PacientePipe, SexoPipe, OrganizacionPipe, SortBloquesPipe, TextFilterPipe,
         FilterPermisos, EnumerarPipe, PluralizarPipe, IconoCamaPipe,
-        PlanificarAgendaComponent, AutocitarTurnoAgendasComponent, PanelEspacioComponent, EspacioFisicoComponent, EditEspacioFisicoComponent, FiltrosMapaEspacioFisicoComponent,
+        PlanificarAgendaComponent, AutocitarTurnoAgendasComponent, BuscadorCie10Component, PanelEspacioComponent, EspacioFisicoComponent, EditEspacioFisicoComponent, FiltrosMapaEspacioFisicoComponent,
         TipoPrestacionComponent, TipoPrestacionCreateUpdateComponent,
         DarTurnosComponent, CalendarioComponent, GestorAgendasComponent,
         TurnosComponent, BotonesAgendaComponent, ClonarAgendaComponent,

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.component.ts
@@ -1,0 +1,127 @@
+import {
+    Component, OnInit, OnChanges, Output, Input,
+    EventEmitter, ElementRef, SimpleChanges,
+    ViewEncapsulation, ContentChildren, OnDestroy
+} from '@angular/core';
+import { Observable } from 'rxjs/Rx';
+import { ISubscription } from 'rxjs/Subscription';
+import { Auth } from '@andes/auth';
+import { Plex } from '@andes/plex';
+import { Cie10Service } from '../../../../services/term/cie10.service';
+
+@Component({
+    selector: 'buscador-cie10',
+    templateUrl: 'buscador-cie10.html',
+    encapsulation: ViewEncapsulation.None,
+    styleUrls: [
+        'buscador-cie10.scss'
+    ]
+})
+
+export class BuscadorCie10Component implements OnInit, OnDestroy {
+
+    // Output que devuelve los resultados de la busqueda
+    @Output() seleccionEmit: EventEmitter<any> = new EventEmitter<any>();
+
+    private timeoutHandle: number;
+
+    // En caso de querer ocultar el input de busqueda y solo utilizar el valor de searchTerm
+    @Input() autofocus: Boolean = true;
+
+    // termino a buscar
+    public searchTerm: String = '';
+
+    // ocultar lista
+    public hideLista: Boolean = true;
+
+    // lista de resultados
+    public resultados;
+
+    private cachePrestacionesTurneables = null;
+
+    // ultima request que se almacena con el subscribe
+    private lastRequest: ISubscription;
+
+    constructor(
+        private auth: Auth,
+        private plex: Plex,
+        private servicioCie10: Cie10Service
+    ) {
+    }
+
+    /* limpiamos la request que se haya ejecutado */
+    ngOnDestroy() {
+        if (this.lastRequest) {
+            this.lastRequest.unsubscribe();
+        }
+    }
+
+    ngOnInit() {
+    }
+
+    /**
+     * Buscar conceptos cie10
+     * @param event  change event en el input buscar
+     * @returns      Void
+     */
+    buscar(): void {
+        // Cancela la búsqueda anterior
+        if (this.timeoutHandle) {
+            window.clearTimeout(this.timeoutHandle);
+        }
+
+        if (this.searchTerm && this.searchTerm !== '') {
+
+            if (this.searchTerm.match(/^\s{1,}/)) {
+                this.searchTerm = '';
+                return;
+            };
+
+            // levantamos el valor que escribimos en el input
+            // let search = this.searchTerm.trim();
+
+            // armamos query para enviar al servicio
+            let query = {
+                nombre: this.searchTerm,
+                limit: 10
+            };
+
+            // seteamos un timeout de 3 segundos luego que termino de escribir
+            // para poder realizar la busqueda
+            this.timeoutHandle = window.setTimeout(() => {
+
+                // buscamos
+
+                let idTimeOut = this.timeoutHandle;
+
+                if (this.lastRequest) {
+                    this.lastRequest.unsubscribe();
+                }
+
+                this.lastRequest = this.servicioCie10.get(query).subscribe(results => {
+
+                    if (idTimeOut === this.timeoutHandle) {
+                        // Para evitar que se oculte la lista de resultados
+                        this.resultados = results;
+                        this.hideLista = false;
+                    }
+
+                }, err => {
+                    this.plex.toast('error', 'No se pudo realizar la búsqueda', '', 5000);
+                });
+
+            }, 600);
+        } else {
+            // cancelamos ultimo request
+            if (this.lastRequest) {
+                this.lastRequest.unsubscribe();
+            }
+        }
+    }
+
+    seleccionarPrestacion(item) {
+        this.hideLista = true;
+        this.seleccionEmit.emit(item);
+        this.searchTerm = '';
+    }
+}

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
@@ -7,7 +7,7 @@
         <tbody>
             <tr *ngFor="let item of resultados; let i = index; " class="hover">
                 <td (click)="seleccionarPrestacion(item)">
-                    {{item.nombre}}
+                    {{item.sinonimo}}
                 </td>
             </tr>
         </tbody>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
@@ -1,6 +1,7 @@
 <form>
     <div class="buscador">
-        <plex-text [(ngModel)]="searchTerm" name="searchTerm" (keyup)="buscar()" placeholder="Buscar ..." [autoFocus]="autofocus"></plex-text>
+        <plex-text [(ngModel)]="searchTerm" name="searchTerm" (keyup)="buscar()" placeholder="Buscar ..." [autoFocus]="autofocus"
+            label="Buscar prestación"></plex-text>
     </div>
     <table *ngIf="!hideLista" class="table table-bordered table-hover  table-sm ">
         <tbody>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
@@ -1,7 +1,6 @@
 <form>
     <div class="buscador">
-        <plex-text [(ngModel)]="searchTerm" name="searchTerm" (keyup)="buscar()" placeholder="Buscar ..." [autoFocus]="autofocus"
-            label="Buscar prestación"></plex-text>
+        <plex-text [(ngModel)]="searchTerm" name="searchTerm" (keyup)="buscar()" placeholder="Buscar ..." [autoFocus]="autofocus"></plex-text>
     </div>
     <table *ngIf="!hideLista" class="table table-bordered table-hover  table-sm ">
         <tbody>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
@@ -1,0 +1,14 @@
+<form>
+    <div class="buscador">
+        <plex-text [(ngModel)]="searchTerm" name="searchTerm" (keyup)="buscar()" placeholder="Buscar ..." [autoFocus]="autofocus"></plex-text>
+    </div>
+    <table *ngIf="!hideLista" class="table table-bordered table-hover  table-sm ">
+        <tbody>
+            <tr *ngFor="let item of resultados; let i = index; " class="hover">
+                <td (click)="seleccionarPrestacion(item)">
+                    {{item.nombre}}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</form>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.scss
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.scss
@@ -1,0 +1,25 @@
+.buscador {
+    margin-top: 5px;
+}
+
+.buscador input {
+    border-width: 2px;
+}
+
+
+.header {
+    align-items: center;
+}
+
+.results {
+    margin-top: 0;
+}
+
+.buscador {
+    margin-top: 5px;
+}
+
+.buscador input {
+    border-width: 2px;
+}
+

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -164,6 +164,7 @@ export class RevisionAgendaComponent implements OnInit {
         if (this.turnoSeleccionado) {
             this.turnoSeleccionado.asistencia = asistencia.id;
         }
+        this.onSave();
     }
 
     asistenciaSeleccionada(asistencia) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -66,7 +66,6 @@ export class RevisionAgendaComponent implements OnInit {
     horaInicio: any;
     turnoSeleccionado: any = null;
     bloqueSeleccionado: any = null;
-    reparo: any;
     paciente: IPaciente;
     turnoTipoPrestacion: any = null;
     pacientesSearch = false;
@@ -346,16 +345,15 @@ export class RevisionAgendaComponent implements OnInit {
         this.showReparo = true;
     }
 
-    repararDiagnostico() {
-        if (this.reparo) {
-            this.diagnosticos[this.indiceReparo].codificacionAuditoria = this.reparo;
+    repararDiagnostico(reparo) {
+        if (reparo) {
+            this.diagnosticos[this.indiceReparo].codificacionAuditoria = reparo;
             this.showReparo = false;
-            this.reparo = {};
         }
     }
 
     borrarReparo(index) {
-        this.diagnosticos[this.indiceReparo].codificacionAuditoria = null;
+        this.diagnosticos[index].codificacionAuditoria = null;
         this.showReparo = false;
     }
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -190,7 +190,7 @@ export class RevisionAgendaComponent implements OnInit {
         };
         nuevoDiagnostico.codificacionAuditoria = diagnostico;
         this.diagnosticos.push(nuevoDiagnostico);
-        console.log(this.diagnosticos)
+        this.onSave();
     }
 
     borrarDiagnostico(index) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -156,8 +156,6 @@ export class RevisionAgendaComponent implements OnInit {
             this.pacientesSearch = false;
             if (turno.diagnostico.codificaciones && turno.diagnostico.codificaciones.length) {
                 this.diagnosticos = this.diagnosticos.concat(turno.diagnostico.codificaciones);
-                // Verificamos si existe alguna codificación de profesional.
-                this.existeCodificacionProfesional = (this.diagnosticos.filter(elem => elem.codificacionProfesional !== null)).length > 0 ? true : false;
             }
         }
     }
@@ -191,7 +189,7 @@ export class RevisionAgendaComponent implements OnInit {
         };
         nuevoDiagnostico.codificacionAuditoria = diagnostico;
         this.diagnosticos.push(nuevoDiagnostico);
-
+        console.log(this.diagnosticos)
     }
 
     borrarDiagnostico(index) {
@@ -203,17 +201,12 @@ export class RevisionAgendaComponent implements OnInit {
         if (index === 0) {
             this.plex.toast('warning', 'Información', 'El diagnostico principal fue eliminado');
         }
+        this.onSave();
     }
 
     aprobar(index) {
         this.diagnosticos[index].codificacionAuditoria = this.diagnosticos[index].codificacionProfesional;
-    }
-
-
-    marcarIlegible() {
-        this.turnoSeleccionado.diagnostico.codificaciones[0].codificacionAuditoria = 'Ilegible';
-        this.turnoSeleccionado.diagnostico.codificaciones[0].primeraVez = false;
-        this.diagnosticos = [];
+        this.onSave();
     }
 
     cerrarAsistencia() {
@@ -309,10 +302,10 @@ export class RevisionAgendaComponent implements OnInit {
 
         if (this.turnoSeleccionado.tipoPrestacion) {
             this.serviceTurno.put(datosTurno).subscribe(resultado => {
-                this.plex.toast('success', 'Información', 'El turno fue actualizado');
+                // this.plex.toast('success', 'Información', 'El turno fue actualizado');
                 this.cerrarAsistencia();
                 this.cerrarCodificacion();
-                this.turnoSeleccionado = null;
+                // this.turnoSeleccionado = null;
             });
         } else {
             this.plex.alert('Debe seleccionar un tipo de Prestacion');
@@ -350,11 +343,13 @@ export class RevisionAgendaComponent implements OnInit {
             this.diagnosticos[this.indiceReparo].codificacionAuditoria = reparo;
             this.showReparo = false;
         }
+        this.onSave();
     }
 
     borrarReparo(index) {
         this.diagnosticos[index].codificacionAuditoria = null;
         this.showReparo = false;
+        this.onSave();
     }
 
     volverRevision() {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -122,7 +122,12 @@ export class RevisionAgendaComponent implements OnInit {
             this.turnoSeleccionado.estado = estado;
         }
     }
-
+    /**
+     * Output de la búsqueda de paciente
+     * 
+     * @param {IPaciente} paciente 
+     * @memberof RevisionAgendaComponent
+     */
     onReturn(paciente: IPaciente): void {
         if (paciente.id) {
             this.paciente = paciente;
@@ -209,7 +214,11 @@ export class RevisionAgendaComponent implements OnInit {
         this.diagnosticos[index].codificacionAuditoria = this.diagnosticos[index].codificacionProfesional;
         this.onSave();
     }
-
+    /**
+     * Verifica si cada turno tiene la asistencia verificada y modifica el estado de la agenda.
+     * 
+     * @memberof RevisionAgendaComponent
+     */
     cerrarAsistencia() {
         // Se verifica que todos los campos tengan asistencia chequeada
         let turnoSinVerificar = null;
@@ -235,7 +244,11 @@ export class RevisionAgendaComponent implements OnInit {
             });
         }
     }
-
+    /**
+     * Verifica que cada turno esté codificado y modifica el estado de la agenda si corresponde
+     * 
+     * @memberof RevisionAgendaComponent
+     */
     cerrarCodificacion() {
         // Se verifica que todos los campos tengan el diagnostico codificado
         let turnoSinCodificar = null;
@@ -338,7 +351,12 @@ export class RevisionAgendaComponent implements OnInit {
         this.indiceReparo = index;
         this.showReparo = true;
     }
-
+    /**
+     * Agrega el diagnóstico provisto por el revisor, y persiste el cambio automáticamente
+     * 
+     * @param {any} reparo 
+     * @memberof RevisionAgendaComponent
+     */
     repararDiagnostico(reparo) {
         if (reparo) {
             this.diagnosticos[this.indiceReparo].codificacionAuditoria = reparo;

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -254,15 +254,18 @@
                                                                 (click)="aprobar(i)"></plex-button>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-succes" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo
+                                                            <span class="badge-success" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo
                                             === diagnostico.codificacionProfesional.codigo">Aprobado</span>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-success" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo !==
+                                                            <span class="badge-warning" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo !==
                                             diagnostico.codificacionProfesional.codigo">Reparado</span>
                                                         </td>
                                                         <td class="col-1 ">
-                                                            <plex-button *ngIf="existeCodificacionProfesional" icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)"> </plex-button>
+                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null " icon="mdi mdi-pencil" title="Reparar"
+                                                                (click)="mostrarReparo(i)"> </plex-button>
+                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria != null" icon="mdi mdi-refresh" title="Reestablecer"
+                                                                (click)="borrarReparo(i)"> </plex-button>
                                                         </td>
                                                         <td class="col-4 " *ngIf="diagnostico.codificacionAuditoria == null">
                                                             <span *ngIf="diagnostico.codificacionProfesional != null"> {{diagnostico.codificacionProfesional.sinonimo}} </span>
@@ -271,7 +274,7 @@
                                                             <span> {{diagnostico.codificacionAuditoria.sinonimo}} </span>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span *ngIf="i==0" class="badge-success ">Principal</span>
+                                                            <span *ngIf="i==0" class="badge-info">Principal</span>
                                                         </td>
                                                         <td class="col-1 ">
                                                             <plex-button *ngIf="!existeCodificacionProfesional" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
@@ -280,7 +283,7 @@
                                                             <plex-bool *ngIf="i==0" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
                                                         </td>
                                                         <td class="col-2" *ngIf="existeCodificacionProfesional">
-                                                            <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-success">Primera vez</span>
+                                                            <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-info">Primera vez</span>
                                                         </td>
                                                     </tr>
                                                 </tbody>
@@ -290,10 +293,10 @@
                                 </div>
                                 <!-- Buscador de prestaciones cie10 -->
                                 <div class="row" *ngIf="!existeCodificacionProfesional">
-                                    <div class="col-4">
+                                    <div class="col-2">
                                         <plex-bool [(ngModel)]='turnoSeleccionado.diagnostico.ilegible' name="ilegible" label="Diagnóstico ilegible" (click)="marcarIlegible()"></plex-bool>
                                     </div>
-                                    <div class="col-8" *ngIf="!turnoSeleccionado.diagnostico.ilegible">
+                                    <div class="col-10" *ngIf="!turnoSeleccionado.diagnostico.ilegible">
                                         <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
                                     </div>
 
@@ -304,7 +307,7 @@
                                 <div *ngIf="turnoSeleccionado && existeCodificacionProfesional && showReparo">
                                     <div class="row">
                                         <div class="col">
-                                            <h5>codificación del profesional:</h5> {{diagnosticos[indiceReparo].codificacionProfesional.sinonimo}}
+                                            <h5>codificación del profesional</h5> {{diagnosticos[indiceReparo].codificacionProfesional.sinonimo}}
                                             <hr>
                                         </div>
                                     </div>
@@ -312,12 +315,8 @@
                                     <div class="row">
                                         <div class="col-8">
                                             Seleccionar código reparo
-                                            <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
+                                            <buscador-cie10 (seleccionEmit)="repararDiagnostico($event)"></buscador-cie10>
 
-                                        </div>
-                                        <div class="col">
-                                            <br>
-                                            <plex-button icon="delete" label="Eliminar Reparo" type="danger" (click)="borrarReparo()"></plex-button>
                                         </div>
                                     </div>
                                 </div>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -187,14 +187,13 @@
                 </div>
                 <div class="row">
                     <div class="col-6" *ngIf="turnoSeleccionado.paciente?.id">
-                        <div *ngIf="turnoSeleccionado.paciente?.id"> {{ turnoSeleccionado.paciente | paciente }}</div>
-                        <small>
-                            <span *ngIf="turnoSeleccionado.paciente.documento !== ''"> DNI {{ turnoSeleccionado.paciente.documento | number}}</span>
+                        <div *ngIf="turnoSeleccionado.paciente?.id"> {{ turnoSeleccionado.paciente | paciente }}
+                            <span *ngIf="turnoSeleccionado.paciente.documento !== ''"> | DNI {{ turnoSeleccionado.paciente.documento | number}}</span>
                             <span *ngIf="turnoSeleccionado.paciente.documento === ''"> Sin documento (temporal)</span>
                             <span *ngIf="turnoSeleccionado.paciente.fechaNacimiento !== null">| Edad: {{ turnoSeleccionado.paciente | edad }}</span>
                             <span *ngIf="turnoSeleccionado?.paciente?.id && turnoSeleccionado?.paciente?.sexo">| Sexo: {{ turnoSeleccionado.paciente | sexo }}</span>
                             <span *ngIf="turnoSeleccionado?.paciente?.id && turnoSeleccionado?.paciente?.edad">{{ turno.paciente.fechaNacimiento | date: 'dd/MM/yyyy' }}</span>
-                        </small>
+                        </div>
                     </div>
                 </div>
                 <div class="row">
@@ -238,87 +237,94 @@
                     <br>
 
                     <!--CODIFICACION-->
-
-                    <div *ngIf="turnoSeleccionado && turnoSeleccionado.asistencia == 'asistio'">
-                        <h5>Codificación</h5>
-                        <hr>
-                        <div>
-                            <div class="row" *ngIf="!existeCodificacionProfesional">
-                                <div class="col-4">
-                                    <br>
-                                    <plex-bool [(ngModel)]='turnoSeleccionado.diagnostico.ilegible' name="ilegible" label="Diagnóstico ilegible" (click)="marcarIlegible()"></plex-bool>
-                                </div>
-
-                                <div class="col-8" *ngIf="!turnoSeleccionado.diagnostico.ilegible">
-                                    <plex-select [(ngModel)]="nuevoCodigo" label="Nuevo diagnóstico" name="searchCodigo" labelField="codigo+' '+sinonimo" (getData)="buscarCodificacion($event)"
-                                        placeholder="Seleccione un ćodigo CIE10" (change)="agregarDiagnostico()"></plex-select>
-                                </div>
+                    <div class="row">
+                        <div class="col-12">
+                            <div *ngIf="turnoSeleccionado && turnoSeleccionado.asistencia == 'asistio'">
+                                <h5>Codificación</h5>
                                 <hr>
-                            </div>
-                            <div *ngIf="diagnosticos.length>0 && !turnoSeleccionado.diagnostico.ilegible && !showReparo ">
+                                <!-- Listado de codificaciones seleccionadas -->
+                                <div *ngIf="diagnosticos.length>0 && !turnoSeleccionado.diagnostico.ilegible && !showReparo ">
+                                    <div class="row">
+                                        <div class="col-12">
+                                            <table class="table table-striped">
+                                                <tbody>
+                                                    <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover row">
+                                                        <td class="col-1">
+                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null" icon="mdi mdi-check" title="Aprobar"
+                                                                (click)="aprobar(i)"></plex-button>
+                                                        </td>
+                                                        <td class="col-1">
+                                                            <span class="badge-succes" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo
+                                            === diagnostico.codificacionProfesional.codigo">Aprobado</span>
+                                                        </td>
+                                                        <td class="col-1">
+                                                            <span class="badge-success" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo !==
+                                            diagnostico.codificacionProfesional.codigo">Reparado</span>
+                                                        </td>
+                                                        <td class="col-1 ">
+                                                            <plex-button *ngIf="existeCodificacionProfesional" icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)"> </plex-button>
+                                                        </td>
+                                                        <td class="col-4 " *ngIf="diagnostico.codificacionAuditoria == null">
+                                                            <span *ngIf="diagnostico.codificacionProfesional != null"> {{diagnostico.codificacionProfesional.sinonimo}} </span>
+                                                        </td>
+                                                        <td class="col-4" *ngIf="diagnostico.codificacionAuditoria != null">
+                                                            <span> {{diagnostico.codificacionAuditoria.sinonimo}} </span>
+                                                        </td>
+                                                        <td class="col-1">
+                                                            <span *ngIf="i==0" class="badge-success ">Principal</span>
+                                                        </td>
+                                                        <td class="col-1 ">
+                                                            <plex-button *ngIf="!existeCodificacionProfesional" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
+                                                        </td>
+                                                        <td class="col-2" *ngIf="!existeCodificacionProfesional">
+                                                            <plex-bool *ngIf="i==0" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
+                                                        </td>
+                                                        <td class="col-2" *ngIf="existeCodificacionProfesional">
+                                                            <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-success">Primera vez</span>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- Buscador de prestaciones cie10 -->
+                                <div class="row" *ngIf="!existeCodificacionProfesional">
+                                    <div class="col-4">
+                                        <plex-bool [(ngModel)]='turnoSeleccionado.diagnostico.ilegible' name="ilegible" label="Diagnóstico ilegible" (click)="marcarIlegible()"></plex-bool>
+                                    </div>
+                                    <div class="col-8" *ngIf="!turnoSeleccionado.diagnostico.ilegible">
+                                        <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
+                                    </div>
 
-                                <table class="table table-striped">
-                                    <tbody>
-                                        <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover">
-                                            <td *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null">
-                                                <plex-button icon="mdi mdi-check" title="Aprobar" (click)="aprobar(i)"></plex-button>
-                                            </td>
-                                            <td *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria && diagnostico.codificacionAuditoria.codigo === diagnostico.codificacionProfesional.codigo">
-                                                <span class="badge-success">Aprobado</span>
-                                            </td>
-                                            <td *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria && diagnostico.codificacionAuditoria != null && diagnostico.codificacionAuditoria.codigo !== diagnostico.codificacionProfesional.codigo">
-                                                <span class="badge-success">Reparado</span>
-                                            </td>
-                                            <td *ngIf="existeCodificacionProfesional">
-                                                <plex-button icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)"> </plex-button>
-                                            </td>
-                                            <td *ngIf="diagnostico.codificacionAuditoria == null && diagnostico.codificacionProfesional != null">
-                                                {{diagnostico.codificacionProfesional.sinonimo}}
-                                            </td>
-                                            <td *ngIf="diagnostico.codificacionAuditoria != null">
-                                                {{diagnostico.codificacionAuditoria.sinonimo}}
-                                            </td>
-                                            <td *ngIf="i==0">
-                                                <span class="badge-success">Principal</span>
-                                            </td>
-                                            <td *ngIf="!existeCodificacionProfesional">
-                                                <plex-button icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
-                                            </td>
-                                            <td *ngIf="i==0 && !existeCodificacionProfesional">
-                                                <plex-bool [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
-                                            </td>
-                                            <td *ngIf="i==0 && existeCodificacionProfesional">
-                                                <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-success">Primera vez</span>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-
-                        <!-- Reparo -->
-                        <div *ngIf="turnoSeleccionado && existeCodificacionProfesional && showReparo">
-                            <div class="row">
-                                <div class="col">
-                                    <h5>codificación del profesional:</h5> {{diagnosticos[indiceReparo].codificacionProfesional.sinonimo}}
                                     <hr>
                                 </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-8">
-                                    Seleccionar código reparo:
-                                    <plex-select [(ngModel)]="reparo" name="searchReparo" labelField="codigo+' '+sinonimo" (getData)="buscarCodificacion($event)"
-                                        placeholder="Seleccione un ćodigo CIE10" (change)="repararDiagnostico()"></plex-select>
+
+                                <!-- Reparo -->
+                                <div *ngIf="turnoSeleccionado && existeCodificacionProfesional && showReparo">
+                                    <div class="row">
+                                        <div class="col">
+                                            <h5>codificación del profesional:</h5> {{diagnosticos[indiceReparo].codificacionProfesional.sinonimo}}
+                                            <hr>
+                                        </div>
+                                    </div>
+                                    <!-- Búsqueda de prestaciones cie10 -->
+                                    <div class="row">
+                                        <div class="col-8">
+                                            Seleccionar código reparo
+                                            <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
+
+                                        </div>
+                                        <div class="col">
+                                            <br>
+                                            <plex-button icon="delete" label="Eliminar Reparo" type="danger" (click)="borrarReparo()"></plex-button>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="col">
-                                    <br>
-                                    <plex-button icon="delete" label="Eliminar Reparo" type="danger" (click)="borrarReparo()"></plex-button>
-                                </div>
+                                <!-- /Reparo -->
                             </div>
                         </div>
                     </div>
-                    <!-- /Reparo -->
-
                     <!--/ CODIFICACION-->
                     <br>
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -260,10 +260,10 @@
                                                                 title="Reestablecer" (click)="borrarReparo(i)"> </plex-button>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.codigo">Aprobado</span>
+                                                            <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.codigo">Aprobado</span>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-warning" *ngIf=" diagnostico.codificacionAuditoria?.codigo !==diagnostico.codificacionProfesional?.codigo">Reparado</span>
+                                                            <span class="badge-warning" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo !== diagnostico.codificacionProfesional?.codigo">Reparado</span>
                                                         </td>
                                                         <td class="col-4 " *ngIf="!diagnostico.codificacionAuditoria">
                                                             <span *ngIf="diagnostico.codificacionProfesional"> {{diagnostico.codificacionProfesional.sinonimo}} </span>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -288,18 +288,18 @@
                                             </table>
                                         </div>
                                     </div>
-                                </div>
-                                <!-- Buscador de prestaciones cie10 -->
-                                <div class="row">
-                                    <div class="col-10">
-                                        <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
-                                    </div>
+                                    <!-- Buscador de prestaciones cie10 -->
+                                    <div class="row">
+                                        <div class="col-10">
+                                            <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
+                                        </div>
 
-                                    <hr>
+                                        <hr>
+                                    </div>
                                 </div>
 
                                 <!-- Reparo -->
-                                <div *ngIf="turnoSeleccionado && existeCodificacionProfesional && showReparo">
+                                <div *ngIf="turnoSeleccionado && diagnosticos[indiceReparo]?.codificacionProfesional && showReparo">
                                     <div class="row">
                                         <div class="col">
                                             <h5>codificación del profesional</h5> {{diagnosticos[indiceReparo].codificacionProfesional.sinonimo}}

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -250,39 +250,37 @@
                                                 <tbody>
                                                     <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover row">
                                                         <td class="col-1">
-                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null" type="success" icon="mdi mdi-check"
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional && !diagnostico.codificacionAuditoria" type="success" icon="mdi mdi-check"
                                                                 title="Aprobar" (click)="aprobar(i)"></plex-button>
                                                         </td>
                                                         <td class="col-1 ">
-                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null " type="danger" icon="mdi mdi-pencil"
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional && !diagnostico.codificacionAuditoria " type="danger" icon="mdi mdi-pencil"
                                                                 title="Reparar" (click)="mostrarReparo(i)"> </plex-button>
-                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria != null" type="info" icon="mdi mdi-refresh"
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria" type="info" icon="mdi mdi-refresh"
                                                                 title="Reestablecer" (click)="borrarReparo(i)"> </plex-button>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-success" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo
-                                                                                                    === diagnostico.codificacionProfesional.codigo">Aprobado</span>
+                                                            <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.codigo">Aprobado</span>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-warning" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo !==
-                                                                                                    diagnostico.codificacionProfesional.codigo">Reparado</span>
+                                                            <span class="badge-warning" *ngIf=" diagnostico.codificacionAuditoria?.codigo !==diagnostico.codificacionProfesional?.codigo">Reparado</span>
                                                         </td>
-                                                        <td class="col-4 " *ngIf="diagnostico.codificacionAuditoria == null">
-                                                            <span *ngIf="diagnostico.codificacionProfesional != null"> {{diagnostico.codificacionProfesional.sinonimo}} </span>
+                                                        <td class="col-4 " *ngIf="!diagnostico.codificacionAuditoria">
+                                                            <span *ngIf="diagnostico.codificacionProfesional"> {{diagnostico.codificacionProfesional.sinonimo}} </span>
                                                         </td>
-                                                        <td class="col-4" *ngIf="diagnostico.codificacionAuditoria != null">
+                                                        <td class="col-4" *ngIf="diagnostico.codificacionAuditoria">
                                                             <span> {{diagnostico.codificacionAuditoria.sinonimo}} </span>
                                                         </td>
                                                         <td class="col-1">
                                                             <span *ngIf="i==0" class="badge-info">Principal</span>
                                                         </td>
                                                         <td class="col-1 ">
-                                                            <plex-button *ngIf="!existeCodificacionProfesional" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
+                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
                                                         </td>
-                                                        <td class="col-2" *ngIf="!existeCodificacionProfesional">
+                                                        <td class="col-2" *ngIf="!diagnostico.codificacionProfesional">
                                                             <plex-bool *ngIf="i==0" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
                                                         </td>
-                                                        <td class="col-2" *ngIf="existeCodificacionProfesional">
+                                                        <td class="col-2" *ngIf="diagnostico.codificacionProfesional">
                                                             <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-info">Primera vez</span>
                                                         </td>
                                                     </tr>
@@ -292,11 +290,8 @@
                                     </div>
                                 </div>
                                 <!-- Buscador de prestaciones cie10 -->
-                                <div class="row" *ngIf="!existeCodificacionProfesional">
-                                    <div class="col-2">
-                                        <plex-bool [(ngModel)]='turnoSeleccionado.diagnostico.ilegible' name="ilegible" label="Diagnóstico ilegible" (click)="marcarIlegible()"></plex-bool>
-                                    </div>
-                                    <div class="col-10" *ngIf="!turnoSeleccionado.diagnostico.ilegible">
+                                <div class="row">
+                                    <div class="col-10">
                                         <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
                                     </div>
 
@@ -325,16 +320,7 @@
                         </div>
                     </div>
                     <!--/ CODIFICACION-->
-                    <br>
-
-                    <div class="row" *ngIf="!showReparo">
-                        <div class="col text-right">
-                            <plex-button label="Cancelar" type="danger" (click)="cancelar()"></plex-button>
-                            <plex-button label="Guardar" type="success" (click)="onSave()"></plex-button>
-                        </div>
-                    </div>
                 </div>
-
             </plex-box>
         </div>
     </div>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -250,22 +250,22 @@
                                                 <tbody>
                                                     <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover row">
                                                         <td class="col-1">
-                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null" icon="mdi mdi-check" title="Aprobar"
-                                                                (click)="aprobar(i)"></plex-button>
+                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null" type="success" icon="mdi mdi-check"
+                                                                title="Aprobar" (click)="aprobar(i)"></plex-button>
+                                                        </td>
+                                                        <td class="col-1 ">
+                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null " type="danger" icon="mdi mdi-pencil"
+                                                                title="Reparar" (click)="mostrarReparo(i)"> </plex-button>
+                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria != null" type="info" icon="mdi mdi-refresh"
+                                                                title="Reestablecer" (click)="borrarReparo(i)"> </plex-button>
                                                         </td>
                                                         <td class="col-1">
                                                             <span class="badge-success" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo
-                                            === diagnostico.codificacionProfesional.codigo">Aprobado</span>
+                                                                                                    === diagnostico.codificacionProfesional.codigo">Aprobado</span>
                                                         </td>
                                                         <td class="col-1">
                                                             <span class="badge-warning" *ngIf="(existeCodificacionProfesional && diagnostico.codificacionAuditoria) && diagnostico.codificacionAuditoria.codigo !==
-                                            diagnostico.codificacionProfesional.codigo">Reparado</span>
-                                                        </td>
-                                                        <td class="col-1 ">
-                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria == null " icon="mdi mdi-pencil" title="Reparar"
-                                                                (click)="mostrarReparo(i)"> </plex-button>
-                                                            <plex-button *ngIf="existeCodificacionProfesional && diagnostico.codificacionAuditoria != null" icon="mdi mdi-refresh" title="Reestablecer"
-                                                                (click)="borrarReparo(i)"> </plex-button>
+                                                                                                    diagnostico.codificacionProfesional.codigo">Reparado</span>
                                                         </td>
                                                         <td class="col-4 " *ngIf="diagnostico.codificacionAuditoria == null">
                                                             <span *ngIf="diagnostico.codificacionProfesional != null"> {{diagnostico.codificacionProfesional.sinonimo}} </span>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -278,7 +278,7 @@
                                                             <plex-button *ngIf="!diagnostico.codificacionProfesional" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
                                                         </td>
                                                         <td class="col-2" *ngIf="!diagnostico.codificacionProfesional">
-                                                            <plex-bool *ngIf="i==0" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
+                                                            <plex-bool *ngIf="i==0" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
                                                         </td>
                                                         <td class="col-2" *ngIf="diagnostico.codificacionProfesional">
                                                             <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-info">Primera vez</span>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.scss
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.scss
@@ -1,0 +1,6 @@
+table {
+    td {
+        text-align: left;
+        vertical-align: middle;
+    }
+}


### PR DESCRIPTION
1. cambiamos el plex select para seleccionar diagnóstico por un plex-text.
2. nuevo componente de búsqueda 
3. habilitamos la posibilidad de agregar nuevos diagnósticos a turnos  codificados por profesional, además de la opción de reparar/aprobar diagnóstico
4. Cada cambio dispara automáticamente un patch a la agenda, sacamos el botón guardar. :warning: