### PR TITLE
Revision

### DIFF
--- a/src/app/components/turnos/enums.ts
+++ b/src/app/components/turnos/enums.ts
@@ -31,7 +31,7 @@ export let EstadosAgenda: IEnum = {
     },
     'auditada': {
         nombre: 'Auditada',
-        class: 'warning'
+        class: 'info'
     }
 };
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/buscador-cie10.html
@@ -6,7 +6,7 @@
         <tbody>
             <tr *ngFor="let item of resultados; let i = index; " class="hover">
                 <td (click)="seleccionarPrestacion(item)">
-                    {{item.sinonimo}}
+                    ({{item.codigo}}) {{item.sinonimo}}
                 </td>
             </tr>
         </tbody>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -104,7 +104,6 @@ export class RevisionAgendaComponent implements OnInit {
             return (turno.paciente && turno.paciente.id);
         });
         this.cantidadTurnosAsignados = turnosAsignados.length;
-        console.log(turnosAsignados);
     }
 
     buscarPaciente() {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -51,18 +51,14 @@ export class RevisionAgendaComponent implements OnInit {
     @Output() escaneado: EventEmitter<any> = new EventEmitter<any>();
 
     public cantidadTurnosAsignados: number;
-    private timeoutHandle: number;
-    private lastRequest: ISubscription; // ultima request que se almacena con el subscribe
     private estadoPendienteAuditoria;
     private estadoCodificado;
 
-    public searchTerm: String = '';
     indiceReparo: any;
     public showReparo = false;
     existeCodificacionProfesional: Boolean;
     showRevisionAgenda: Boolean = true;
     showAgregarSobreturno: Boolean = false;
-    sobreturnos = [];
     horaInicio: any;
     turnoSeleccionado: any = null;
     bloqueSeleccionado: any = null;

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -140,8 +140,8 @@ export class RevisionAgendaComponent implements OnInit {
     }
     /**
      * Output de la búsqueda de paciente
-     * 
-     * @param {IPaciente} paciente 
+     *
+     * @param {IPaciente} paciente
      * @memberof RevisionAgendaComponent
      */
     onReturn(paciente: IPaciente): void {
@@ -232,7 +232,7 @@ export class RevisionAgendaComponent implements OnInit {
     }
     /**
      * Verifica si cada turno tiene la asistencia verificada y modifica el estado de la agenda.
-     * 
+     *
      * @memberof RevisionAgendaComponent
      */
     cerrarAsistencia() {
@@ -262,7 +262,7 @@ export class RevisionAgendaComponent implements OnInit {
     }
     /**
      * Verifica que cada turno esté codificado y modifica el estado de la agenda si corresponde
-     * 
+     *
      * @memberof RevisionAgendaComponent
      */
     cerrarCodificacion() {
@@ -369,8 +369,8 @@ export class RevisionAgendaComponent implements OnInit {
     }
     /**
      * Agrega el diagnóstico provisto por el revisor, y persiste el cambio automáticamente
-     * 
-     * @param {any} reparo 
+     *
+     * @param {any} reparo
      * @memberof RevisionAgendaComponent
      */
     repararDiagnostico(reparo) {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -177,7 +177,7 @@ export class RevisionAgendaComponent implements OnInit {
         }
     }
 
-    seleccionarAsistencia(asistencia, i) {
+    seleccionarAsistencia(asistencia) {
         if (this.turnoSeleccionado) {
             this.turnoSeleccionado.asistencia = asistencia.id;
         }

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -216,7 +216,7 @@ export class RevisionAgendaComponent implements OnInit {
     }
 
     borrarDiagnostico(index) {
-        if (!this.diagnosticos[index].codificacionProfesional.snomed.term) {
+        if (!this.diagnosticos[index].codificacionProfesional || (this.diagnosticos[index].codificacionProfesional && this.diagnosticos[index].codificacionProfesional.snomed && !this.diagnosticos[index].codificacionProfesional.snomed.term)) {
             this.diagnosticos.splice(index, 1);
         } else {
             this.diagnosticos[index].codificacionAuditoria = null;

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.component.ts
@@ -244,8 +244,7 @@ export class RevisionAgendaComponent implements OnInit {
         turnoSinVerificar = listaTurnos.find(t => {
             return (t && t.paciente && t.paciente.id && !t.asistencia && t.estado !== 'suspendido');
         });
-        if (!turnoSinVerificar) {
-            // TODO!!!
+        if (!turnoSinVerificar) { // Si todos los turnos están verificados..
             // Se cambia de estado la agenda a pendienteAuditoria
             let patch = {
                 'op': 'pendienteAuditoria',
@@ -254,6 +253,19 @@ export class RevisionAgendaComponent implements OnInit {
             this.serviceAgenda.patch(this._agenda.id, patch).subscribe(resultado => {
                 this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Pendiente Auditoria');
             });
+        } else {
+            // este caso se dá cuando se agregan sobreturnos desde la auditoria
+            // si hay algún turno sin verificar asistencia y la agenda ya está en otro estado, se vuelve a pendiente asisitencia
+            if (this.agenda.estado !== 'pendienteAsistencia') {
+                // Se cambia de estado la agenda a pendienteAuditoria
+                let patch = {
+                    'op': 'pendienteAsistencia',
+                    'estado': 'pendienteAsistencia'
+                };
+                this.serviceAgenda.patch(this._agenda.id, patch).subscribe(resultado => {
+                    this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Pendiente Asistencia');
+                });
+            }
         }
     }
     /**
@@ -289,7 +301,6 @@ export class RevisionAgendaComponent implements OnInit {
                 this.plex.toast('success', 'El estado de la agenda fue actualizado', 'Auditada');
             });
         }
-
     }
 
     cancelar() {
@@ -328,10 +339,8 @@ export class RevisionAgendaComponent implements OnInit {
 
         if (this.turnoSeleccionado.tipoPrestacion) {
             this.serviceTurno.put(datosTurno).subscribe(resultado => {
-                // this.plex.toast('success', 'Información', 'El turno fue actualizado');
                 this.cerrarAsistencia();
                 this.cerrarCodificacion();
-                // this.turnoSeleccionado = null;
             });
         } else {
             this.plex.alert('Debe seleccionar un tipo de Prestacion');
@@ -388,6 +397,7 @@ export class RevisionAgendaComponent implements OnInit {
         this.showRevisionAgenda = true;
         this.modoCompleto = true;
         this.refresh();
+        this.cerrarAsistencia();
     }
 
 }

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -239,9 +239,8 @@
                                             <Label>Agregar diagnóstico</Label>
                                             <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
                                         </div>
-
                                     </div>
-                                    <hr>
+                                    <br>
                                     <!-- Listado de codificaciones seleccionadas -->
                                     <div class="row">
                                         <div class="col">
@@ -249,7 +248,7 @@
                                                 <thead>
                                                     <th></th>
                                                     <th class="text-left">Primera vez</th>
-                                                    <th></th>
+                                                    <th class="text-left">Estado</th>
                                                     <th class="text-left">Diagnóstico Snomed</th>
                                                     <th class="text-left">Diagnóstico CIE10</th>
                                                 </thead>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -289,7 +289,7 @@
                                                             <plex-bool *ngIf="i==0" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
                                                         </td>
                                                         <td class="col-2" *ngIf="diagnostico.codificacionProfesional.snomed.term">
-                                                            <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-info">Primera vez</span>
+                                                            <span *ngIf="diagnostico.primeraVez" class="badge-info">Primera vez</span>
                                                         </td>
                                                     </tr>
                                                 </tbody>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -1,166 +1,7 @@
 <section *ngIf="showRevisionAgenda">
     <div class="row">
-        <div class="col-4">
-            <plex-box>
-                <header class="header-fixed" [ngClass]="{'header-fixed-front': mostrarHeaderCompleto}">
-                    <fieldset>
-                        <legend>
-                            <div class="clearfix">
-                                <span class="float-left">Revisión de Agendas</span>
-                            </div>
-                        </legend>
-                        <!--Header de la agenda-->
-                        <div class="alert alert-default mb-0">
-                            <div class="float-right">
-                                <plex-button type="default" title="Mostrar detalle de la agenda" titlePosition="left" [icon]="mostrarHeaderCompleto ? 'chevron-up' : 'chevron-down'"
-                                    (click)="mostrarHeaderCompleto = !mostrarHeaderCompleto"></plex-button>
-                            </div>
-                            <!--Header pequeño-->
-                            <div *ngIf="!mostrarHeaderCompleto" class="row">
-                                <div class="col-12">
-                                    {{ agenda.horaInicio | date: 'EEE' | uppercase }} {{ agenda.horaInicio | date: 'dd/MM/yyyy'}}, {{ agenda.horaInicio | date:
-                                    'HH:mm'}} a {{ agenda.horaFin | date: 'HH:mm'}} hs
-                                    <div *ngFor="let tipoPrestacion of agenda.tipoPrestaciones">{{tipoPrestacion.nombre}}</div>
-                                </div>
-                            </div>
-                            <!--Header completo-->
-                            <div *ngIf="mostrarHeaderCompleto" class="row">
-                                <div class="col-12">
-                                    <label>Fecha</label> {{ agenda.horaInicio | date: 'EEE' | uppercase }} {{ agenda.horaInicio
-                                    | date: 'dd/MM/yyyy'}}, {{ agenda.horaInicio | date: 'HH:mm'}} a {{ agenda.horaFin |
-                                    date: 'HH:mm'}} hs
-                                </div>
-                            </div>
-                            <div *ngIf="mostrarHeaderCompleto" class="row">
-                                <div class="col-12">
-                                    <label>Tipos de prestación</label>
-                                    <div *ngFor="let tipoPrestacion of agenda.tipoPrestaciones">{{tipoPrestacion.nombre}}</div>
-                                </div>
-                            </div>
-                            <div *ngIf="mostrarHeaderCompleto" class="row">
-                                <div class="col-12">
-                                    <label>Profesionales</label>
-                                    <span *ngIf="agenda.profesionales?.length == 0" class="text-danger">Profesional no asignado</span>
-                                    <ng-container *ngIf="agenda.profesionales">
-                                        <div *ngFor="let profesional of agenda.profesionales">{{profesional | profesional}}</div>
-                                    </ng-container>
-                                </div>
-                            </div>
-                            <div *ngIf="mostrarHeaderCompleto" class="row">
-                                <div class="col-12">
-                                    <label>Espacio físico</label>
-                                    <span *ngIf="agenda.espacioFisico?.nombre">{{agenda.espacioFisico.nombre}}</span>
-                                    <span *ngIf="!agenda.espacioFisico?.nombre" class="text-danger">Espacio físico no asignado</span>
-                                </div>
-                            </div>
-                        </div>
-                        <!--Nota-->
-                        <div *ngIf="agenda.nota" class="alert alert-default mb-0">
-                            <i class="mdi mdi-comment mr-3"></i>{{ agenda.nota }}
-                        </div>
-                    </fieldset>
-                </header>
-
-                <table *ngFor="let bloque of agenda.bloques" class="table table-striped">
-                    <thead *ngIf="bloque.descripcion">
-                        <tr>
-                            <th colspan="4">{{bloque.descripcion}}
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr *ngFor="let turno of bloque.turnos; let i=index" class="hover" [ngClass]="{'bg-inverse text-white': estaSeleccionado(bloque.turnos[i])}">
-                            <td (click)="seleccionarTurno(turno, bloque)">
-                                <i *ngIf="estaSeleccionado(bloque.turnos[i])" class="mdi mdi-checkbox-marked"></i>
-                                <i *ngIf="!estaSeleccionado(bloque.turnos[i])" class="mdi mdi-checkbox-blank-outline"></i>
-                            </td>
-                            <td (click)="seleccionarTurno(bloque.turnos[i], bloque)">
-                                <strong *ngIf="turno">{{ turno.horaInicio | date: 'HH:mm' }}</strong>
-                            </td>
-                            <td (click)="seleccionarTurno(bloque.turnos[i], bloque)">
-                                <span *ngIf="turno.paciente && turno.paciente.id">{{ turno.paciente | paciente }} </span>
-                                <small *ngIf="turno.paciente && turno.paciente.id && turno.paciente.documento !== ''">
-                                    <span *ngIf="turno.paciente.documento !== ''">| DNI: {{ turno.paciente.documento | number }}</span>
-                                </small>
-                                <small *ngIf="turno.paciente && turno.paciente.id && turno.paciente.documento === ''">
-                                    <span>| Sin documento (temporal)</span>
-                                </small>
-                                <small>
-                                    <span *ngIf="turno.paciente && turno.paciente.id && turno.paciente.carpetaEfectores && turno.paciente.carpetaEfectores.length > 0 && turno.paciente.carpetaEfectores[0].nroCarpeta!=''">
-                                        | Nro Carpeta
-                                        <span *ngFor="let carpeta of turno.paciente.carpetaEfectores | slice:0:1;">
-                                            {{ carpeta.nroCarpeta }}
-                                            <!-- <plex-text [(ngModel)]="carpeta.nroCarpeta"></plex-text> -->
-                                        </span>
-                                    </span>
-                                </small>
-                                <span *ngIf="turno && turno.estado === 'disponible'">Disponible</span>
-                                <span [ngClass]="{'text-danger': turno.estado === 'turnoDoble'}" *ngIf="turno && turno.estado === 'turnoDoble'">Turno Doble</span>
-                                <span [ngClass]="{'text-danger': turno.estado === 'suspendido'}" *ngIf="turno && turno.estado === 'suspendido'">Suspendido</span>
-                                <span *ngIf="turno && turno.nota">
-                                    <i title="{{turno.nota}}" class="text-warning warning mdi mdi-message"></i>
-                                </span>
-                                <span [ngClass]="{'text-warning': true}" *ngIf="turno?.asistencia && turno?.asistencia == 'asistio' && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo && !turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed?.term">| Asistencia Verificada</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed?.term">| Registrado por Profesional</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && turno?.asistencia && (turno.asistencia =='noAsistio'|| turno.asistencia=='sinDatos' ||  turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo) ">| Auditado</span>
-
-                            </td>
-                        </tr>
-
-                    </tbody>
-                </table>
-                <table class="table table-striped">
-                    <thead *ngIf="agenda.sobreturnos.length > 0">
-                        <tr>
-                            <th colspan="4">Sobreturnos </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <!-- SOBRETURNOS -->
-                        <tr *ngFor="let sobreturno of agenda.sobreturnos; let i=index" class="hover" [ngClass]="{'bg-inverse text-white': estaSeleccionado(agenda.sobreturnos[i])}">
-                            <td (click)="seleccionarTurno(sobreturno, -1)">
-                                <i *ngIf="estaSeleccionado(agenda.sobreturnos[i])" class="mdi mdi-checkbox-marked"></i>
-                                <i *ngIf="!estaSeleccionado(agenda.sobreturnos[i])" class="mdi mdi-checkbox-blank-outline"></i>
-                            </td>
-                            <td (click)="seleccionarTurno(agenda.sobreturnos[i], bloque)">
-                                <strong *ngIf="sobreturno">{{ sobreturno.horaInicio | date: 'HH:mm' }}</strong>
-                            </td>
-                            <td (click)="seleccionarTurno(agenda.sobreturnos[i], -1)">
-                                <span *ngIf="sobreturno.paciente && sobreturno.paciente.id">{{ sobreturno.paciente | paciente }} </span>
-                                <small>
-                                    <span *ngIf="sobreturno.paciente && sobreturno.paciente.id && sobreturno.paciente.documento !== ''">| DNI: {{ sobreturno.paciente.documento | number }}</span>
-                                    <span *ngIf="sobreturno.paciente && sobreturno.paciente.id && sobreturno.paciente.documento === ''" class="text-danger">| DNI: Sin documento (temporal)</span>
-                                </small>
-                                <small>
-                                    <span *ngIf="sobreturno.paciente && sobreturno.paciente.id && sobreturno.paciente.carpetaEfectores && sobreturno.paciente.carpetaEfectores.length > 0 && sobreturno.paciente.carpetaEfectores[0].nroCarpeta!=''">
-                                        | Nro Carpeta
-                                        <span *ngFor="let carpeta of sobreturno.paciente.carpetaEfectores | slice:0:1;">
-                                            {{carpeta.nroCarpeta}}
-                                            <!-- <plex-text [(ngModel)]="carpeta.nroCarpeta"></plex-text> -->
-                                        </span>
-                                    </span>
-                                </small>
-                                <span [ngClass]="{'text-danger': sobreturno.estado === 'suspendido'}" *ngIf="sobreturno && sobreturno.estado === 'suspendido'">Suspendido</span>
-                                <span *ngIf="sobreturno && sobreturno.nota">
-                                    <i title="{{sobreturno.nota}}" class="text-warning warning mdi mdi-message"></i>
-                                </span>
-                                <span [ngClass]="{'text-warning': true}" *ngIf="sobreturno?.asistencia && sobreturno?.asistencia == 'asistio' && !sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo">| Asistencia Verificada</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="sobreturno?.paciente?.id && (sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo || (sobreturno?.asistencia && sobreturno.asistencia =='noAsistio'|| sobreturno.asistencia=='sinDatos'))">| Auditado</span>
-
-                            </td>
-                        </tr>
-                    </tbody>
-                    <!-- /SOBRETURNOS -->
-                </table>
-                <div class="row">
-                    <div class="col-6">
-                        <plex-button type="primary" label="Agregar Sobreturno" (click)="agregarSobreturno()"></plex-button>
-                    </div>
-                </div>
-            </plex-box>
-        </div>
-        <div class="col-8" *ngIf="turnoSeleccionado && turnoSeleccionado.estado !== 'suspendido' && turnoSeleccionado.estado !== 'turnoDoble'">
-            <plex-box>
+        <div class="col-8">
+            <plex-box *ngIf="turnoSeleccionado && turnoSeleccionado.estado !== 'suspendido' && turnoSeleccionado.estado !== 'turnoDoble'">
                 <!--REGISTRO DE ASISTENCIA-->
                 <header>
                     <div class="clearfix">
@@ -248,7 +89,7 @@
                                                 <thead>
                                                     <th>Operaciones</th>
                                                     <th class="text-left">Primera vez</th>
-                                                    <th class="text-left">Estado</th>
+                                                    <th class="text-center">Estado</th>
                                                     <th class="text-left">Diagnóstico Snomed</th>
                                                     <th class="text-left">Diagnóstico CIE10</th>
                                                 </thead>
@@ -351,6 +192,162 @@
                         </div>
                     </div>
                     <!--/ CODIFICACION-->
+                </div>
+            </plex-box>
+        </div>
+        <div class="col-4">
+            <plex-box>
+                <header class="header-fixed" [ngClass]="{'header-fixed-front': mostrarHeaderCompleto}">
+                    <fieldset>
+                        <legend>
+                            <div class="clearfix">
+                                <span class="float-left">Revisión de Agendas</span>
+                            </div>
+                        </legend>
+                        <!--Header de la agenda-->
+                        <div class="alert alert-default mb-0">
+                            <div class="float-right">
+                                <plex-button type="default" title="Mostrar detalle de la agenda" titlePosition="left" [icon]="mostrarHeaderCompleto ? 'chevron-up' : 'chevron-down'"
+                                    (click)="mostrarHeaderCompleto = !mostrarHeaderCompleto"></plex-button>
+                            </div>
+                            <!--Header pequeño-->
+                            <div *ngIf="!mostrarHeaderCompleto" class="row">
+                                <div class="col-12">
+                                    {{ agenda.horaInicio | date: 'EEE' | uppercase }} {{ agenda.horaInicio | date: 'dd/MM/yyyy'}}, {{ agenda.horaInicio | date:
+                                    'HH:mm'}} a {{ agenda.horaFin | date: 'HH:mm'}} hs
+                                    <div *ngFor="let tipoPrestacion of agenda.tipoPrestaciones">{{tipoPrestacion.nombre}}</div>
+                                </div>
+                            </div>
+                            <!--Header completo-->
+                            <div *ngIf="mostrarHeaderCompleto" class="row">
+                                <div class="col-12">
+                                    <label>Fecha</label> {{ agenda.horaInicio | date: 'EEE' | uppercase }} {{ agenda.horaInicio
+                                    | date: 'dd/MM/yyyy'}}, {{ agenda.horaInicio | date: 'HH:mm'}} a {{ agenda.horaFin |
+                                    date: 'HH:mm'}} hs
+                                </div>
+                            </div>
+                            <div *ngIf="mostrarHeaderCompleto" class="row">
+                                <div class="col-12">
+                                    <label>Tipos de prestación</label>
+                                    <div *ngFor="let tipoPrestacion of agenda.tipoPrestaciones">{{tipoPrestacion.nombre}}</div>
+                                </div>
+                            </div>
+                            <div *ngIf="mostrarHeaderCompleto" class="row">
+                                <div class="col-12">
+                                    <label>Profesionales</label>
+                                    <span *ngIf="agenda.profesionales?.length == 0" class="text-danger">Profesional no asignado</span>
+                                    <ng-container *ngIf="agenda.profesionales">
+                                        <div *ngFor="let profesional of agenda.profesionales">{{profesional | profesional}}</div>
+                                    </ng-container>
+                                </div>
+                            </div>
+                            <div *ngIf="mostrarHeaderCompleto" class="row">
+                                <div class="col-12">
+                                    <label>Espacio físico</label>
+                                    <span *ngIf="agenda.espacioFisico?.nombre">{{agenda.espacioFisico.nombre}}</span>
+                                    <span *ngIf="!agenda.espacioFisico?.nombre" class="text-danger">Espacio físico no asignado</span>
+                                </div>
+                            </div>
+                        </div>
+                        <!--Nota-->
+                        <div *ngIf="agenda.nota" class="alert alert-default mb-0">
+                            <i class="mdi mdi-comment mr-3"></i>{{ agenda.nota }}
+                        </div>
+                    </fieldset>
+                </header>
+
+                <table *ngFor="let bloque of agenda.bloques" class="table table-striped">
+                    <thead *ngIf="bloque.descripcion">
+                        <tr>
+                            <th colspan="4">{{bloque.descripcion}}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr *ngFor="let turno of bloque.turnos; let i=index" class="hover" [ngClass]="{'bg-inverse text-white': estaSeleccionado(bloque.turnos[i])}">
+
+                            <td (click)="seleccionarTurno(bloque.turnos[i], bloque)">
+                                <strong *ngIf="turno">{{ turno.horaInicio | date: 'HH:mm' }}</strong>
+                            </td>
+                            <td (click)="seleccionarTurno(bloque.turnos[i], bloque)">
+                                <span *ngIf="turno.paciente && turno.paciente.id">{{ turno.paciente | paciente }} </span>
+                                <small *ngIf="turno.paciente && turno.paciente.id && turno.paciente.documento !== ''">
+                                    <span *ngIf="turno.paciente.documento !== ''">| DNI: {{ turno.paciente.documento | number }}</span>
+                                </small>
+                                <small *ngIf="turno.paciente && turno.paciente.id && turno.paciente.documento === ''">
+                                    <span>| Sin documento (temporal)</span>
+                                </small>
+                                <small>
+                                    <span *ngIf="turno.paciente && turno.paciente.id && turno.paciente.carpetaEfectores && turno.paciente.carpetaEfectores.length > 0 && turno.paciente.carpetaEfectores[0].nroCarpeta!=''">
+                                        | Nro Carpeta
+                                        <span *ngFor="let carpeta of turno.paciente.carpetaEfectores | slice:0:1;">
+                                            {{ carpeta.nroCarpeta }}
+                                            <!-- <plex-text [(ngModel)]="carpeta.nroCarpeta"></plex-text> -->
+                                        </span>
+                                    </span>
+                                </small>
+                                <span *ngIf="turno && turno.estado === 'disponible'">Disponible</span>
+                                <span [ngClass]="{'text-danger': turno.estado === 'turnoDoble'}" *ngIf="turno && turno.estado === 'turnoDoble'">Turno Doble</span>
+                                <span [ngClass]="{'text-danger': turno.estado === 'suspendido'}" *ngIf="turno && turno.estado === 'suspendido'">Suspendido</span>
+                                <span *ngIf="turno && turno.nota">
+                                    <i title="{{turno.nota}}" class="text-warning warning mdi mdi-message"></i>
+                                </span>
+                                <span [ngClass]="{'text-warning': true}" *ngIf="turno?.asistencia && turno?.asistencia == 'asistio' && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo && !turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed?.term">| Asistencia Verificada</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed?.term">| Registrado por Profesional</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && turno?.asistencia && (turno.asistencia =='noAsistio'|| turno.asistencia=='sinDatos' ||  turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo) ">| Auditado</span>
+
+                            </td>
+                        </tr>
+
+                    </tbody>
+                </table>
+                <table class="table table-striped">
+                    <thead *ngIf="agenda.sobreturnos.length > 0">
+                        <tr>
+                            <th colspan="4">Sobreturnos </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- SOBRETURNOS -->
+                        <tr *ngFor="let sobreturno of agenda.sobreturnos; let i=index" class="hover" [ngClass]="{'bg-inverse text-white': estaSeleccionado(agenda.sobreturnos[i])}">
+                            <td (click)="seleccionarTurno(sobreturno, -1)">
+                                <i *ngIf="estaSeleccionado(agenda.sobreturnos[i])" class="mdi mdi-checkbox-marked"></i>
+                                <i *ngIf="!estaSeleccionado(agenda.sobreturnos[i])" class="mdi mdi-checkbox-blank-outline"></i>
+                            </td>
+                            <td (click)="seleccionarTurno(agenda.sobreturnos[i], bloque)">
+                                <strong *ngIf="sobreturno">{{ sobreturno.horaInicio | date: 'HH:mm' }}</strong>
+                            </td>
+                            <td (click)="seleccionarTurno(agenda.sobreturnos[i], -1)">
+                                <span *ngIf="sobreturno.paciente && sobreturno.paciente.id">{{ sobreturno.paciente | paciente }} </span>
+                                <small>
+                                    <span *ngIf="sobreturno.paciente && sobreturno.paciente.id && sobreturno.paciente.documento !== ''">| DNI: {{ sobreturno.paciente.documento | number }}</span>
+                                    <span *ngIf="sobreturno.paciente && sobreturno.paciente.id && sobreturno.paciente.documento === ''" class="text-danger">| DNI: Sin documento (temporal)</span>
+                                </small>
+                                <small>
+                                    <span *ngIf="sobreturno.paciente && sobreturno.paciente.id && sobreturno.paciente.carpetaEfectores && sobreturno.paciente.carpetaEfectores.length > 0 && sobreturno.paciente.carpetaEfectores[0].nroCarpeta!=''">
+                                        | Nro Carpeta
+                                        <span *ngFor="let carpeta of sobreturno.paciente.carpetaEfectores | slice:0:1;">
+                                            {{carpeta.nroCarpeta}}
+                                            <!-- <plex-text [(ngModel)]="carpeta.nroCarpeta"></plex-text> -->
+                                        </span>
+                                    </span>
+                                </small>
+                                <span [ngClass]="{'text-danger': sobreturno.estado === 'suspendido'}" *ngIf="sobreturno && sobreturno.estado === 'suspendido'">Suspendido</span>
+                                <span *ngIf="sobreturno && sobreturno.nota">
+                                    <i title="{{sobreturno.nota}}" class="text-warning warning mdi mdi-message"></i>
+                                </span>
+                                <span [ngClass]="{'text-warning': true}" *ngIf="sobreturno?.asistencia && sobreturno?.asistencia == 'asistio' && !sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo">| Asistencia Verificada</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="sobreturno?.paciente?.id && (sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo || (sobreturno?.asistencia && sobreturno.asistencia =='noAsistio'|| sobreturno.asistencia=='sinDatos'))">| Auditado</span>
+
+                            </td>
+                        </tr>
+                    </tbody>
+                    <!-- /SOBRETURNOS -->
+                </table>
+                <div class="row">
+                    <div class="col-6">
+                        <plex-button type="primary" label="Agregar Sobreturno" (click)="agregarSobreturno()"></plex-button>
+                    </div>
                 </div>
             </plex-box>
         </div>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -100,9 +100,9 @@
                                 <span *ngIf="turno && turno.nota">
                                     <i title="{{turno.nota}}" class="text-warning warning mdi mdi-message"></i>
                                 </span>
-                                <span [ngClass]="{'text-warning': true}" *ngIf="turno?.asistencia && turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria == null && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional == null">| Asistencia Verificada</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria == null && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional != null">| Registrado por Profesional</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria != null ">| Auditado</span>
+                                <span [ngClass]="{'text-warning': true}" *ngIf="turno?.asistencia && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria && !turno?.diagnostico?.codificaciones[0]?.codificacionProfesional">| Asistencia Verificada</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed">| Registrado por Profesional</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && (turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria)">| Auditado</span>
 
                             </td>
                         </tr>
@@ -249,46 +249,57 @@
                                             <table class="table table-striped">
                                                 <tbody>
                                                     <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover row">
-                                                        <td class="col-1">
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional.snomed.term && !diagnostico.codificacionAuditoria" type="success"
+                                                        <td class="col-1 text-right">
+                                                            <!-- Boton aprobar diagnostico profesional -->
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && !diagnostico.codificacionAuditoria" type="success"
                                                                 icon="mdi mdi-check" title="Aprobar" (click)="aprobar(i)"></plex-button>
+                                                            <!-- Boton eliminar diagnostico (para diagnosticos de auditoría) -->
+                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional?.snomed?.term" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
                                                         </td>
                                                         <td class="col-1 ">
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional.snomed.term && !diagnostico.codificacionAuditoria " type="danger"
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && !diagnostico.codificacionAuditoria?.codigo" type="danger"
                                                                 icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)">
                                                             </plex-button>
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional.snomed.term && diagnostico.codificacionAuditoria" type="info" icon="mdi mdi-refresh"
-                                                                title="Reestablecer" (click)="borrarReparo(i)"> </plex-button>
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo" type="info"
+                                                                icon="mdi mdi-refresh" title="Reestablecer" (click)="borrarReparo(i)">
+                                                            </plex-button>
                                                         </td>
                                                         <td class="col-1">
                                                             <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.cie10?.codigo">Aprobado</span>
-                                                        </td>
-                                                        <td class="col-1">
-                                                            <span class="badge-warning" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo !== diagnostico.codificacionProfesional?.cie10?.codigo">Reparado</span>
-                                                        </td>
-                                                        <td class="col-4 " *ngIf="!diagnostico.codificacionAuditoria">
-                                                            <div>
-                                                                <span *ngIf="diagnostico.codificacionProfesional.snomed.term"> SNOMED | {{diagnostico.codificacionProfesional.snomed.term}}
-                                                                </span>
-                                                            </div>
-                                                            <div>
-                                                                <span *ngIf="diagnostico.codificacionProfesional.cie10"> MAPEO CIE10 | {{diagnostico.codificacionProfesional.cie10.sinonimo}}
-                                                                </span>
-                                                            </div>
-                                                        </td>
-                                                        <td class="col-4" *ngIf="diagnostico.codificacionAuditoria">
-                                                            <span> {{diagnostico.codificacionAuditoria.sinonimo}} </span>
+
+                                                            <span class="badge-warning" *ngIf="diagnostico.codificacionAuditoria?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo != diagnostico.codificacionProfesional?.cie10?.codigo">Reparado</span>
                                                         </td>
                                                         <td class="col-1">
                                                             <span *ngIf="i==0" class="badge-info">Principal</span>
                                                         </td>
-                                                        <td class="col-1 ">
-                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional.snomed.term" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
+                                                        <td class="col-6">
+                                                            <!-- Mostramos la codificación snomed hecha por profesional -->
+                                                            <div>
+                                                                <span *ngIf="diagnostico.codificacionProfesional?.snomed?.term"> SNOMED | {{diagnostico.codificacionProfesional.snomed.term}}
+                                                                </span>
+                                                            </div>
+                                                            <div>
+                                                                <!-- Si no mapea a cie10 -->
+                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term &&!diagnostico.codificacionProfesional?.cie10?.codigo && !diagnostico.codificacionAuditoria">
+                                                                    Mapeo Cie10 | No encontrado
+                                                                </span>
+                                                                <!-- Mostramos el mapeo de la codificación snomed -->
+                                                                <span *ngIf="diagnostico.codificacionProfesional?.cie10 && (!diagnostico.codificacionAuditoria || diagnostico.codificacionAuditoria?.codigo == diagnostico.codificacionProfesional?.cie10?.codigo )">
+                                                                    Mapeo Cie10 | {{diagnostico.codificacionProfesional.cie10.sinonimo}}
+                                                                </span>
+                                                                <!-- Mostramos la codificación reparada -->
+                                                                <span *ngIf="diagnostico.codificacionAuditoria?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo != diagnostico.codificacionProfesional?.cie10?.codigo">
+                                                                    Reparo | {{diagnostico.codificacionAuditoria.sinonimo}}
+                                                                </span>
+                                                                <!-- Mostramos la codificación cuando no hay diagnóstico del profesional -->
+                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.sinonimo"> Cie10 | {{diagnostico.codificacionAuditoria.sinonimo}}
+                                                                </span>
+                                                            </div>
                                                         </td>
-                                                        <td class="col-2" *ngIf="!diagnostico.codificacionProfesional.snomed.term">
+                                                        <td class="col-2" *ngIf="!diagnostico.codificacionProfesional?.snomed?.term">
                                                             <plex-bool *ngIf="i==0" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
                                                         </td>
-                                                        <td class="col-2" *ngIf="diagnostico.codificacionProfesional.snomed.term">
+                                                        <td class="col-2" *ngIf="diagnostico.codificacionProfesional?.snomed?.term">
                                                             <span *ngIf="diagnostico.primeraVez" class="badge-info">Primera vez</span>
                                                         </td>
                                                     </tr>
@@ -299,6 +310,7 @@
                                     <!-- Buscador de prestaciones cie10 -->
                                     <div class="row">
                                         <div class="col-10">
+                                            <Label>Seleccionar código reparo Cie10</Label>
                                             <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
                                         </div>
 
@@ -325,8 +337,8 @@
                                     </div>
                                     <!-- Búsqueda de prestaciones cie10 -->
                                     <div class="row">
-                                        <div class="col-8">
-                                            <Label textWrap="true">Seleccionar código reparo Cie10</Label>
+                                        <div class="col-10">
+                                            <Label>Seleccionar código reparo Cie10</Label>
                                             <buscador-cie10 (seleccionEmit)="repararDiagnostico($event)"></buscador-cie10>
                                         </div>
                                     </div>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -110,7 +110,7 @@
                                                                 type="info" icon="mdi mdi-refresh" title="Reestablecer" (click)="borrarReparo(i)">
                                                             </plex-button>
                                                         </td>
-                                                        <td class="text-center">
+                                                        <td>
                                                             <plex-bool *ngIf="!diagnostico.codificacionProfesional?.snomed?.term" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez'></plex-bool>
                                                             <!-- Muestro primera vez solo para diagnosticos de profesional -->
                                                             <span class="badge-success" *ngIf="(diagnostico.codificacionProfesional?.snomed?.term && diagnostico.primeraVez && !(diagnostico.codificacionAuditoria)) || (diagnostico.codificacionAuditoria?.codigo == diagnostico.codificacionProfesional?.cie10?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.primeraVez)">

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -293,14 +293,14 @@
                                                                 </span>
                                                                 <!-- Mostramos el mapeo de la codificación snomed -->
                                                                 <span *ngIf="diagnostico.codificacionProfesional?.cie10 && (!diagnostico.codificacionAuditoria || diagnostico.codificacionAuditoria?.codigo == diagnostico.codificacionProfesional?.cie10?.codigo )">
-                                                                    Mapeo Cie10 | {{diagnostico.codificacionProfesional.cie10.sinonimo}}
+                                                                    Mapeo Cie10 |({{diagnostico.codificacionProfesional.cie10.codigo}}) {{diagnostico.codificacionProfesional.cie10.sinonimo}}
                                                                 </span>
                                                                 <!-- Mostramos la codificación reparada -->
                                                                 <span *ngIf="diagnostico.codificacionAuditoria?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo != diagnostico.codificacionProfesional?.cie10?.codigo">
-                                                                    Reparo | {{diagnostico.codificacionAuditoria.sinonimo}}
+                                                                    Reparo | ({{diagnostico.codificacionAuditoria.codigo}}) {{diagnostico.codificacionAuditoria.sinonimo}}
                                                                 </span>
                                                                 <!-- Mostramos la codificación cuando no hay diagnóstico del profesional -->
-                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.sinonimo"> Cie10 | {{diagnostico.codificacionAuditoria.sinonimo}}
+                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.sinonimo"> Cie10 | ({{diagnostico.codificacionAuditoria.codigo}}) {{diagnostico.codificacionAuditoria.sinonimo}}
                                                                 </span>
                                                             </div>
                                                         </td>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -280,8 +280,10 @@
                                                             <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.cie10?.codigo">Aprobado</span>
 
                                                             <span class="badge-warning" *ngIf="diagnostico.codificacionAuditoria?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo != diagnostico.codificacionProfesional?.cie10?.codigo">Reparado</span>
-
+                                                            <!-- La funcion codificarTurno establece que el diagnóstico principal siempre es el primero -->
                                                             <span *ngIf="i==0" class="badge-info">Principal</span>
+
+                                                            <span *ngIf="diagnostico.codificacionAuditoria?.c2 || diagnostico.codificacionProfesional?.cie10?.c2" class="badge-danger">C2</span>
                                                         </td>
                                                         <td>
                                                             <!-- Mostramos la codificación snomed hecha por profesional -->

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -240,33 +240,41 @@
                     <div class="row">
                         <div class="col-12">
                             <div *ngIf="turnoSeleccionado?.asistencia == 'asistio'">
-                                <h5>Codificación</h5>
-                                <hr>
-                                <!-- Listado de codificaciones seleccionadas -->
                                 <div *ngIf="!showReparo">
+                                    <h5>Codificación</h5>
+                                    <hr>
+                                    <!-- Listado de codificaciones seleccionadas -->
                                     <div class="row">
                                         <div class="col-12">
                                             <table class="table table-striped">
                                                 <tbody>
                                                     <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover row">
                                                         <td class="col-1">
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional && !diagnostico.codificacionAuditoria" type="success" icon="mdi mdi-check"
-                                                                title="Aprobar" (click)="aprobar(i)"></plex-button>
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional.snomed.term && !diagnostico.codificacionAuditoria" type="success"
+                                                                icon="mdi mdi-check" title="Aprobar" (click)="aprobar(i)"></plex-button>
                                                         </td>
                                                         <td class="col-1 ">
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional && !diagnostico.codificacionAuditoria " type="danger" icon="mdi mdi-pencil"
-                                                                title="Reparar" (click)="mostrarReparo(i)"> </plex-button>
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria" type="info" icon="mdi mdi-refresh"
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional.snomed.term && !diagnostico.codificacionAuditoria " type="danger"
+                                                                icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)">
+                                                            </plex-button>
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional.snomed.term && diagnostico.codificacionAuditoria" type="info" icon="mdi mdi-refresh"
                                                                 title="Reestablecer" (click)="borrarReparo(i)"> </plex-button>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.codigo">Aprobado</span>
+                                                            <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.cie10?.codigo">Aprobado</span>
                                                         </td>
                                                         <td class="col-1">
-                                                            <span class="badge-warning" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo !== diagnostico.codificacionProfesional?.codigo">Reparado</span>
+                                                            <span class="badge-warning" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo !== diagnostico.codificacionProfesional?.cie10?.codigo">Reparado</span>
                                                         </td>
                                                         <td class="col-4 " *ngIf="!diagnostico.codificacionAuditoria">
-                                                            <span *ngIf="diagnostico.codificacionProfesional"> {{diagnostico.codificacionProfesional.sinonimo}} </span>
+                                                            <div>
+                                                                <span *ngIf="diagnostico.codificacionProfesional.snomed.term"> SNOMED | {{diagnostico.codificacionProfesional.snomed.term}}
+                                                                </span>
+                                                            </div>
+                                                            <div>
+                                                                <span *ngIf="diagnostico.codificacionProfesional.cie10"> MAPEO CIE10 | {{diagnostico.codificacionProfesional.cie10.sinonimo}}
+                                                                </span>
+                                                            </div>
                                                         </td>
                                                         <td class="col-4" *ngIf="diagnostico.codificacionAuditoria">
                                                             <span> {{diagnostico.codificacionAuditoria.sinonimo}} </span>
@@ -275,12 +283,12 @@
                                                             <span *ngIf="i==0" class="badge-info">Principal</span>
                                                         </td>
                                                         <td class="col-1 ">
-                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
+                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional.snomed.term" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
                                                         </td>
-                                                        <td class="col-2" *ngIf="!diagnostico.codificacionProfesional">
+                                                        <td class="col-2" *ngIf="!diagnostico.codificacionProfesional.snomed.term">
                                                             <plex-bool *ngIf="i==0" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
                                                         </td>
-                                                        <td class="col-2" *ngIf="diagnostico.codificacionProfesional">
+                                                        <td class="col-2" *ngIf="diagnostico.codificacionProfesional.snomed.term">
                                                             <span *ngIf="i==0 && diagnostico.primeraVez" class="badge-info">Primera vez</span>
                                                         </td>
                                                     </tr>
@@ -302,16 +310,24 @@
                                 <div *ngIf="turnoSeleccionado && diagnosticos[indiceReparo]?.codificacionProfesional && showReparo">
                                     <div class="row">
                                         <div class="col">
-                                            <h5>codificación del profesional</h5> {{diagnosticos[indiceReparo].codificacionProfesional.sinonimo}}
+                                            <h3>Codificación del profesional</h3>
+                                            <h5>
+                                                <label> Codificación Snomed: </label> {{diagnosticos[indiceReparo].codificacionProfesional.snomed.term}}
+                                            </h5>
+                                            <h5>
+                                                <label> Mapeo a Cie10: </label>
+                                                <span *ngIf="diagnosticos[indiceReparo].codificacionProfesional.cie10?.sinonimo">
+                                                    {{diagnosticos[indiceReparo].codificacionProfesional.cie10.sinonimo}}</span>
+
+                                            </h5>
                                             <hr>
                                         </div>
                                     </div>
                                     <!-- Búsqueda de prestaciones cie10 -->
                                     <div class="row">
                                         <div class="col-8">
-                                            <Label text="Seleccionar código reparo" textWrap="true"></Label>
+                                            <Label textWrap="true">Seleccionar código reparo Cie10</Label>
                                             <buscador-cie10 (seleccionEmit)="repararDiagnostico($event)"></buscador-cie10>
-
                                         </div>
                                     </div>
                                 </div>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -246,7 +246,7 @@
                                         <div class="col">
                                             <table class="table table-striped">
                                                 <thead>
-                                                    <th></th>
+                                                    <th>Operaciones</th>
                                                     <th class="text-left">Primera vez</th>
                                                     <th class="text-left">Estado</th>
                                                     <th class="text-left">Diagnóstico Snomed</th>
@@ -271,7 +271,10 @@
                                                         </td>
                                                         <td class="text-center">
                                                             <plex-bool *ngIf="!diagnostico.codificacionProfesional?.snomed?.term" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez'></plex-bool>
-                                                            <span class="badge-success" *ngIf="diagnostico.codificacionProfesional?.snomed?.term && diagnostico.primeraVez">Aprobado</span>
+                                                            <!-- Muestro primera vez solo para diagnosticos de profesional -->
+                                                            <span class="badge-success" *ngIf="(diagnostico.codificacionProfesional?.snomed?.term && diagnostico.primeraVez && !(diagnostico.codificacionAuditoria)) || (diagnostico.codificacionAuditoria?.codigo == diagnostico.codificacionProfesional?.cie10?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.primeraVez)">
+                                                                Si
+                                                            </span>
                                                         </td>
                                                         <td>
                                                             <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.cie10?.codigo">Aprobado</span>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -185,7 +185,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-6" *ngIf="turnoSeleccionado.paciente?.id">
+                    <div class="col" *ngIf="turnoSeleccionado.paciente?.id">
                         <div *ngIf="turnoSeleccionado.paciente?.id"> {{ turnoSeleccionado.paciente | paciente }}
                             <span *ngIf="turnoSeleccionado.paciente.documento !== ''"> | DNI {{ turnoSeleccionado.paciente.documento | number}}</span>
                             <span *ngIf="turnoSeleccionado.paciente.documento === ''"> Sin documento (temporal)</span>
@@ -214,21 +214,12 @@
                 </div>
                 <div *ngIf="turnoSeleccionado && (turnoSeleccionado.paciente?.id || paciente?.id) && !pacientesSearch">
                     <div class="row">
-                        <div class="col">
+                        <div class="col-4">
                             <!--ASISTENCIA-->
                             <div *ngIf="!existeCodificacionProfesional">
-                                <br>
-                                <h5>Asistencia</h5>
-                                <hr>
-                                <div *ngFor="let estado of estadosAsistencia; let i=index">
-                                    <td (click)="seleccionarAsistencia(estado)">
-                                        <i *ngIf="asistenciaSeleccionada(estado)" class="mdi mdi-checkbox-marked"></i>
-                                        <i *ngIf="!asistenciaSeleccionada(estado)" class="mdi mdi-checkbox-blank-outline"></i>
-                                    </td>
-                                    <td (click)="asistenciaSeleccionada(estado)">
-                                        <strong>{{ estado.nombre }}</strong>
-                                    </td>
-                                </div>
+                                <plex-select label="Asistencia" [(ngModel)]="turnoSeleccionado.asistencia" name="localidad" [data]="estadosAsistencia" placeholder="Seleccione..."
+                                    (change)="seleccionarAsistencia(turnoSeleccionado.asistencia)">
+                                </plex-select>
                             </div>
                             <!--/ ASISTENCIA-->
                         </div>
@@ -253,62 +244,70 @@
                                     <hr>
                                     <!-- Listado de codificaciones seleccionadas -->
                                     <div class="row">
-                                        <div class="col-12">
+                                        <div class="col">
                                             <table class="table table-striped">
+                                                <thead>
+                                                    <th></th>
+                                                    <th class="text-left">Primera vez</th>
+                                                    <th></th>
+                                                    <th class="text-left">Diagnóstico Snomed</th>
+                                                    <th class="text-left">Diagnóstico CIE10</th>
+                                                </thead>
                                                 <tbody>
-                                                    <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover row">
-                                                        <td class="col-1 text-right">
+                                                    <tr *ngFor="let diagnostico of diagnosticos; let i = index; " class="hover">
+                                                        <td>
                                                             <!-- Boton aprobar diagnostico profesional -->
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && !diagnostico.codificacionAuditoria" type="success"
-                                                                icon="mdi mdi-check" title="Aprobar" (click)="aprobar(i)"></plex-button>
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && !diagnostico.codificacionAuditoria" class="btn btn-sm"
+                                                                type="success" icon="mdi mdi-check" title="Aprobar" (click)="aprobar(i)"></plex-button>
                                                             <!-- Boton eliminar diagnostico (para diagnosticos de auditoría) -->
-                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional?.snomed?.term" icon="delete" title="Eliminar" type="danger" (click)="borrarDiagnostico(i)"></plex-button>
-                                                        </td>
-                                                        <td class="col-1 ">
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && !diagnostico.codificacionAuditoria?.codigo" type="danger"
-                                                                icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)">
+                                                            <plex-button *ngIf="!diagnostico.codificacionProfesional?.snomed?.term" icon="delete" title="Eliminar" class="btn btn-sm"
+                                                                type="danger" (click)="borrarDiagnostico(i)"></plex-button>
+
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && !diagnostico.codificacionAuditoria?.codigo" class="btn btn-sm"
+                                                                type="danger" icon="mdi mdi-pencil" title="Reparar" (click)="mostrarReparo(i)">
                                                             </plex-button>
-                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo" type="info"
-                                                                icon="mdi mdi-refresh" title="Reestablecer" (click)="borrarReparo(i)">
+                                                            <plex-button *ngIf="diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo" class="btn btn-sm"
+                                                                type="info" icon="mdi mdi-refresh" title="Reestablecer" (click)="borrarReparo(i)">
                                                             </plex-button>
                                                         </td>
-                                                        <td class="col-1">
+                                                        <td class="text-center">
+                                                            <plex-bool *ngIf="!diagnostico.codificacionProfesional?.snomed?.term" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez'></plex-bool>
+                                                            <span class="badge-success" *ngIf="diagnostico.codificacionProfesional?.snomed?.term && diagnostico.primeraVez">Aprobado</span>
+                                                        </td>
+                                                        <td>
                                                             <span class="badge-success" *ngIf=" diagnostico.codificacionAuditoria && diagnostico.codificacionProfesional && diagnostico.codificacionAuditoria?.codigo === diagnostico.codificacionProfesional?.cie10?.codigo">Aprobado</span>
 
                                                             <span class="badge-warning" *ngIf="diagnostico.codificacionAuditoria?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo != diagnostico.codificacionProfesional?.cie10?.codigo">Reparado</span>
-                                                        </td>
-                                                        <td class="col-1">
+
                                                             <span *ngIf="i==0" class="badge-info">Principal</span>
                                                         </td>
-                                                        <td class="col-6">
+                                                        <td>
                                                             <!-- Mostramos la codificación snomed hecha por profesional -->
                                                             <div>
-                                                                <span *ngIf="diagnostico.codificacionProfesional?.snomed?.term"> SNOMED | {{diagnostico.codificacionProfesional.snomed.term}}
+                                                                <span *ngIf="diagnostico.codificacionProfesional?.snomed?.term">{{diagnostico.codificacionProfesional.snomed.term}}
+                                                                </span>
+                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term"> -
                                                                 </span>
                                                             </div>
+                                                        </td>
+                                                        <td>
                                                             <div>
                                                                 <!-- Si no mapea a cie10 -->
                                                                 <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term &&!diagnostico.codificacionProfesional?.cie10?.codigo && !diagnostico.codificacionAuditoria">
-                                                                    Mapeo Cie10 | No encontrado
+                                                                    No encontrado
                                                                 </span>
                                                                 <!-- Mostramos el mapeo de la codificación snomed -->
                                                                 <span *ngIf="diagnostico.codificacionProfesional?.cie10 && (!diagnostico.codificacionAuditoria || diagnostico.codificacionAuditoria?.codigo == diagnostico.codificacionProfesional?.cie10?.codigo )">
-                                                                    Mapeo Cie10 |({{diagnostico.codificacionProfesional.cie10.codigo}}) {{diagnostico.codificacionProfesional.cie10.sinonimo}}
+                                                                    ({{diagnostico.codificacionProfesional.cie10.codigo}}) {{diagnostico.codificacionProfesional.cie10.sinonimo}}
                                                                 </span>
                                                                 <!-- Mostramos la codificación reparada -->
                                                                 <span *ngIf="diagnostico.codificacionAuditoria?.codigo && diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.codigo != diagnostico.codificacionProfesional?.cie10?.codigo">
-                                                                    Reparo | ({{diagnostico.codificacionAuditoria.codigo}}) {{diagnostico.codificacionAuditoria.sinonimo}}
+                                                                    ({{diagnostico.codificacionAuditoria.codigo}}) {{diagnostico.codificacionAuditoria.sinonimo}}
                                                                 </span>
                                                                 <!-- Mostramos la codificación cuando no hay diagnóstico del profesional -->
-                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.sinonimo"> Cie10 | ({{diagnostico.codificacionAuditoria.codigo}}) {{diagnostico.codificacionAuditoria.sinonimo}}
+                                                                <span *ngIf="!diagnostico.codificacionProfesional?.snomed?.term && diagnostico.codificacionAuditoria?.sinonimo">({{diagnostico.codificacionAuditoria.codigo}}) {{diagnostico.codificacionAuditoria.sinonimo}}
                                                                 </span>
                                                             </div>
-                                                        </td>
-                                                        <td class="col-2" *ngIf="!diagnostico.codificacionProfesional?.snomed?.term">
-                                                            <plex-bool *ngIf="i==0" (change)="onSave()" [(ngModel)]='diagnostico.primeraVez' name="primeraVez" label="Primera Vez"></plex-bool>
-                                                        </td>
-                                                        <td class="col-2" *ngIf="diagnostico.codificacionProfesional?.snomed?.term">
-                                                            <span *ngIf="diagnostico.primeraVez" class="badge-info">Primera vez</span>
                                                         </td>
                                                     </tr>
                                                 </tbody>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -100,9 +100,9 @@
                                 <span *ngIf="turno && turno.nota">
                                     <i title="{{turno.nota}}" class="text-warning warning mdi mdi-message"></i>
                                 </span>
-                                <span [ngClass]="{'text-warning': true}" *ngIf="turno?.asistencia && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria && !turno?.diagnostico?.codificaciones[0]?.codificacionProfesional">| Asistencia Verificada</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed">| Registrado por Profesional</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && (turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria)">| Auditado</span>
+                                <span [ngClass]="{'text-warning': true}" *ngIf="turno?.asistencia && turno?.asistencia == 'asistio' && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo && !turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed?.term">| Asistencia Verificada</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && !turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo && turno?.diagnostico?.codificaciones[0]?.codificacionProfesional?.snomed?.term">| Registrado por Profesional</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="turno?.paciente?.id && turno?.asistencia && (turno.asistencia =='noAsistio'|| turno.asistencia=='sinDatos' ||  turno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo) ">| Auditado</span>
 
                             </td>
                         </tr>
@@ -112,8 +112,7 @@
                 <table class="table table-striped">
                     <thead *ngIf="agenda.sobreturnos.length > 0">
                         <tr>
-                            <th colspan="4">Sobreturnos
-                            </th>
+                            <th colspan="4">Sobreturnos </th>
                         </tr>
                     </thead>
                     <tbody>
@@ -145,8 +144,8 @@
                                 <span *ngIf="sobreturno && sobreturno.nota">
                                     <i title="{{sobreturno.nota}}" class="text-warning warning mdi mdi-message"></i>
                                 </span>
-                                <span [ngClass]="{'text-warning': true}" *ngIf="sobreturno?.asistencia === 'asistio' && sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria == null">| Asistencia Verificada</span>
-                                <span [ngClass]="{'text-success': true}" *ngIf="sobreturno?.paciente?.id && (sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria != null || (sobreturno?.asistencia && sobreturno?.asistencia !== 'asistio'))">| Auditado</span>
+                                <span [ngClass]="{'text-warning': true}" *ngIf="sobreturno?.asistencia && sobreturno?.asistencia == 'asistio' && !sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo">| Asistencia Verificada</span>
+                                <span [ngClass]="{'text-success': true}" *ngIf="sobreturno?.paciente?.id && (sobreturno?.diagnostico?.codificaciones[0]?.codificacionAuditoria?.codigo || (sobreturno?.asistencia && sobreturno.asistencia =='noAsistio'|| sobreturno.asistencia=='sinDatos'))">| Auditado</span>
 
                             </td>
                         </tr>

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/revision-agenda.html
@@ -243,6 +243,15 @@
                                 <div *ngIf="!showReparo">
                                     <h5>Codificación</h5>
                                     <hr>
+                                    <!-- Buscador de prestaciones cie10 -->
+                                    <div class="row">
+                                        <div class="col-10">
+                                            <Label>Agregar diagnóstico</Label>
+                                            <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
+                                        </div>
+
+                                    </div>
+                                    <hr>
                                     <!-- Listado de codificaciones seleccionadas -->
                                     <div class="row">
                                         <div class="col-12">
@@ -307,15 +316,7 @@
                                             </table>
                                         </div>
                                     </div>
-                                    <!-- Buscador de prestaciones cie10 -->
-                                    <div class="row">
-                                        <div class="col-10">
-                                            <Label>Seleccionar código reparo Cie10</Label>
-                                            <buscador-cie10 (seleccionEmit)="agregarDiagnostico($event)"></buscador-cie10>
-                                        </div>
 
-                                        <hr>
-                                    </div>
                                 </div>
 
                                 <!-- Reparo -->

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/sobreturno.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/sobreturno.component.ts
@@ -87,7 +87,7 @@ export class AgregarSobreturnoComponent implements OnInit {
         };
         this.showSobreturno = false;
         this.pacientesSearch = true;
-        if (this.agenda.tipoPrestaciones.length == 1) {
+        if (this.agenda.tipoPrestaciones.length === 1) {
             this.tipoPrestacion = this.agenda.tipoPrestaciones[0];
         }
     }

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/sobreturno.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/sobreturno.component.ts
@@ -87,6 +87,9 @@ export class AgregarSobreturnoComponent implements OnInit {
         };
         this.showSobreturno = false;
         this.pacientesSearch = true;
+        if (this.agenda.tipoPrestaciones.length == 1) {
+            this.tipoPrestacion = this.agenda.tipoPrestaciones[0];
+        }
     }
 
     afterCreateUpdate(paciente) {

--- a/src/app/modules/rup/components/ejecucion/internacion/iniciarInternacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/internacion/iniciarInternacion.component.ts
@@ -125,7 +125,7 @@ export class IniciarInternacionComponent implements OnInit {
     onPacienteSelected(paciente: IPaciente) {
         if (paciente.id) {
             this.servicioPrestacion.internacionesXPaciente(paciente, 'ejecucion').subscribe(resultado => {
-                // Si el paciente ya tiene una internacion en ejecucion          
+                // Si el paciente ya tiene una internacion en ejecucion
                 if (resultado) {
                     if (resultado.cama) {
                         this.plex.alert('El paciente registra una internación en ejecución y está ocupando una cama');

--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
@@ -375,7 +375,7 @@ export class PrestacionValidacionComponent implements OnInit {
     }
 
     primeraVez(elem) {
-        this.prestacion.ejecucion.registros.map(reg => reg.esPrimeraVez = false);
+        // this.prestacion.ejecucion.registros.map(reg => reg.esPrimeraVez = false);
         elem.esPrimeraVez = !elem.esPrimeraVez;
     }
 

--- a/src/app/services/obraSocial.service.ts
+++ b/src/app/services/obraSocial.service.ts
@@ -11,9 +11,9 @@ export class ObraSocialService {
     constructor(private server: Server) { }
     /**
      * Obtiene los datos de la obra social asociada a un paciente
-     * 
-     * @param {*} dni 
-     * @returns {Observable<any>} 
+     *
+     * @param {*} dni
+     * @returns {Observable<any>}
      * @memberof ObraSocialService
      */
     get(dni: any): Observable<any> {


### PR DESCRIPTION
**para probarlo son necesarias las modificaciones hechas en el PR 233 de la API**

**Cambios**
1. Se visualizan los conceptos de snomed para los turnos con diagnóstico/s de profesional
2. Se corrige el label del turno y sobreturno cuando la asistencia está marcada como no asistió o sin datos
3. Se corrige un bug al dar sobreturno para agendas de una sola prestación.
4. Se permite más de un diagnóstico "primera vez" para agendas codificadas por profesional