### PR TITLE
se arregla el sortCarpetas y select de profesional en el form

### DIFF
--- a/src/app/components/prestamosHC/solicitudes/listar-solicitudes.component.ts
+++ b/src/app/components/prestamosHC/solicitudes/listar-solicitudes.component.ts
@@ -170,6 +170,8 @@ export class ListarSolicitudesComponent implements OnInit {
                 listaProfesionales = resultado;
                 event.callback(listaProfesionales);
             });
+        } else {
+            event.callback(this.espacioFisico || []);
         }
     }
 
@@ -240,7 +242,7 @@ export class ListarSolicitudesComponent implements OnInit {
     sortCarpetas() {
         let val = this.sortDescending ? -1 : 1;
         // this.carpetas.sort((a, b) => { return (parseInt(a.numero) > parseInt(b.numero)) ? val : (parseInt(b.numero) > parseInt(a.numero)) ? -val : 0; } );
-        this.carpetas.sort((a, b) => { return (a.numero > b.numero) ? val : ((b.numero > a.numero) ? -val : 0); });
+        this.carpetas.sort((a, b) => { return (parseInt(a.numero) > parseInt(b.numero)) ? val : ((b.numero > a.numero) ? -val : 0); });
     }
 
     toogleSort() {

--- a/src/app/components/prestamosHC/solicitudes/listar-solicitudes.component.ts
+++ b/src/app/components/prestamosHC/solicitudes/listar-solicitudes.component.ts
@@ -242,7 +242,7 @@ export class ListarSolicitudesComponent implements OnInit {
     sortCarpetas() {
         let val = this.sortDescending ? -1 : 1;
         // this.carpetas.sort((a, b) => { return (parseInt(a.numero) > parseInt(b.numero)) ? val : (parseInt(b.numero) > parseInt(a.numero)) ? -val : 0; } );
-        this.carpetas.sort((a, b) => { return (parseInt(a.numero) > parseInt(b.numero)) ? val : ((b.numero > a.numero) ? -val : 0); });
+        this.carpetas.sort((a, b) => { return (parseInt(a.numero, 10) > parseInt(b.numero, 10)) ? val : ((b.numero > a.numero) ? -val : 0); });
     }
 
     toogleSort() {


### PR DESCRIPTION
* el metodo sortCarpetas de listar-solicitudes estaba comparando por string los valores del atributo "numeros", generando una mal ordenamiento.
* En el select de profesionales ya no se visualiza mas el icono de "actualizando"