### PR TITLE
Fix iniciar prestación futura

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -387,7 +387,9 @@ export class PuntoInicioComponent implements OnInit {
 
     // Detecta si una Agenda es futura
     esFutura(agenda: IAgenda = null) {
-        return moment(agenda.horaInicio).endOf('day').isAfter(moment(new Date()).startOf('day'));
+        let fechaAgenda = moment(agenda.horaInicio).startOf('day');
+        let fechaActual = moment(new Date()).endOf('day');
+        return fechaAgenda.isAfter(fechaActual);
     }
 
     // Detecta si "hoy" es el día de la Agenda


### PR DESCRIPTION
Corregimos el control para iniciar prestaciones futuras, que permita crear prestaciones del día aunque la hora no se haya cumplido.