### PR TITLE
Verificación de asistencia a través del concepto snomed

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
@@ -689,18 +689,23 @@ export class PrestacionEjecucionComponent implements OnInit {
                 localStorage.removeItem('idAgenda');
                 // Se hace un patch en el turno para indicar que el paciente no asistió (turno.asistencia = "noAsistio")
                 let cambios;
-                if (this.servicioPrestacion.prestacionPacienteAusente(this.prestacion)) {
-                    cambios = {
-                        op: 'noAsistio',
-                        turnos: [this.prestacion.solicitud.turno]
-                    };
-                } else {
-                    cambios = {
-                        op: 'darAsistencia',
-                        turnos: [this.prestacion.solicitud.turno]
-                    };
-                }
-                this.servicioAgenda.patch(this.idAgenda, cambios).subscribe();
+                this.servicioPrestacion.prestacionPacienteAusente().subscribe(
+                    result => {
+                        let filtroRegistros = this.prestacion.ejecucion.registros.filter(x => result.find(y => y.conceptId === x.concepto.conceptId));
+                        if (filtroRegistros && filtroRegistros.length > 0) {
+
+                            cambios = {
+                                op: 'noAsistio',
+                                turnos: [this.prestacion.solicitud.turno]
+                            };
+                        } else {
+                            cambios = {
+                                op: 'darAsistencia',
+                                turnos: [this.prestacion.solicitud.turno]
+                            };
+                        }
+                        this.servicioAgenda.patch(this.idAgenda, cambios).subscribe();
+                    });
             }
 
             // Actualizamos las prestaciones de la HUDS

--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
@@ -239,11 +239,13 @@ export class PrestacionValidacionComponent implements OnInit {
                     this.motivoReadOnly = true;
 
                     // Cargar el mapeo de snomed a cie10 para las prestaciones que vienen de agendas
-                    if (this.prestacion.solicitud.turno && !this.servicioPrestacion.prestacionPacienteAusente(this.prestacion)) {
-                        this.servicioAgenda.patchCodificarTurno({ 'op': 'codificarTurno', 'turnos': [this.prestacion.solicitud.turno] }).subscribe(salida => { });
-                    }
-
-
+                    this.servicioPrestacion.prestacionPacienteAusente().subscribe(
+                        result => {
+                            let filtroRegistros = this.prestacion.ejecucion.registros.filter(x => result.find(y => y.conceptId === x.concepto.conceptId));
+                            if (this.prestacion.solicitud.turno && !(filtroRegistros && filtroRegistros.length > 0)) {
+                                this.servicioAgenda.patchCodificarTurno({ 'op': 'codificarTurno', 'turnos': [this.prestacion.solicitud.turno] }).subscribe(salida => { });
+                            }
+                        });
                     this.plex.toast('success', 'La prestación se validó correctamente', 'Información', 300);
                 }, (err) => {
                     this.plex.toast('danger', 'ERROR: No es posible validar la prestación');

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Rx';
 import { Auth } from '@andes/auth';
 import { Server } from '@andes/shared';
 import { IPrestacion } from '../interfaces/prestacion.interface';
-
+import { SnomedService } from '../../../services/term/snomed.service';
 @Injectable()
 export class PrestacionesService {
 
@@ -26,16 +26,10 @@ export class PrestacionesService {
 
     // Ids de conceptos que refieren que un paciente no concurrió a la consulta
     // Se usan para hacer un PATCH en el turno, quedando turno.asistencia = 'noAsistio'
-    public conceptosNoConcurrio = [
-        '397710003',
-        '281399006',
-        '270426007',
-        '275694009'
-    ];
 
     public conceptosTurneables: any[];
 
-    constructor(private server: Server, public auth: Auth, private servicioTipoPrestacion: TipoPrestacionService) {
+    constructor(private server: Server, public auth: Auth, private servicioTipoPrestacion: TipoPrestacionService, public snomed: SnomedService) {
 
         this.servicioTipoPrestacion.get({}).subscribe(conceptosTurneables => {
             this.conceptosTurneables = conceptosTurneables;
@@ -589,10 +583,10 @@ export class PrestacionesService {
                 tipoPrestacion: snomedConcept,
                 // profesional logueado
                 profesional:
-                    {
-                        id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
-                        apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
-                    },
+                {
+                    id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
+                    apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
+                },
                 // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre },
                 registros: []
@@ -610,10 +604,10 @@ export class PrestacionesService {
                 tipoPrestacion: snomedConcept,
                 // profesional logueado
                 profesional:
-                    {
-                        id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
-                        apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
-                    },
+                {
+                    id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
+                    apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
+                },
                 // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre },
                 registros: []
@@ -637,10 +631,10 @@ export class PrestacionesService {
                 tipoPrestacion: snomedConcept,
                 // profesional logueado
                 profesional:
-                    {
-                        id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
-                        apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
-                    },
+                {
+                    id: this.auth.profesional.id, nombre: this.auth.usuario.nombre,
+                    apellido: this.auth.usuario.apellido, documento: this.auth.usuario.documento
+                },
                 // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre },
                 registros: []
@@ -782,14 +776,8 @@ export class PrestacionesService {
      * @returns  {boolean}
      * @memberof BuscadorComponent
      */
-    public prestacionPacienteAusente(prestacion) {
-        let filtroRegistros = null;
-        filtroRegistros = prestacion.ejecucion.registros.filter(x => this.conceptosNoConcurrio.find(y => y === x.concepto.conceptId));
-        if (filtroRegistros && filtroRegistros.length > 0) {
-            return true;
-        } else {
-            return false;
-        }
+    public prestacionPacienteAusente(): Observable<any[]> {
+        return this.snomed.getQuery({ expression: '<<281399006' });
 
     }
 


### PR DESCRIPTION
* Quitamos array hardcodeado de conceptos snomed correspondientes a una "no asistencia" y lo reemplazamos por una query que devuelve todos los hijos del concepto "NO ASISTIÓ"

* Actualizamos el chequeo de asistencia que se realiza al guardar y validar prestación. 