### PR TITLE
RUP - Relaciones con niveles anidados

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
@@ -387,8 +387,18 @@ export class PrestacionValidacionComponent implements OnInit {
         this.showDatosSolicitud = bool;
     }
 
-    relacionadoConPadre(id) {
-        return this.prestacion.ejecucion.registros.filter(rel => rel.relacionadoCon[0] === id);
+    relacionadoConPadreDeep(registros: any[], conceptId) {
+        if (registros) {
+            for (let i = 0; i < registros.length; i++) {
+                if (registros[i].relacionadoCon.length && registros[i].relacionadoCon[0].concepto && registros[i].relacionadoCon[0].concepto.conceptId === conceptId) {
+                    return i;
+                } else {
+                    this.relacionadoConPadreDeep(registros[i].registros, conceptId);
+                }
+            }
+            return false;
+        }
+
     }
 
     armarRelaciones(registros) {
@@ -419,6 +429,8 @@ export class PrestacionValidacionComponent implements OnInit {
 
         this.registrosOrdenados = relacionesOrdenadas;
     }
+
+
 
     reordenarRelaciones() {
         let rel: any;

--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.html
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.html
@@ -241,15 +241,14 @@
                             </div>
                         </div>
                     </header>
+
                     <ng-container *ngFor="let rama of registrosOrdenados; let iRama = index">
                         <ul class="list-group">
                             <li [ngClass]="{
-                                'ml-0': !rama.esDiagnosticoPrincipal,
-                                'ml-2': rama.relacionadoCon[0] && relacionadoConPadre(rama.relacionadoCon[0].id)
-                            }" class="list-group-item pl-0 pt-0 pb-0 mb-0">
+                                'ml-0': !rama.esDiagnosticoPrincipal
+                            }" class="list-group-item pl-0 pt-0 pb-0 mb-0 ml-{{relacionadoConPadreDeep(this.prestacion.ejecucion.registros, rama.relacionadoCon[0]?.concepto.conceptId)}}">
                                 <div>
                                     <span class="type {{ rama.esSolicitud ? 'plan' : rama.concepto.semanticTag }} pr-2 mr-1"></span>
-                                    <!-- [ngClass]="{'font-weight-bold': rama.esDiagnosticoPrincipal}" -->
                                     <small>{{ rama.nombre }}
                                         <small class="badge badge-info" *ngIf="rama.esDiagnosticoPrincipal">
                                             Motivo de consulta principal


### PR DESCRIPTION
### Requerimiento
Se requiere visualizar relaciones anidadas en las pantallas de Validación y Resumen de RUP. Actualmente se muestra sólo 1 o más niveles padre sin hijos de nivel 2, así:

1. **(P)** padre 
===>1.1 **(H1)** hijo de **(P)** :trollface: 
===>1.1.1 (H2) hijo de hijo **(H1)**


### Funcionalidad desarrollada 
La mejora realizada se muestra así:
1. **(P)** padre 
===>1.1 **(H1)** hijo de **(P)** :trollface: 
=======>1.1.1 (H2) hijo de hijo **(H1)**


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde (no planificado)

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Autor
@andrrrl 