### PR TITLE
RUP - Sacar filtro en autocitación cuando la agenda es por segmentos

### DIFF
--- a/src/app/components/turnos/autocitar/autocitar.html
+++ b/src/app/components/turnos/autocitar/autocitar.html
@@ -60,7 +60,7 @@
                                                                 <span>{{bloque.descripcion}}</span>
                                                             </div>
                                                             <ng-container *ngIf="turno.horaInicio && (getFecha(hoy) === getFecha(agenda.horaInicio) && getHora(turno.horaInicio) > getHora(hoy)) || (getFecha(hoy) !== getFecha(agenda.horaInicio))">
-                                                                <div class="m-0 p-0" *ngIf="!bloque.pacienteSimultaneos && !bloque.citarPorBloque">
+                                                                <div class="m-0 p-0" *ngIf="!bloque.pacienteSimultaneos">
                                                                     <div *ngIf="turno.estado === 'disponible'" class="text-center p-0 mb-1 hover outline-dashed-default" [appHover]="'text-info outline-info'"
                                                                         (click)="seleccionarCandidata(indiceTurno, indiceBloque, indiceAgenda)">
                                                                         {{turno.horaInicio | date: 'HH:mm'}}
@@ -77,13 +77,13 @@
                                                                             [appHover]="'text-info outline-info'" (click)="seleccionarCandidata(indiceTurno, indiceBloque, indiceAgenda)">
                                                                             {{turno.horaInicio | date: 'HH:mm'}}
                                                                         </div>
-                                                                    </div>
-                                                                    <div *ngIf="bloque.citarPorBloque  && !esTurnoDoble(prestacionAutocitar)">
-                                                                        <div *ngIf="turno.estado == 'disponible' && primerSimultaneoDisponible(bloque, turno, indiceTurno)" class="text-center p-2 mb-1 hover outline-dashed-default"
-                                                                            [appHover]="'text-info outline-info'" (click)="seleccionarCandidata(indiceTurno, indiceBloque, indiceAgenda)">
-                                                                            {{turno.horaInicio | date: 'HH:mm'}}
-                                                                        </div>
                                                                     </div> -->
+                                                                <!-- <div *ngIf="bloque.citarPorBloque  && !esTurnoDoble(prestacionAutocitar)">
+                                                                    <div *ngIf="turno.estado == 'disponible' && primerSimultaneoDisponible(bloque, turno, indiceTurno)" class="text-center p-2 mb-1 hover outline-dashed-default"
+                                                                        [appHover]="'text-info outline-info'" (click)="seleccionarCandidata(indiceTurno, indiceBloque, indiceAgenda)">
+                                                                        {{turno.horaInicio | date: 'HH:mm'}}
+                                                                    </div>
+                                                                </div> -->
                                                             </ng-container>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
<!-- El titulo del pull request debe respetar lo siguiente:
- Mencionar el modulo
- Si la funcionalidad a mergear corresponde a una user storie debe ser el mismo titulo
- En caso contrario poner una frase que describa la funcionalidad desarrollada
- PROHIBIDO USAR LA PALABRA FIX!!!
EJ: 'CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes'
 -->

<!--Asignar Revisor/es: Miembro del equipo responsable de revisar el pull request. -->

### Requerimiento
Un profesional debe poder autocitar en una agenda que tiene bloques configurados por segmentos

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Sacamos el filtro en la autocitación que estaba ocultando los turnos de los bloques por segmento



### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->

<!-- Código relevante 


  ```
  // TODO: Código que considere importante incorporar.  
  ``` -->
