### PR TITLE
Fecha de nacimiento para consultas desde Renaper

### DIFF
--- a/src/app/components/paciente/paciente-detalle.ts
+++ b/src/app/components/paciente/paciente-detalle.ts
@@ -81,7 +81,7 @@ export class PacienteDetalleComponent implements OnInit {
                 if (patient.estado === 'temporal') {
                     patient.nombre = datos.nombres;
                     patient.apellido = datos.apellido;
-                    patient.fechaNacimiento = datos.fechaNacimiento;
+                    patient.fechaNacimiento = moment(datos.fechaNacimiento, 'YYYY-MM-DD');
                     patient.estado = 'validado';
                     this.paciente.direccion[0].valor = datos.calle + ' ' + datos.numero;
                     this.paciente.direccion[0].codigoPostal = datos.cpostal;


### PR DESCRIPTION
### Requerimiento
* Al realizar la consulta de Renaper en algunos navegadores la fecha de nacimiento queda incorrecta.

### Funcionalidad desarrollada
1. Se aplica moment para estandarizar el formato de la fecha independientemente del navegador.

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No
 