### PR TITLE
CITAS - Se agrega nota previa del turno

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -563,6 +563,7 @@ export class DarTurnosComponent implements OnInit {
                 this.turnoTipoPrestacion = this.opciones.tipoPrestacion;
             }
             this.habilitarTurnoDoble();
+            this.nota = this.turno.nota;
             this.estadoT = 'confirmacion';
         } else {
             this.plex.info('warning', 'Debe seleccionar un paciente');
@@ -740,9 +741,6 @@ export class DarTurnosComponent implements OnInit {
         this.turno = {};
         if (this.paciente) {
             this.bloque = this.agenda.bloques[0];
-            // this.indiceBloque = this.agenda.bloques.indexOf(this.bloque);
-            // this.indiceTurno = indice;
-            // this.turno = bloque.turnos[indice];
             if (this.bloque.tipoPrestaciones.length === 1) {
                 this.turnoTipoPrestacion = this.bloque.tipoPrestaciones[0];
                 this.turno.tipoPrestacion = this.bloque.tipoPrestaciones[0];


### PR DESCRIPTION
### Requerimiento
* Resuelve Issue: fix #722

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Al momento de dar el turno no se recuperaba la nota del mismo (si es que hubiera)
2. Se agregó este control y la nota se carga en la confirmación del turno permitiendo editarla.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
