### PR TITLE
CITAS - corrección en dar turnos con llave

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -414,7 +414,6 @@ export class DarTurnosComponent implements OnInit {
 
                 // Tipo de Prestación, para poder filtrar las agendas
                 let tipoPrestacion: String = this.opciones.tipoPrestacion ? this.opciones.tipoPrestacion.id : '';
-
                 // Se filtran los bloques segun el filtro tipoPrestacion
                 this.bloques = this.agenda.bloques.filter(
                     function (value) {
@@ -435,7 +434,7 @@ export class DarTurnosComponent implements OnInit {
                         if (agendaDeHoy) {
                             return (value.restantesDelDia) + (value.restantesProgramados) > 0;
                         } else {
-                            return ((value.restantesProgramados) + (value.reservadoGestion) + (value.restantesProfesional) > 0);
+                            return ((value.restantesProgramados) + (value.restantesGestion) + (value.restantesProfesional) > 0);
                         }
                     }
                 );


### PR DESCRIPTION
### Requerimiento
* Resuelve parte del issue #736 

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se corrigió un control que verificaba la cantidad de turnos de gestión configurados en lugar de restantes. 

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
