### PR TITLE
HUDS - Screening de otoemisión acústica neonatal: antecedentes

### DIFF
--- a/src/app/modules/rup/components/elementos/SelectPorRefset.component.ts
+++ b/src/app/modules/rup/components/elementos/SelectPorRefset.component.ts
@@ -1,3 +1,4 @@
+import { IPrestacionGetParams } from './../../services/prestacionGetParams.interface';
 import { Component, OnInit, Output, Input, EventEmitter, AfterViewInit } from '@angular/core';
 import { RUPComponent } from './../core/rup.component';
 
@@ -13,13 +14,41 @@ export class SelectPorRefsetComponent extends RUPComponent implements OnInit {
     public unique: number = new Date().getTime();
 
     ngOnInit() {
+
         if (!this.registro.valor) {
             this.registro.valor = [];
         }
+
         if (this.params) {
+
+            // Conceptos de Refset
             this.snomedService.getQuery({ expression: '^' + this.params.refsetId }).subscribe(resultado => {
                 this.conceptos = resultado;
             });
+
+            // Si params.ultimoValor es true, se traen los últimos datos validados de la HUDS
+            // Sirve por ejemplo para pre-setear antecedentes y trastornos crónicos
+            if (this.params.ultimoValor) {
+                let params: IPrestacionGetParams = {
+                    idPaciente: this.paciente.id,
+                    conceptId: this.prestacion.solicitud.tipoPrestacion.conceptId,
+                    estado: 'validada'
+                };
+
+                this.prestacionesService.get(params).subscribe(ultimaPrestacionPaciente => {
+
+                    let registroValor = null;
+                    if (ultimaPrestacionPaciente && ultimaPrestacionPaciente.length > 0) {
+                        registroValor = ultimaPrestacionPaciente[ultimaPrestacionPaciente.length - 1].ejecucion.registros
+                            .find(y => y.concepto.conceptId === this.registro.concepto.conceptId);
+
+                        if (registroValor.valor && registroValor.valor.length) {
+                            this.registro.valor = registroValor.valor;
+                        }
+                    }
+
+                });
+            }
         }
     }
 

--- a/src/app/modules/rup/components/elementos/SelectPorRefset.html
+++ b/src/app/modules/rup/components/elementos/SelectPorRefset.html
@@ -12,12 +12,12 @@
 
             <label class="custom-control custom-radio">
                 <ng-container *ngIf="registro.valor && registro.valor.concepto.conceptId === concepto.conceptId">
-                    <input class="custom-control-input" name="radioConceptos-{{unique}}" (change)="selectRadio(concepto)" value="{{concepto.conceptId}}"
-                        type="radio" checked>
+                    <input class="custom-control-input" name="radioConceptos-{{unique}}" (change)="selectRadio(concepto)"
+                        value="{{concepto.conceptId}}" type="radio" checked>
                 </ng-container>
                 <ng-container *ngIf="registro.valor?.concepto.conceptId !== concepto.conceptId">
-                    <input class="custom-control-input" name="radioConceptos-{{unique}}" (change)="selectRadio(concepto)" value="{{concepto.conceptId}}"
-                        type="radio">
+                    <input class="custom-control-input" name="radioConceptos-{{unique}}" (change)="selectRadio(concepto)"
+                        value="{{concepto.conceptId}}" type="radio">
                 </ng-container>
                 <span class="custom-control-indicator"></span>
                 <span class="custom-control-description"> {{concepto.term}}</span>
@@ -26,19 +26,17 @@
     </ng-container>
 
     <p *ngIf="soloValores" class="readonly">
-        <ng-container *ngIf="registro.valor && registro.valor.length > 0 && registro.valor.length > 1">
+        <ng-container *ngIf="registro?.valor?.concepto || registro.valor.length === 1">
+            <p class="list-item-group text-capitalize">{{ registro.valor?.concepto ? registro.valor.concepto.term :
+                registro.valor[0].concepto.term }}</p>
+        </ng-container>
+        <ng-container *ngIf="registro.valor && registro.valor.length && registro.valor.length > 1">
             <ul class="list-item-group" *ngFor="let valor of registro.valor let i = index">
-                <li class="list-item">{{valor.concepto.term}}</li>
+                <li class="list-item text-capitalize">{{ valor.concepto.term }}</li>
             </ul>
         </ng-container>
-        <ng-container *ngIf="registro.valor && registro.valor.length > 0 && registro.valor.length === 1">
-            <p class="list-item-group" *ngFor="let valor of registro.valor let i = index">{{valor.concepto.term}}</p>
+        <ng-container *ngIf="!registro.valor.concepto && !registro.valor.length">
+            Sin datos
         </ng-container>
-        <ng-container *ngIf="registro.valor && registro.valor.concepto; else sinDatos">
-            {{registro.valor?.concepto?.term}}
-        </ng-container>
-        <ng-template #sinDatos>
-            SIN DATOS
-        </ng-template>
     </p>
 </form>

--- a/src/app/modules/rup/services/prestacionGetParams.interface.ts
+++ b/src/app/modules/rup/services/prestacionGetParams.interface.ts
@@ -1,0 +1,21 @@
+export class IPrestacionGetParams {
+    id?: string;
+    estado?: any;
+    sinEstado?: string;
+    fechaDesde?: Date;
+    fechaHasta?: Date;
+    idProfesional?: string;
+    idPaciente?: string;
+    idPrestacionOrigen?: string;
+    conceptId?: string;
+    turnos?: any[];
+    conceptsIdEjecucion?: any[];
+    solicitudDesde?: Date;
+    solicitudHasta?: Date;
+    tienePrestacionOrigen?: 'si' | 'no';
+    tieneTurno?: 'si' | 'no';
+    organizacion?: string;
+    ordenFecha?: boolean;
+    ordenFechaEjecucion?: boolean;
+    limit?: number;
+}


### PR DESCRIPTION
HUDS - Prestación Screening de otoemisión acústica neonatal

### Requerimiento
* Este PR implementa la mejora descripta en el siguiente issue: https://github.com/andes/app/issues/617

### Funcionalidad desarrollada 
1. Si en una consulta de Screening de Otoemisión acústica se registran en antecedentes, estos se visualizan cuando se inicia una consulta nueva de Screening de Otoemisión del mismo paciente.

### UserStories llegó a completarse
- [X] Si
- [ ] No

### Requiere actualizaciones en la base de datos
- [X] Si
- [ ] No

- Al elementoRUP cuya key "componente" es "ScreeningDeOtoemisionAcusticaNeonatalComponent"
- Dentro de su array de "requeridos"
- En el concepto cuyo term es "evaluación de antecedentes"
- Se le debe configurar el siguiente param:
`"ultimoValor": true`

Quedando:
```
"params": {
         "titulo": "Seleccione algún antecedente",
         "refsetId": "2121000013101",
         "tipoSelect": "select",
         "multiple": true,
         "ultimoValor": true
}
```
