### PR TITLE
RUP - Control en los filtros del mapa de camas para cuando no hay camas cargadas

### DIFF
--- a/src/app/components/organizacion/organizacion-create-update.html
+++ b/src/app/components/organizacion/organizacion-create-update.html
@@ -45,8 +45,7 @@
                             <div>
                                 <div class="row">
                                     <div class="col-4">
-                                        <plex-select name="localidad" [data]="localidadesNeuquen" [(ngModel)]="organizacionModel.direccion.ubicacion.localidad.nombre"
-                                            label="Localidad:">
+                                        <plex-select name="localidad" [data]="localidadesNeuquen" [(ngModel)]="organizacionModel.direccion.ubicacion.localidad" label="Localidad:">
                                         </plex-select>
                                     </div>
                                     <div class="col-4">
@@ -164,11 +163,12 @@
                         </div>
                     </fieldset>
                     <fieldset>
-                        <legend>Servicios</legend>
+                        <legend>Unidades Organizativas</legend>
 
                         <div class="row">
                             <div class="col-6">
-                                <plex-select [multiple]="true" name="servicios" labelField="term" [data]='listadoUO' idField="conceptId" [(ngModel)]="organizacionModel.unidadesOrganizativas" label="Servicios:">
+                                <plex-select [multiple]="true" name="servicios" labelField="term" [data]='listadoUO' idField="conceptId" [(ngModel)]="organizacionModel.unidadesOrganizativas"
+                                    label="Unidades Organizativas:">
                                 </plex-select>
                             </div>
                         </div>
@@ -182,8 +182,6 @@
     <footer>
         <div class="row">
             <div class="col-6 text-left">
-                <plex-button type="primary" label="Ver listado de camas" (click)="routeCama()">
-                </plex-button>
             </div>
             <div class="col-6 text-right">
                 <plex-button label="Cancelar" icon="close-circle-outline" type="danger" (click)="onCancel()">

--- a/src/app/modules/rup/components/internacion/mapa-de-camas/mapa-de-camas/mapa-de-camas.component.ts
+++ b/src/app/modules/rup/components/internacion/mapa-de-camas/mapa-de-camas/mapa-de-camas.component.ts
@@ -320,15 +320,29 @@ export class MapaDeCamasComponent implements OnInit {
     }
 
     countFiltros() {
-        this.cantidadXEstado = {
-            ocupada: this.camas.filter(c => c.ultimoEstado.estado === 'ocupada'),
-            desocupada: this.camas.filter(c => c.ultimoEstado.estado === 'desocupada'),
-            reparacion: this.camas.filter(c => c.ultimoEstado.estado === 'reparacion'),
-            bloqueada: this.camas.filter(c => c.ultimoEstado.estado === 'bloqueada'),
-            oxigeno: this.camas.filter(c => c.equipamiento.find(e => e.conceptId === '261746005')),
-            disponible: this.camas.filter(c => c.ultimoEstado.estado === 'disponible')
-        };
+        if ((this.camas && this.camas.length > 0)) {
+            this.cantidadXEstado = {
+                ocupada: this.camas.filter(c => c.ultimoEstado.estado === 'ocupada'),
+                desocupada: this.camas.filter(c => c.ultimoEstado.estado === 'desocupada'),
+                reparacion: this.camas.filter(c => c.ultimoEstado.estado === 'reparacion'),
+                bloqueada: this.camas.filter(c => c.ultimoEstado.estado === 'bloqueada'),
+                oxigeno: this.camas.filter(c => c.equipamiento.find(e => e.conceptId === '261746005')),
+                disponible: this.camas.filter(c => c.ultimoEstado.estado === 'disponible')
+            };
+        } else {
+            this.cantidadXEstado = {
+                ocupada: 0,
+                desocupada: 0,
+                reparacion: 0,
+                bloqueada: 0,
+                oxigeno: 0,
+                disponible: 0
+            };
+        }
         this.loadCountFiltros = true;
+
+
+
     }
 
     // selecionarCama(cama) {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
Ingresar al mapa de camas cuando aún no se han configurado camas para un efector.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Agregamos un control cuando se cargan los filtros del mapa de camas

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
