### PR TITLE
CITAS - Control de estado de agenda al verificar solapamiento de profesionales

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
@@ -228,7 +228,7 @@ export class PanelAgendaComponent implements OnInit {
                         desde: this.agenda.horaInicio,
                         hasta: this.agenda.horaFin,
                         estados: ['planificacion', 'disponible', 'publicada', 'pausada']
-                    }
+                    };
                     // this.serviceAgenda.get({ 'organizacion': this.auth.organizacion.id, 'idProfesional': profesional.id, 'rango': true, 'desde': this.agenda.horaInicio, 'hasta': this.agenda.horaFin }).subscribe(agendas => {
                     this.serviceAgenda.get(params).subscribe(agendas => {
                         // Hay problemas de solapamiento?

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
@@ -221,7 +221,16 @@ export class PanelAgendaComponent implements OnInit {
             // Loop profesionales
             if (this.agenda.profesionales) {
                 this.agenda.profesionales.forEach((profesional, index) => {
-                    this.serviceAgenda.get({ 'organizacion': this.auth.organizacion.id, 'idProfesional': profesional.id, 'rango': true, 'desde': this.agenda.horaInicio, 'hasta': this.agenda.horaFin }).subscribe(agendas => {
+                    let params = {
+                        organizacion: this.auth.organizacion.id,
+                        idProfesional: profesional.id,
+                        rango: true,
+                        desde: this.agenda.horaInicio,
+                        hasta: this.agenda.horaFin,
+                        estados: ['planificacion', 'disponible', 'publicada', 'pausada']
+                    }
+                    // this.serviceAgenda.get({ 'organizacion': this.auth.organizacion.id, 'idProfesional': profesional.id, 'rango': true, 'desde': this.agenda.horaInicio, 'hasta': this.agenda.horaFin }).subscribe(agendas => {
+                    this.serviceAgenda.get(params).subscribe(agendas => {
                         // Hay problemas de solapamiento?
                         let agendasConSolapamiento = agendas.filter(agenda => {
                             return agenda.id !== this.agenda.id || !this.agenda.id; // Ignorar agenda actual


### PR DESCRIPTION
### Requerimiento
* Resuelve Issue #705

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se agregó control de estado de agenda al verificar solapamiento cuando se edita agenda.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
