### PR TITLE
Publicar la ruta de padrones de obra social

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@andes/app",
-    "version": "3.9.2",
+    "version": "3.9.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@andes/app",
-    "version": "3.9.2",
+    "version": "3.9.3",
     "description": "Aplicación web Angular2 para ANDES",
     "angular-cli": {},
     "scripts": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -73,6 +73,7 @@ export class AppComponent {
             accessList.push({ label: 'Formulario Terapeutico', icon: 'mdi mdi-needle', route: '/formularioTerapeutico' });
         }
         this.menuList.push({ label: 'Página principal', icon: 'home', route: '/inicio' });
+        this.menuList.push({ label: 'Padrones', icon: 'magnify', route: '/puco' });
 
         accessList.forEach((permiso) => {
             this.menuList.push(permiso);

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -106,7 +106,7 @@ const appRoutes: Routes = [
   { path: 'mpi', component: PacienteSearchComponent, canActivate: [RoutingGuard] },
 
   // Obras sociales
-  { path: 'puco', component: PucoComponent, canActivate: [RoutingGuard] },
+  { path: 'puco', component: PucoComponent },
 
   // Turnos
   { path: 'citas', component: PuntoInicioTurnosComponent, canActivate: [RoutingGuard] },


### PR DESCRIPTION
### Requerimiento
* Publicar la ruta de padrones para que se pueda acceder desde diferentes efectores de la provincia

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se quita la autenticación a la ruta de puco. Se agrega opción "Padrones" en el menú hamburguesa.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
