### PR TITLE
PRESTAMOS HC - Nueva carpeta paciente

### DIFF
--- a/src/app/components/prestamosHC/solicitudes/listar-solicitudes.component.ts
+++ b/src/app/components/prestamosHC/solicitudes/listar-solicitudes.component.ts
@@ -63,7 +63,7 @@ export class ListarSolicitudesComponent implements OnInit {
     public _listarCarpetas;
 
     get cssLayout() {
-        return { 'col-9': this.verPrestar || this.verSolicitudManual, 'col': !this.verSolicitudManual && !this.verPrestar };
+        return { 'col-9': this.verPrestar || this.verSolicitudManual || this.verNuevaCarpeta, 'col': !this.verSolicitudManual && !this.verPrestar };
     }
 
     get listaCarpetasInput(): any {


### PR DESCRIPTION
### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. En prestamos de carpeta, cuando se realiza un pedido de préstamo manual, y el paciente buscado no tiene carpeta en la institución, se da la posibilidad de crear nuevo numero de carpeta

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
