### PR TITLE
RUP: Agrega filtro en PI para agendas con profesionales "null"

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -220,7 +220,7 @@ export class PuntoInicioComponent implements OnInit {
         // filtramos por agendas propias o todas menos las propias
         if (this.soloMisAgendas) {
             this.agendas = this.agendas.filter(agenda => {
-                return (agenda.profesionales.find(profesional => {
+                return (agenda.profesionales && agenda.profesionales.find(profesional => {
                     return (profesional.id === this.auth.profesional.id);
                 }));
             });


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
* Corregir bug en el puntto de inicio de RUP cuando una agenda tiene el listado de profesionales en null

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Agrega filtro en el punto de inicio para controlar agendas con el listado de profesionales en null
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
