### PR TITLE
rup: fecha de solicitud y ejecución.

### DIFF
--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.html
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.html
@@ -439,10 +439,12 @@
                                                     <div class="row p-0 m-0">
                                                         <div class="col-10 p-0 m-0">
                                                             <div class="sugerido">
-                                                                <small>Fecha: {{ prestacion.fecha | fecha }}</small>
+                                                                <small>Fecha: {{ prestacion.fecha | fecha : 'utc' }}</small>
                                                                 <br>
-                                                                <small>Profesional: {{ prestacion.profesional |
-                                                                    profesional}}</small>
+                                                                <small>
+                                                                    Profesional: 
+                                                                    {{ prestacion.profesional | profesional }}
+                                                                </small>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.html
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.html
@@ -274,14 +274,20 @@
                                     <h4 class="text-capitalize">{{ registro.data.solicitud.tipoPrestacion.term }}</h4>
                                     <div class="row">
                                         <div class="col-12">
-                                            <b>Fecha: </b> {{registro.data.solicitud.fecha | date: 'EEE dd/MM/yyyy HH:MM'}}
+                                            <b> Fecha: </b> 
+                                            {{registro.data.ejecucion.fecha | date: 'EEE dd/MM/yyyy HH:MM'}}
+                                        </div>
+                                        <div class="col-6" *ngIf="(registro.data.ejecucion.fecha - registro.data.solicitud.fecha) > 1000 ">
+                                            <b> Solicitada el: </b> 
+                                            {{ registro.data.solicitud.fecha | date: 'EEE dd/MM/yyyy HH:MM' }}
                                         </div>
                                         <div class="col-12">
-                                            <b>Solicitada por el profesional: </b>{{ registro.data.solicitud.profesional | profesional
-                                            }}
+                                            <b> Solicitada por el profesional: </b>
+                                            {{ registro.data.solicitud.profesional | profesional }}
                                         </div>
                                         <div class="col-12">
-                                            <b>Desde la Organización: </b> {{ registro.data.solicitud.organizacion.nombre }}
+                                            <b> Desde la Organización: </b> 
+                                            {{ registro.data.solicitud.organizacion.nombre }}
                                         </div>
                                     </div>
                                     <div class="row">

--- a/src/app/modules/rup/components/ejecucion/resumen.html
+++ b/src/app/modules/rup/components/ejecucion/resumen.html
@@ -17,7 +17,7 @@
                         <span class="badge badge-info  mdi mdi-link pull-right"></span>
                     </div>
                     <small> Solicitado el
-                        <strong>{{ prestacion.solicitud.fecha | fecha }}</strong>
+                        <strong>{{ prestacion.solicitud.fecha | fecha : 'utc' }}</strong>
                         <span> por {{ prestacion.solicitud.profesional | profesional }}</span>
                         <!--<span *ngIf="!prestacion.ejecucion?.profesionales[0]?.nombreCompleto">(sin profesionales asignados)</span>-->
                     </small>

--- a/src/app/modules/rup/components/ejecucion/vistaCDA.html
+++ b/src/app/modules/rup/components/ejecucion/vistaCDA.html
@@ -23,7 +23,7 @@
 
     <div class="row">
         <div class="col">
-            <strong>Fecha:</strong> {{ registro.data.fecha | fecha }}
+            <strong>Fecha:</strong> {{ registro.data.fecha | fecha : 'utc' }}
         </div>
     </div>
 

--- a/src/app/modules/rup/components/ejecucion/vistaHuds.html
+++ b/src/app/modules/rup/components/ejecucion/vistaHuds.html
@@ -45,18 +45,21 @@
                                     [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'prestacion'">
                                     <h4 class="text-capitalize">{{ registro.data.solicitud.tipoPrestacion.term }}</h4>
                                     <div class="row">
-                                        <div class="col-12">
-                                            <b>Fecha: </b> {{ registro.data.solicitud.fecha | date: 'EEE
-                                            dd/MM/yyyyHH:MM' }}
+                                        <div class="col-6">
+                                            <b> Fecha: </b> 
+                                            {{ registro.data.ejecucion.fecha | date: 'EEE dd/MM/yyyy HH:MM' }}
+                                        </div>
+                                        <div class="col-6" *ngIf="(registro.data.ejecucion.fecha - registro.data.solicitud.fecha) > 1000 ">
+                                            <b> Solicitada el: </b> 
+                                            {{ registro.data.solicitud.fecha | date: 'EEE dd/MM/yyyy HH:MM' }}
                                         </div>
                                         <div class="col-12">
-                                            <b>Solicitada por el profesional: </b>{{
-                                            registro.data.solicitud.profesional | profesional
-                                            }}
+                                            <b> Solicitada por el profesional: </b>
+                                            {{ registro.data.solicitud.profesional | profesional }}
                                         </div>
                                         <div class="col-12">
-                                            <b>Desde la Organización: </b> {{
-                                            registro.data.solicitud.organizacion.nombre }}
+                                            <b> Desde la Organización: </b>
+                                            {{ registro.data.solicitud.organizacion.nombre }}
                                         </div>
                                     </div>
                                     <div class="row">


### PR DESCRIPTION
### Requerimiento
* Diferenciar fecha de solicitud y fecha de ejecución. Se estaba mostrando la fecha de solictud y en algunos casos había más de un mes de diferencia.

### Funcionalidad desarrollada
1. Muestra la fecha de ejecución.
2. Si hay una solicitud, muestra la fecha de solicitud.
3. Resuelve #1044 


### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
