### PR TITLE
CITAS - Cambio control de profesionales en agenda

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
@@ -71,7 +71,7 @@ export class PanelAgendaComponent implements OnInit {
 
             // Quitar cuando esté solucionado inconveniente de plex-select
             let profesional = [];
-            if (this.agenda.profesionales && this.agenda.profesionales.length > 10) {
+            if (this.agenda.profesionales && this.agenda.profesionales.length > 40) {
                 this.plex.info('warning', 'Seleccione un profesional de la lista');
             } else {
                 if (this.agenda.profesionales) {


### PR DESCRIPTION
### Requerimiento
* Se modifica restricción en  la cantidad de profesionales que se puede asignar por agenda

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Cambia control en la edición de profesionales de una agenda

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

