### PR TITLE
CITAS - Corrige condición al verificar conflictos en la clonación

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/clonar-agenda.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/clonar-agenda.ts
@@ -161,7 +161,7 @@ export class ClonarAgendaComponent implements OnInit {
                     let actualFin = moment(actual.horaFin).format('HH:mm');
                     band = actual.estado !== 'suspendida';
                     band = band && moment(dia.fecha).isSame(moment(actual.horaInicio), 'day');
-                    band = band && ((originalIni < actualIni && actualIni < originalFin) || (originalIni < actualFin && actualFin < originalFin));
+                    band = band && ((originalIni <= actualIni && actualIni < originalFin) || (originalIni < actualFin && actualFin <= originalFin));
                     return band;
                 }
             );


### PR DESCRIPTION
### Requerimiento
* Verificar en la clonación de agendas los chequeos de conflictos. Había casos en los que permitía clonar una agenda en una fecha donde existía un conflicto (coincidencia en el horario y el profesional)

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se modifico el método que verifica los conflictos

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
