### PR TITLE
agrega horario en el caso de selección de agenda dinámica

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.html
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.html
@@ -88,11 +88,13 @@
                             <!-- Botones para ver más agendas -->
                             <plex-button *ngIf="agendas.length > 1" type="link" icon="chevron-left" class="text-lg"
                                 title="Agenda anterior" (click)="verAgenda('izq')"></plex-button>
-                            <!-- <span>{{agenda.horaInicio | date: 'EEE d/MMM' | uppercase}}</span> -->
                             <span>{{ agenda.horaInicio | date: 'EEE d MMM' }}
                                 <div class="badge badge-{{ estadosAgenda[agenda.estado].class }}">
                                     {{ estadosAgenda[agenda.estado].nombre }}</div>
                             </span>
+                            <div *ngIf="estadoT==='dinamica'">
+                                {{agenda.horaInicio | date: 'HH:mm'}}-{{agenda.horaFin | date: 'HH:mm'}}
+                            </div>
                             <plex-button *ngIf="agendas.length > 1" type="link" icon="chevron-right" class="text-lg"
                                 title="Agenda siguiente" (click)="verAgenda('der')"></plex-button>
                             <!-- /Botones para ver más agendas -->


### PR DESCRIPTION
### Requerimiento
* Se requiere al momento de dar el turno, si es una agenda dinámica que aparezca el horario de la agenda en sidebar.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
