### PR TITLE
Fix solapamiento

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -341,7 +341,7 @@ export class DarTurnosComponent implements OnInit {
             this.mostrarCalendario = true;
             // Agendas a partir de hoy aplicando filtros seleccionados y permisos
             params = {
-                rango: true, desde: new Date(), hasta: fechaHasta,
+                desde: new Date(), hasta: fechaHasta,
                 idTipoPrestacion: (this.opciones.tipoPrestacion ? this.opciones.tipoPrestacion.id : ''),
                 organizacion: this.auth.organizacion._id,
                 nominalizada: true

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
@@ -912,8 +912,8 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
         this.showBloque = true;
     }
     /**
-     * Verifica si es una agenda no nominalizada, en cuyo caso chequea
-     * que la agenda tenga una sola prestación
+     * Verifica si es una agenda no nominalizada, en cuyo caso chequea que la agenda
+     * tenga una sola prestación
      * @returns boolean TRUE/FALSE chequeos no nominalizada Ok
      * @memberof PlanificarAgendaComponent
      */


### PR DESCRIPTION
### Requerimiento
* Corrige Bug que ocurría al planificar o editar una agenda en planificación. Se mostraba conflicto de profesional o espacio físico cuando una agenda finalizaba exactamente al mismo horario que comenzaba otra.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se elimina parámetro extra en llamada al servicio de agendas.

### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
