### PR TITLE
CITAS: Se reemplaza la información estadística de agendas por información útil al usuario.

### DIFF
--- a/src/app/components/turnos/dashboard/estadisticas-agendas.component.ts
+++ b/src/app/components/turnos/dashboard/estadisticas-agendas.component.ts
@@ -1,9 +1,6 @@
 import { Component, Input, OnInit, EventEmitter, Output } from '@angular/core';
 import { Plex } from '@andes/plex';
 import { Auth } from '@andes/auth';
-import * as moment from 'moment';
-// Servicios
-import { TurnoService } from '../../../services/turnos/turno.service';
 
 @Component({
     selector: 'estadisticas-agendas',
@@ -12,72 +9,12 @@ import { TurnoService } from '../../../services/turnos/turno.service';
 
 export class EstadisticasAgendasComponent implements OnInit {
 
-    cantTurnosAsignados = 125;
-    turnosPacientesValidados = 0;
-    turnosPacientesTemporales = 0;
-    cantTurnosRestantes = 0;
-    cantTurnosSuspendidos = 0;
-    turnosVerificados = 0;
-    turnosCodificados = 0;
-    turnosAuditados = 0;
     // Inicialización
-    constructor(public serviceTurno: TurnoService, public plex: Plex, public auth: Auth) { }
+    constructor(public plex: Plex, public auth: Auth) { }
 
     ngOnInit() {
-        // Se cargan los datos calculados
-        let cantTurnosPorPacientes;
-        this.cantidadTurnosPorEstadoPaciente(this.auth.usuario);
-        this.cantidadTotalDeTurnosAsignados();
-        this.cantidadTurnosconAsistenciaVerificada(this.auth.usuario);
-        this.cantidadTurnosCodificados();
+
     }
 
-    cantidadTurnosPorEstadoPaciente(userLogged) {
-        let datosTurno = { estado: 'asignado', userName: userLogged.username, userDoc: userLogged.documento };
-        let countTemporal = 0;
-        let countValidado = 0;
-
-        this.serviceTurno.getTurnos(datosTurno).subscribe(turnos => {
-            turnos.forEach(turno => {
-                if (turno.paciente.estado === 'temporal') {
-                    countTemporal++;
-                } else {
-                    countValidado++;
-                }
-            });
-            this.turnosPacientesTemporales = countTemporal;
-            this.turnosPacientesValidados = countValidado;
-        });
-    }
-
-    cantidadTotalDeTurnosAsignados() {
-        let fecha = moment().format();
-        let today = moment(fecha).startOf('day');
-
-        let datosTurno = { estado: 'asignado' };
-        this.serviceTurno.getTurnos(datosTurno).subscribe(turnos => {
-            this.cantTurnosAsignados = turnos.length;
-        });
-    }
-
-    cantidadTurnosconAsistenciaVerificada(userLogged?) {
-        // TurnosChequeados por usuario o total depende si se envia el usuario
-        let datosTurno = { asistencia: true };
-        if (userLogged) {
-            datosTurno['usuario'] = userLogged;
-        }
-        this.serviceTurno.getTurnos(datosTurno).subscribe(turnos => {
-            this.turnosVerificados = turnos.length;
-        });
-    }
-
-    cantidadTurnosCodificados() {
-        let datosTurno = { codificado: true };
-        this.serviceTurno.getTurnos(datosTurno).subscribe(turnos => {
-            this.turnosAuditados = turnos.filter(item => item.asistencia &&
-                (item.asistencia === 'noAsistio' || item.asistencia === 'sinDatos' ||
-                    (item.diagnostico.codificaciones[0] && item.diagnostico.codificaciones[0].codificacionAuditoria && item.diagnostico.codificaciones[0].codificacionAuditoria.codigo))).length;
-        });
-    }
 
 }

--- a/src/app/components/turnos/dashboard/estadisticas-agendas.html
+++ b/src/app/components/turnos/dashboard/estadisticas-agendas.html
@@ -1,8 +1,8 @@
 <!--Header de estadisticas-->
 <fieldset>
-    <legend>Estadísticas | Ventanillas</legend>
+    <legend>INFORMACIÓN ÚTIL</legend>
 
-    <div class="row">
+    <!-- <div class="row">
         <div class="col-4">
             <i class="mdi mdi-calendar-clock mdi-36px"></i>
             <span class="h3">{{cantTurnosAsignados}}</span>
@@ -21,38 +21,22 @@
     </div>
     <br>
     <legend>Estadísticas | Valores Totales</legend>
-    <br>
+    <br> -->
     <div class="row">
-        <div class="col-2 vertical-center text-center">
+        <div class="col-3 vertical-center text-center">
             <h3 class="mdi mdi-account-check mdi-36px"></h3>
         </div>
-        <div class="col-7 vertical-center">
-            <h5>Turnos / Pacientes Validados</h5>
-        </div>
-        <div class="col-2 badge badge-success">
-            <span class="h3">{{turnosPacientesValidados}}</span>
+        <div class="col-8 vertical-center">
+            <h5>Ingrese el <b>scan del documento</b> para validar los datos del paciente</h5>
         </div>
     </div>
+    <hr>
     <div class="row">
-        <div class="col-2 vertical-center text-center">
+        <div class="col-3 vertical-center text-center">
             <h3 class="mdi mdi-account-outline mdi-36px"></h3>
         </div>
-        <div class="col-7 vertical-center">
-            <h5>Turnos /Pacientes Temporales</h5>
-        </div>
-        <div class="col-2 badge badge-warning">
-            <span class="h3">{{turnosPacientesTemporales}}</span>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-2 vertical-center text-center">
-            <h3 class="mdi mdi-calendar-multiple-check mdi-36px"></h3>
-        </div>
-        <div class="col-7 vertical-center">
-            <h5>Turnos auditados</h5>
-        </div>
-        <div class="col-2 badge badge-success">
-            <span class="h3">{{turnosAuditados}}</span>
+        <div class="col-8 vertical-center">
+            <h5>En caso, que el paciente no posea documento se puede ingresar como temporal</h5>
         </div>
     </div>
 </fieldset>

--- a/src/app/components/turnos/dashboard/estadisticas-agendas.html
+++ b/src/app/components/turnos/dashboard/estadisticas-agendas.html
@@ -27,7 +27,7 @@
             <h3 class="mdi mdi-account-check mdi-36px"></h3>
         </div>
         <div class="col-8 vertical-center">
-            <h5>Ingrese el <b>scan del documento</b> para validar los datos del paciente</h5>
+            <h5><b>Paciente con dni</b> scanee el documento para validar sus datos </h5>
         </div>
     </div>
     <hr>
@@ -36,7 +36,7 @@
             <h3 class="mdi mdi-account-outline mdi-36px"></h3>
         </div>
         <div class="col-8 vertical-center">
-            <h5>En caso, que el paciente no posea documento se puede ingresar como temporal</h5>
+            <h5><b>Paciente sin dni</b> Puede ingresar sus datos a través del botón "Nuevo Paciente Temporal"</h5>
         </div>
     </div>
 </fieldset>

--- a/src/app/components/turnos/dashboard/estadisticas-pacientes.component.ts
+++ b/src/app/components/turnos/dashboard/estadisticas-pacientes.component.ts
@@ -62,13 +62,6 @@ export class EstadisticasPacientesComponent implements OnInit {
         private obraSocialService: ObraSocialService) { }
 
     ngOnInit() {
-        // Se cargan los datos calculados
-        let hoy = {
-            fechaDesde: moment().startOf('month').toDate(),
-            fechaHasta: moment().endOf('day').toDate()
-        };
-        this.fechaDesde = moment().startOf('month').toDate();
-        this.fechaHasta = moment().endOf('day').toDate();
         this.carpetaEfector = {
             organizacion: {
                 id: this.auth.organizacion.id,

--- a/src/app/components/turnos/dashboard/estadisticas-pacientes.component.ts
+++ b/src/app/components/turnos/dashboard/estadisticas-pacientes.component.ts
@@ -27,9 +27,6 @@ export class EstadisticasPacientesComponent implements OnInit {
     @Input() showTab: Number = 0;
     @Input('paciente')
     set paciente(value: any) {
-        this.turnosOtorgados = 0;
-        this.inasistencias = 0;
-        this.anulaciones = 0;
         this.pacienteSeleccionado = value;
         this._paciente = value;
 
@@ -100,7 +97,9 @@ export class EstadisticasPacientesComponent implements OnInit {
                             if (turno.asistencia && turno.asistencia === 'noAsistio') {
                                 cantInasistencias++;
                             }
+
                         });
+
                         this.turnosOtorgados = turnos.length;
                         this.inasistencias = cantInasistencias;
                         this.sortTurnos(turnos);

--- a/src/app/components/turnos/dashboard/estadisticas-pacientes.html
+++ b/src/app/components/turnos/dashboard/estadisticas-pacientes.html
@@ -102,7 +102,7 @@
                 </div>
             </div>
             <hr>
-            <div class="row">
+            <!-- <div class="row">
                 <div class="col">
                     <span>Filtrar por Fechas</span>
                 </div>
@@ -119,7 +119,7 @@
                     </plex-datetime>
                 </div>
             </div>
-            <br>
+            <br> -->
             <div class="row">
                 <div class="col-2 vertical-center text-center">
                     <i class="mdi mdi-account-check mdi-36px"></i>


### PR DESCRIPTION
Se quita la sección de cálculos estadísticos totales de turnos asignados (entre otras queries) y se reemplaza por información útil al usuario. Evitando la ejecución del cálculo estadístico de agendas por cada dación de turno.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

