### PR TITLE
RUP: Se resuelve problema de actividades comunidad al subir archivo.

### DIFF
--- a/src/app/modules/rup/components/elementos/adjuntarDocumento.component.ts
+++ b/src/app/modules/rup/components/elementos/adjuntarDocumento.component.ts
@@ -140,7 +140,7 @@ export class AdjuntarDocumentoComponent extends RUPComponent implements OnInit {
     }
 
     fromMobile() {
-        let paciente = this.paciente.id;
+        let paciente = this.paciente ? this.paciente.id : null;
         let prestacion = this.prestacion.id;
         let registro = this.registro.id;
         this.loading = true;


### PR DESCRIPTION
Al momento de querer adjuntar un archivo con la app mobile para la prestación "actividades con la comunidad" daba un error ya que no se estaba controlando que venga el paciente. Estas prestaciones no tienen un paciente.
