### PR TITLE
HUDS: visualizar registros de epicrisis y colonoscopia

### DIFF
--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -224,6 +224,23 @@ export class PrestacionesService {
                     prestaciones = prestaciones.filter(p => p.estados[p.estados.length - 1].tipo === 'validada');
                 }
                 prestaciones.forEach((prestacion: any) => {
+                    // Fix momentaneo hasta reestructurar las busquedas en las HUDS.
+                    // Epicrisis y Colonoscopia tienen secciones.
+                    if (['73761001', '2341000013106'].indexOf(prestacion.solicitud.tipoPrestacion.conceptId) >= 0) {
+                        let regs = [];
+                        prestacion.ejecucion.registros[0].registros.forEach(r => {
+                            // Excluimos Pautas de Alarmas. Porque son hallazgos de alarmas y no presentes.
+                            if (r.concepto.conceptId !== '900000000000003001') {
+                                regs = [...regs, ...r.registros];
+                            }
+                        });
+                        regs.forEach(r => {
+                            r.createdAt = prestacion.ejecucion.registros[0].createdAt;
+                            r.createdBy = prestacion.ejecucion.registros[0].createdBy;
+                        });
+                        prestacion.ejecucion.registros = regs;
+                    }
+
                     if (prestacion.ejecucion) {
                         const conceptos = prestacion.ejecucion.registros
                             // .filter(registro => semanticTags.includes(registro.concepto.semanticTag))


### PR DESCRIPTION
 ### Requerimiento
* Epicrisis y colonoscopía al tener seccionados, quedaron afuera los hallazgos y trastornos registrados. Se requiere poder visualizarlos en el listado de la HUDS.

### Funcionalidad realizada
1. Se realizo un patch momentaneo, especifico para esta dos prestaciones. 

Queda pendiente detectar automáticamente las secciones para cualquier prestaciones. 

### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
