### PR TITLE
Permiso - MPI y visualización de huds

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,7 +46,7 @@ export class AppComponent {
         if (this.auth.getPermissions('turnos:planificarAgenda:?').length > 0) {
             accessList.push({ label: 'CITAS: Gestor de Agendas y Turnos', icon: 'calendar', route: '/citas/gestor_agendas' });
         }
-        if (this.auth.getPermissions('turnos:puntoInicio:?').length > 0) {
+        if (this.auth.getPermissions('turnos:puntoInicio:?').length && this.auth.getPermissions('mpi:?').length) {
             accessList.push({ label: 'CITAS: Punto de Inicio', icon: 'calendar', route: '/citas/puntoInicio' });
         }
 

--- a/src/app/components/paciente/paciente-search.component.ts
+++ b/src/app/components/paciente/paciente-search.component.ts
@@ -64,7 +64,7 @@ export class PacienteSearchComponent implements OnInit, OnDestroy {
     }
 
     public ngOnInit() {
-        if (!this.auth.check('huds:visualizacionHuds')) {
+        if (!this.auth.getPermissions('mpi:?').length) {
             this.router.navigate(['./inicio']);
         }
 

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -67,7 +67,7 @@ export class PuntoInicioComponent implements OnInit {
 
     ngOnInit() {
         // Verificamos permisos globales para rup, si no posee realiza redirect al home
-        if (!this.auth.check('rup')) {
+        if (!this.auth.getPermissions('rup:?').length) {
             this.redirect('inicio');
         }
         this.puedeVerHudsPaciente = this.auth.check('huds:visualizacionHuds');


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
En un PR se modificó mal el permiso para ingresar al componente `paciente-search`. Entonces cada vez que se trataba de entrar a un lugar donde se utiliza este componente sin permiso de visualización de huds, rebotaba.
Descubrí también que podía ver en el menú hamburguesa CITAS: Punto de Inicio y no poder ingresar por no poseer MPI. Le agregué este permiso, además de citas, para mostrar el acceso solamente cuando pueda entrar realmente (ahorro el rebote a inicio).
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
