### PR TITLE
AGENDAS: Refresca botonera de agenda al dar asistencia a un turno

### DIFF
--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -31,8 +31,6 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
         this.guardarAgendaPanel = theElementRef;
     }
 
-    @ViewChild('botonesAgenda') botonesAgendaComponent: BotonesAgendaComponent;
-
     agendasSeleccionadas: IAgenda[] = [];
     turnosSeleccionados: ITurno[] = [];
 

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -1,3 +1,4 @@
+import { BotonesAgendaComponent } from './operaciones-agenda/botones-agenda.component';
 import { Component, OnInit, OnDestroy, HostBinding, ViewContainerRef, ViewChild } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -29,6 +30,8 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
     @ViewChild('guardarAgendaPanel') set setGuardarAgendaPanel(theElementRef: ViewContainerRef) {
         this.guardarAgendaPanel = theElementRef;
     }
+
+    @ViewChild('botonesAgenda') botonesAgendaComponent: BotonesAgendaComponent;
 
     agendasSeleccionadas: IAgenda[] = [];
     turnosSeleccionados: ITurno[] = [];
@@ -454,11 +457,7 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
                     }
 
                     if (!multiple) {
-                        if (ag.estado === 'suspendida') {
-                            this.showSuspendida = true; // Mostramos los pacientes y sus teléfonos de la agenda suspendida
-                        }
-                        this.agendasSeleccionadas = [];
-                        this.agendasSeleccionadas = [...this.agendasSeleccionadas, ag];
+                        this.onSeleccionAgendaNoMultiple(ag);
                     } else {
                         let index = this.estaSeleccionada(agenda);
                         if (index >= 0) {
@@ -491,6 +490,14 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
                 });
             }
         }
+    }
+
+    onSeleccionAgendaNoMultiple(ag) {
+        if (ag.estado === 'suspendida') {
+            this.showSuspendida = true; // Mostramos los pacientes y sus teléfonos de la agenda suspendida
+        }
+        this.agendasSeleccionadas = [];
+        this.agendasSeleccionadas = [...this.agendasSeleccionadas, ag];
     }
 
     hayAgendasSuspendidas() {

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.html
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.html
@@ -14,7 +14,7 @@
                                 (editarAgendaEmit)="editarAgenda($event)" (actualizarEstadoEmit)="actualizarEstadoEmit($event)"
                                 (listarTurnosEmit)="listarTurnos($event)" (listarCarpetasEmit)="listarCarpetas($event)"
                                 (revisionAgendaEmit)="revisionAgenda($event)" (reasignarTurnosEmit)="reasignarTurnos($event)"
-                                [turnosSuspendidos]="turnosSuspendidos">
+                                [turnosSuspendidos]="turnosSuspendidos" #botonesAgenda>
                             </botones-agenda>
                         </div>
 
@@ -144,7 +144,8 @@
                 <plex-box>
                     <div *ngIf="showTurnos && agendasSeleccionadas?.length == 1 && !showSuspenderTurnos" type="info">
                         <turnos [agenda]="agendasSeleccionadas[0]" (reasignaTurno)="reasignaTurno($event)"
-                            (recargarAgendas)="loadAgendas($event)"></turnos>
+                            (recargarAgendas)="loadAgendas($event)"
+                            (actualizarBotonesAgendasEmiter)="onSeleccionAgendaNoMultiple($event)"></turnos>
                     </div>
                     <div *ngIf="showEditarAgendaPanel && agendasSeleccionadas?.length === 1" type="info">
                         <panel-agenda [editaAgendaPanel]="agendasSeleccionadas[0]" (showVistaTurnosEmit)="showVistaTurnos($event)"

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.html
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.html
@@ -14,7 +14,7 @@
                                 (editarAgendaEmit)="editarAgenda($event)" (actualizarEstadoEmit)="actualizarEstadoEmit($event)"
                                 (listarTurnosEmit)="listarTurnos($event)" (listarCarpetasEmit)="listarCarpetas($event)"
                                 (revisionAgendaEmit)="revisionAgenda($event)" (reasignarTurnosEmit)="reasignarTurnos($event)"
-                                [turnosSuspendidos]="turnosSuspendidos" #botonesAgenda>
+                                [turnosSuspendidos]="turnosSuspendidos">
                             </botones-agenda>
                         </div>
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -198,7 +198,7 @@ export class BotonesAgendaComponent implements OnInit {
         if (!agenda.dinamica) {
             return agenda.bloques.some((bloque: any) => bloque.turnos.some((turno: any) => turno.asistencia || (turno.diagnostico && turno.diagnostico.codificaciones && turno.diagnostico.codificaciones.length > 0)));
         } else {
-            return false;
+            return agenda.bloques.some((bloque: any) => bloque.turnos.some((turno: any) => turno.asistencia));
         }
     }
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
@@ -83,9 +83,13 @@ export class SuspenderAgendaComponent implements OnInit {
 
         this.serviceAgenda.patch(this.agenda.id, patch).subscribe((resultado: any) => {
             // Si son múltiples, esperar a que todas se actualicen
-            this.agenda.estado = resultado.estado;
-            this.plex.toast('success', 'Información', 'La agenda cambió el estado a Suspendida');
-            this.returnSuspenderAgenda.emit(this.agenda);
+            if (resultado.mensaje) {
+                this.plex.info('warning', resultado.mensaje);
+            } else {
+                this.agenda.estado = resultado.estado;
+                this.plex.toast('success', 'Información', 'La agenda cambió el estado a Suspendida');
+                this.returnSuspenderAgenda.emit(this.agenda);
+            }
         });
     }
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
@@ -85,6 +85,7 @@ export class SuspenderAgendaComponent implements OnInit {
             // Si son múltiples, esperar a que todas se actualicen
             if (resultado.mensaje) {
                 this.plex.info('warning', resultado.mensaje);
+                this.cancelar();
             } else {
                 this.agenda.estado = resultado.estado;
                 this.plex.toast('success', 'Información', 'La agenda cambió el estado a Suspendida');

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -57,6 +57,7 @@ export class TurnosComponent implements OnInit {
     @Output() reasignaTurno = new EventEmitter<boolean>();
     @Output() recargarAgendas = new EventEmitter<boolean>();
     @Output() recargarBotones = new EventEmitter<boolean>();
+    @Output() actualizarBotonesAgendasEmiter = new EventEmitter<IAgenda>();
 
     // Propiedades públicas
     showSeleccionarTodos = true;
@@ -325,7 +326,7 @@ export class TurnosComponent implements OnInit {
 
         // Patchea los turnosSeleccionados (1 o más turnos)
         this.serviceAgenda.patch(this.agenda.id, patch).subscribe(resultado => {
-            this.agenda = resultado;
+            this.actualizarBotonesAgendasEmiter.emit(resultado);
         });
 
         // Reset botones y turnos seleccionados


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
Fix de issues #1288 y #1289

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agregó un event emitter para en el  componente de turnos para refrescar la agenda seleccionada en el gestor de agenda, produciendo la actualización de la botonera.
2. En el componente de botonera de agenda, se agregó una nueva condición (existencia de turno con asistencia registrada) para ocultar botón de suspensión de agenda, en los casos de agendas dinámicas.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si andes/api#707 `validar-asistencia-agenda`
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
