### PR TITLE
refactor(profesional): agrega select en get

### DIFF
--- a/src/app/components/profesional/profesional-create-update.component.ts
+++ b/src/app/components/profesional/profesional-create-update.component.ts
@@ -172,7 +172,7 @@ export class ProfesionalCreateUpdateComponent implements OnInit {
             let match100 = false;
             this.profesional['profesionalMatriculado'] = false;
             this.profesional.sexo = ((typeof this.profesional.sexo === 'string')) ? this.profesional.sexo : (Object(this.profesional.sexo).id);
-            this.profesionalService.get({ documento: this.profesional.documento })
+            this.profesionalService.getProfesional({ documento: this.profesional.documento })
                 .subscribe(
                     datos => {
                         if (datos.length > 0) {

--- a/src/app/components/profesional/profesional.component.ts
+++ b/src/app/components/profesional/profesional.component.ts
@@ -62,7 +62,7 @@ export class ProfesionalComponent implements OnInit {
             'skip': this.skip,
             'limit': this.limit
         };
-        this.profesionalService.get(parametros).subscribe(datos => {
+        this.profesionalService.getProfesional(parametros).subscribe(datos => {
             this.datos = datos;
         });
     }

--- a/src/app/services/profesional.service.ts
+++ b/src/app/services/profesional.service.ts
@@ -17,19 +17,19 @@ export class ProfesionalService {
      */
     get(params: any): Observable<IProfesional[]> {
         params['fields'] = 'id documento nombre apellido';
-        return this.server.get(this.profesionalUrl, {params: params, showError: true});
+        return this.server.get(this.profesionalUrl, { params: params, showError: true });
     }
 
     getProfesional(params: any): Observable<IProfesional[]> {
-        return this.server.get(this.profesionalUrl, {params: params, showError: true});
+        return this.server.get(this.profesionalUrl, { params: params, showError: true });
     }
 
     /**
      * Metodo post. Inserta un nuevo profesional
      * @param {IProfesional} profesional
      */
-    post(organizacion: IProfesional): Observable<IProfesional> {
-        return this.server.post(this.profesionalUrl, organizacion); // ...using post request
+    post(profesional: IProfesional): Observable<IProfesional> {
+        return this.server.post(this.profesionalUrl, profesional); // ...using post request
     }
 
     getFoto(params: any): Observable<any> {

--- a/src/app/services/profesional.service.ts
+++ b/src/app/services/profesional.service.ts
@@ -12,15 +12,21 @@ export class ProfesionalService {
     constructor(private server: Server) { }
 
     /**
-     * Metodo get. Trae el objeto organizacion.
-     * @param {any} params Opciones de busqueda
+     * Metodo get. Devuelve profesionales
+     * @param {any} params Opciones de búsqueda
      */
     get(params: any): Observable<IProfesional[]> {
+        params['fields'] = 'id documento nombre apellido';
         return this.server.get(this.profesionalUrl, {params: params, showError: true});
     }
+
+    getProfesional(params: any): Observable<IProfesional[]> {
+        return this.server.get(this.profesionalUrl, {params: params, showError: true});
+    }
+
     /**
-     * Metodo post. Inserta un objeto organizacion nuevo.
-     * @param {IOrganizacion} organizacion Recibe IOrganizacion
+     * Metodo post. Inserta un nuevo profesional
+     * @param {IProfesional} profesional
      */
     post(organizacion: IProfesional): Observable<IProfesional> {
         return this.server.post(this.profesionalUrl, organizacion); // ...using post request


### PR DESCRIPTION
### Requerimiento
Optimización de ancho de banda para los get de profesionales.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Agrega get para profesionales para que no traiga todos los campos (solamente id, documento, nombre y apellido)

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si andes/api#711 `cambios_profesionales`
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

