### PR TITLE
RUP: Odontograma histórico con detalles de piezas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
       }
     },
     "@andes/plex": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@andes/plex/-/plex-5.2.0.tgz",
-      "integrity": "sha512-OfPbN011zKpJp63H30w/z5KXW3xueIF6AvLiNznmCT4jSxX2oTnvwJkz2sU2Zd+RoKXG7hlvYSGaN7QBBBd6+g==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@andes/plex/-/plex-5.3.1.tgz",
+      "integrity": "sha512-c1+3e/n9WQifm/ksB2qaEYjfHZM5TJ/njMjOs90RgbLlb7SBeA0zuid//OR1EFXrUsGrXvvYdn+ixjAg77ucMg==",
       "requires": {
         "@mdi/font": "^2.7.94",
         "@types/intro.js": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@andes/auth": "^4.0.0",
     "@andes/icons": "^0.6.1",
     "@andes/match": "^1.1.12",
-    "@andes/plex": "^5.2.0",
+    "@andes/plex": "^5.3.1",
     "@andes/shared": "^5.0.4",
     "@angular/animations": "8.1.0",
     "@angular/cdk": "^7.0.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -507,6 +507,7 @@ import { VistaRegistroComponent } from './modules/rup/components/huds/vistaRegis
 import { VistaProcedimientoComponent } from './modules/rup/components/huds/vistaProcedimiento';
 import { VistaSolicitudTopComponent } from './modules/rup/components/huds/vistaSolicitudTop';
 import { VistaContextoPrestacionComponent } from './modules/rup/components/huds/vistaContextoPrestacion';
+import { VistaDetalleRegistroComponent } from './modules/rup/components/huds/vistaDetalleRegistro';
 import { PasesListadoInternacionComponent } from './apps/rup/internacion/components/pasesListadoInternacion.component';
 
 import { SnomedBuscarService } from './components/snomed/snomed-buscar.service';
@@ -615,6 +616,7 @@ registerLocaleData(localeEs, 'es');
         VistaSolicitudTopComponent,
         VistaPrestacionComponent,
         VistaContextoPrestacionComponent,
+        VistaDetalleRegistroComponent,
 
         // Solicitudes
         SolicitudesComponent,

--- a/src/app/components/especialidad/especialidad-create-update.component.ts
+++ b/src/app/components/especialidad/especialidad-create-update.component.ts
@@ -29,7 +29,6 @@ export class EspecialidadCreateUpdateComponent implements OnInit {
                 activo: true,
             };
         }
-        // console.log(this.modelo.codigo.sisa);
         // this.modelo.codigo.sisa = " ";
     }
 

--- a/src/app/components/tipoPrestacion/tipoPrestacion-create-update.component.ts
+++ b/src/app/components/tipoPrestacion/tipoPrestacion-create-update.component.ts
@@ -65,8 +65,6 @@ export class TipoPrestacionCreateUpdateComponent implements OnInit {
                 tipo: String
 
             }; // this.modelo
-            // console.log("this.modelo");
-            // console.log(this.modelo);
         } else {
             this.granularidad.id = this.modelo.granularidad;
             this.tipo.id = this.modelo.tipo;
@@ -143,31 +141,9 @@ export class TipoPrestacionCreateUpdateComponent implements OnInit {
 
     // ****************************************** //
     onSave() {
-        // if (this.reglas.nombre && this.reglas.valor && this.reglas.condicion) {
-        //     this.arrayReglas.push(this.reglas);
-        //     console.log(this.arrayReglas);
-        // }
-        // this.modelo.ejecucion[0].reglas = this.arrayReglas;
-
-
-
 
         this.modelo.granularidad = this.granularidad.id;
         this.modelo.tipo = this.tipo.id;
-        // Modo Update
-        // console.log(this.modelo);
-        // //delete this.modelo.ejecucion //.$order;
-        // for (var i in this.modelo.ejecucion) {
-        //     delete this.modelo.ejecucion[i].$order;
-        // }
-        // console.log('----------------------');
-        // console.log(this.modelo);
-        // console.log('----------------------');
-        //  this.modelo.ejecucion[0].idTipoPrestacion = "2222";
-        // this.modelo.ejecucion[0].reglas[0].nombre = "prueba22";
-        // this.modelo.ejecucion[0].reglas[0].valor = 33;
-        // this.modelo.ejecucion[0].reglas[0].condicion = "condicion22";
-        // console.log(this.modelo);
         let method = (this.seleccion) ? this.tipoPrestacionService.put(this.modelo) : this.tipoPrestacionService.post(this.modelo);
 
         method.subscribe(tipoPrestacion => {
@@ -186,31 +162,5 @@ export class TipoPrestacionCreateUpdateComponent implements OnInit {
 
 
 
-    // Ejecucion() {
-    //     this.showRegla = true;
-    //     this.modelo.ejecucion[0].idTipoPrestacion = this.seleccionado.id;
-    //     console.log(this.modelo.ejecucion[0].idTipoPrestacion);
-    //     console.log("###modelo");
-    //     console.log(this.modelo);
-    //     // console.log(this.modelo.ejecucion.idTipoPrestacion);
-    //     // console.log(this.reglas);
 
-    // }
-
-    // AgregarReglas() {
-    //     if (this.reglas.nombre && this.reglas.valor && this.reglas.condicion) {
-    //         this.arrayReglas.push(this.reglas);
-    //         console.log(this.arrayReglas);
-    //     }
-    //     this.modelo.ejecucion[0].reglas = this.arrayReglas;
-    //     // console.log(this.reglas);
-    //     console.log("###modelo");
-    //     console.log(this.modelo);
-    // }
-    // QuitaReglas(id) {
-    //     this.arrayReglas.splice(id,1);
-    // }
-
-
-
-} // export class TipoPrestacionCreateUpdateComponent
+}

--- a/src/app/components/top/solicitudes/nuevaSolicitud.component.ts
+++ b/src/app/components/top/solicitudes/nuevaSolicitud.component.ts
@@ -236,14 +236,15 @@ export class NuevaSolicitudComponent implements OnInit {
         if (this.tipoSolicitud === 'salida') {
             if (this.modelo.solicitud.organizacion) {
                 this.servicioReglas.get({
-                organizacionOrigen: this.auth.organizacion.id,
-                organizacionDestino: this.modelo.solicitud.organizacion.id,
-                prestacionOrigen: this.modelo.solicitud.tipoPrestacionOrigen.conceptId })
-                .subscribe(
-                    res => {
-                        this.dataReglasDestino = res.map(elem => { return { id: elem.destino.prestacion.conceptId, nombre: elem.destino.prestacion.term }; });
-                    }
-                );
+                    organizacionOrigen: this.auth.organizacion.id,
+                    organizacionDestino: this.modelo.solicitud.organizacion.id,
+                    prestacionOrigen: this.modelo.solicitud.tipoPrestacionOrigen.conceptId
+                })
+                    .subscribe(
+                        res => {
+                            this.dataReglasDestino = res.map(elem => { return { id: elem.destino.prestacion.conceptId, nombre: elem.destino.prestacion.term }; });
+                        }
+                    );
             }
 
         }
@@ -377,7 +378,6 @@ export class NuevaSolicitudComponent implements OnInit {
         let myReader: FileReader = new FileReader();
 
         myReader.onloadend = (e) => {
-            console.log(this.childsComponents.first);
             (this.childsComponents.first as any).nativeElement.value = '';
             let metadata = {};
             this.adjuntosService.upload(myReader.result, metadata).subscribe((data) => {

--- a/src/app/components/top/solicitudes/solicitudes.component.ts
+++ b/src/app/components/top/solicitudes/solicitudes.component.ts
@@ -293,7 +293,7 @@ export class SolicitudesComponent implements OnInit {
 
             }, err => {
                 if (err) {
-                    console.log(err);
+                    // [] Que onda no hace nada!!
                 }
             });
         }

--- a/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/solicitud-turno-ventanilla.component.ts
+++ b/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/solicitud-turno-ventanilla.component.ts
@@ -146,7 +146,6 @@ export class SolicitudTurnoVentanillaComponent implements OnInit {
             this.servicioReglas.get({ organizacionDestino: this.auth.organizacion.id, prestacionDestino: this.modelo.solicitud.tipoPrestacion.conceptId })
                 .subscribe(
                     res => {
-                        console.log(res);
                         this.arrayOrganizacionesOrigen = res;
                         this.dataOrganizacionesOrigen = res.map(elem => { return { id: elem.origen.organizacion.id, nombre: elem.origen.organizacion.nombre }; });
                     }

--- a/src/app/modules/estadisticas/components/tabla-2d/tabla-2d.component.ts
+++ b/src/app/modules/estadisticas/components/tabla-2d/tabla-2d.component.ts
@@ -43,7 +43,6 @@ export class Tabla2DComponent implements OnInit, OnChanges {
     private slug = new Slug('default');
 
     descargar(value) {
-        // console.log('filtros ', this.filtros)
         // ARMAR CSV para visualizar todos los datos
         let tabla = Object.keys(value).map(city => {
             let dataReturn = { Localidad: city };

--- a/src/app/modules/rup/components/core/rup.component.ts
+++ b/src/app/modules/rup/components/core/rup.component.ts
@@ -94,6 +94,10 @@ export class RUPComponent implements OnInit, AfterViewInit {
         componentReference.instance['ejecutarConcepto'].subscribe(value => {
             this.emitEjecutarConcepto(value);
         });
+        // Event bubbling
+        componentReference.instance['ejecutarAccion'].subscribe((value, datos) => {
+            this.emitEjecutarAccion(value, datos);
+        });
 
         // Inicia el detector de cambios
         componentReference.changeDetectorRef.detectChanges();
@@ -176,6 +180,13 @@ export class RUPComponent implements OnInit, AfterViewInit {
         this.ejecutarConcepto.emit(concepto);
     }
 
+    public emitEjecutarAccion(evento, datos) {
+        // this.prepareEmit();
+
+        // Notifica al componente padre del cambio
+        this.ejecutarAccion.emit({ evento, datos });
+    }
+
 
     /**
     * Devuelve los mensajes de los atomos, moleculas, formulas, etc.
@@ -184,7 +195,6 @@ export class RUPComponent implements OnInit, AfterViewInit {
     * @memberof RUPComponent
     */
     public getMensajes() { }
-
 
     /**
      *

--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.html
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.html
@@ -2,114 +2,105 @@
 <div class="menu-buscador">
     <plex-loader class="float-right" *ngIf="loading" type="ball-pulse"></plex-loader>
     <!-- Botones filtros  -->
-    <ng-container>
-        <ng-container>
-            <div class="container-filtros">
-                <ul class="botones-filtros">
-                    <li>
-                        <small *ngIf="getCantidadResultados('planes')" class="badge badge-solicitud ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'planes'}">{{
+    <div class="container-filtros">
+        <ul class="botones-filtros">
+            <li>
+                <small *ngIf="getCantidadResultados('planes')" class="badge badge-solicitud ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'planes'}">{{
                             getCantidadResultados('planes')}}</small>
-                        <button (click)="filtroBuscador('planes')" class="btn btn-block p-0 btn-solicitud"
-                            [ngClass]="{'active': filtroActual === 'planes'}">
-                            <i class="icon mdi mdi-clipboard-check-outline"></i>
-                            PRESTACIONES
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('solicitudes')"
-                            class="badge badge-solicitud ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'solicitudes'}">{{
+                <button (click)="filtroBuscador('planes')" class="btn btn-block p-0 btn-solicitud"
+                        [ngClass]="{'active': filtroActual === 'planes'}">
+                    <i class="icon mdi mdi-clipboard-check-outline"></i>
+                    PRESTACIONES
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('solicitudes')" class="badge badge-solicitud ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'solicitudes'}">{{
                             getCantidadResultados('solicitudes')}}</small>
-                        <button (click)="filtroBuscador('solicitudes')"
-                            [ngClass]="{'active': filtroActual === 'solicitudes'}"
-                            class="btn btn-block p-0 btn-solicitud">
-                            <i class="icon icon-rup-semantic-plan"></i>
-                            SOLICITUDES
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('hallazgo')" class="badge badge-hallazgo ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'hallazgo'}">{{
+                <button (click)="filtroBuscador('solicitudes')" [ngClass]="{'active': filtroActual === 'solicitudes'}"
+                        class="btn btn-block p-0 btn-solicitud">
+                    <i class="icon icon-rup-semantic-plan"></i>
+                    SOLICITUDES
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('hallazgo')" class="badge badge-hallazgo ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'hallazgo'}">{{
                             getCantidadResultados('hallazgo')}}</small>
-                        <button (click)="filtroBuscador('hallazgo')" [ngClass]="{'active': filtroActual === 'hallazgo'}"
-                            class="btn btn-block p-0 btn-hallazgo">
-                            <i class="icon icon-rup-semantic-hallazgo"></i>
-                            HALLAZGOS
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('trastorno')" class="badge badge-trastorno ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'trastorno'}">{{
+                <button (click)="filtroBuscador('hallazgo')" [ngClass]="{'active': filtroActual === 'hallazgo'}"
+                        class="btn btn-block p-0 btn-hallazgo">
+                    <i class="icon icon-rup-semantic-hallazgo"></i>
+                    HALLAZGOS
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('trastorno')" class="badge badge-trastorno ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'trastorno'}">{{
                             getCantidadResultados('trastorno')}}</small>
-                        <button (click)="filtroBuscador('trastorno')"
-                            [ngClass]="{'active': filtroActual === 'trastorno'}"
-                            class="btn btn-block p-0 btn-trastorno">
-                            <i class="icon icon-rup-semantic-trastorno"></i>
-                            TRASTORNOS
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('procedimiento')"
-                            class="badge badge-procedimiento ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'procedimiento'}">{{
+                <button (click)="filtroBuscador('trastorno')" [ngClass]="{'active': filtroActual === 'trastorno'}"
+                        class="btn btn-block p-0 btn-trastorno">
+                    <i class="icon icon-rup-semantic-trastorno"></i>
+                    TRASTORNOS
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('procedimiento')" class="badge badge-procedimiento ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'procedimiento'}">{{
                             getCantidadResultados('procedimiento')}}</small>
-                        <button (click)="filtroBuscador('procedimiento')"
-                            [ngClass]="{'active': filtroActual === 'procedimiento'}"
-                            class="btn btn-block p-0 btn-procedimiento">
-                            <i class="icon icon-rup-semantic-procedimiento"></i>
-                            PROC.
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('producto')" class="badge badge-producto ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'producto'}">{{
+                <button (click)="filtroBuscador('procedimiento')"
+                        [ngClass]="{'active': filtroActual === 'procedimiento'}"
+                        class="btn btn-block p-0 btn-procedimiento">
+                    <i class="icon icon-rup-semantic-procedimiento"></i>
+                    PROC.
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('producto')" class="badge badge-producto ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'producto'}">{{
                             getCantidadResultados('producto')}}</small>
-                        <button (click)="filtroBuscador('producto')" [ngClass]="{'active': filtroActual === 'producto'}"
-                            class="btn btn-block p-0 btn-producto">
-                            <i class="icon icon-rup-semantic-producto"></i>
-                            PRODUCTOS
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('laboratorios')" class="badge badge-otro ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'laboratorios'}">{{
+                <button (click)="filtroBuscador('producto')" [ngClass]="{'active': filtroActual === 'producto'}"
+                        class="btn btn-block p-0 btn-producto">
+                    <i class="icon icon-rup-semantic-producto"></i>
+                    PRODUCTOS
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('laboratorios')" class="badge badge-otro ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'laboratorios'}">{{
                             getCantidadResultados('laboratorios')}}</small>
-                        <button (click)="filtroBuscador('laboratorios')"
-                            [ngClass]="{'active': filtroActual === 'laboratorios'}"
-                            class="btn btn-block p-0 btn-laboratorio">
-                            <i class="icon mdi mdi-flask-empty-outline"></i>
-                            LABOS
-                        </button>
-                    </li>
-                    <li>
-                        <small *ngIf="getCantidadResultados('vacunas')" class="badge badge-vacuna ml-1 float-right"
-                            [ngClass]="{'active': filtroActual === 'vacunas'}">{{ getCantidadResultados('vacunas') }}</small>
+                <button (click)="filtroBuscador('laboratorios')" [ngClass]="{'active': filtroActual === 'laboratorios'}"
+                        class="btn btn-block p-0 btn-laboratorio">
+                    <i class="icon mdi mdi-flask-empty-outline"></i>
+                    LABOS
+                </button>
+            </li>
+            <li>
+                <small *ngIf="getCantidadResultados('vacunas')" class="badge badge-vacuna ml-1 float-right"
+                       [ngClass]="{'active': filtroActual === 'vacunas'}">{{ getCantidadResultados('vacunas') }}</small>
 
-                        <button (click)="filtroBuscador('vacunas')" [ngClass]="{'active': filtroActual === 'vacunas'}"
-                            class="btn btn-block p-0 btn-vacuna">
-                            <i class="icon mdi mdi-eyedropper-variant"></i>
-                            VACUNAS
-                        </button>
-                    </li>
-                </ul>
-            </div>
-        </ng-container>
-        <div class="row">
-            <div class="col-10">
-                <small class="pr-1" *ngIf="getSemanticTagFiltros()">Filtros:</small>
-                <i class="text-secondary ml-1">{{ getSemanticTagFiltros() }}</i>
-            </div>
-            <div class="col-2">
-                <ng-container *ngIf="filtroActual === 'planes'">
-                    <plex-button [icon]="showFiltros ? 'mdi mdi-close' : 'mdi mdi-magnify'" size="sm" type="info"
-                        [title]="showFiltros ? 'Cerrar filtros' : 'Ver filtros'" class="float-right"
-                        (click)="toogleFiltros()">
-                    </plex-button>
-                </ng-container>
-            </div>
+                <button (click)="filtroBuscador('vacunas')" [ngClass]="{'active': filtroActual === 'vacunas'}"
+                        class="btn btn-block p-0 btn-vacuna">
+                    <i class="icon mdi mdi-eyedropper-variant"></i>
+                    VACUNAS
+                </button>
+            </li>
+        </ul>
+    </div>
+    <div class="row">
+        <div class="col-10">
+            <small class="pr-1" *ngIf="getSemanticTagFiltros()">Filtros:</small>
+            <i class="text-secondary ml-1">{{ getSemanticTagFiltros() }}</i>
         </div>
-    </ng-container>
+        <div class="col-2">
+            <ng-container *ngIf="filtroActual === 'planes'">
+                <plex-button [icon]="showFiltros ? 'mdi mdi-close' : 'mdi mdi-magnify'" size="sm" type="info"
+                             [title]="showFiltros ? 'Cerrar filtros' : 'Ver filtros'" class="float-right"
+                             (click)="toogleFiltros()">
+                </plex-button>
+            </ng-container>
+        </div>
+    </div>
 </div>
 <div class="row huds-busqueda">
     <div class="col">
@@ -119,55 +110,65 @@
             <ul *ngIf="procedimientos" class="hover conceptos list-unstyled">
 
                 <ng-container *ngFor="let registro of solicitudesMezcladas; let iPrestacion = index">
-                        <li>
-                            <div class="rup-card mini procedimiento"
-                                [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': true}"
-                                (click)="clickSolicitud(registro)">
-                                
-                                <div class="rup-header">
-                                    <div class="rup-border rup-border-procedimiento"
-                                        [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': true}">
-                                        <div class="row p-0 m-0 border-secondary border-left-0">
-                                            <div class="col-10 p-0 m-0">
-                                                <div class="row m-0 p-0">
-                                                    <div class="col-2 icon-rup drag-handle">
-                                                        <i class='icon icon-rup-semantic-plan'></i>
-                                                    </div>
-                                                    <div class="col p-0 pl-2 float-left">
-                                                        <ng-container *ngIf='registro.evoluciones'>{{ registro.concepto.term }}</ng-container>
-                                                        <ng-container *ngIf='!registro.evoluciones'>{{ registro.solicitud.registros[0].concepto.term }}</ng-container>
-                                                        <div class="row p-0 m-0">
-                                                            <div class="col-10 p-0 m-0">
-                                                                <div class="sugerido">
-                                                                    <small>Creada:
-                                                                        <ng-container *ngIf='registro.evoluciones'>{{ registro.evoluciones[0].fechaCarga | fecha }}</ng-container>
-                                                                        <ng-container *ngIf='!registro.evoluciones'>{{ registro.createdAt | fecha }}</ng-container>
-                                                                    </small>
-                                                                    <br>
-                                                                    <small>Profesional: 
-                                                                        <ng-container *ngIf='registro.evoluciones'>{{ registro.evoluciones[0].profesional }}</ng-container>
-                                                                        <ng-container *ngIf='!registro.evoluciones'>{{ registro.solicitud.profesionalOrigen | profesional }}</ng-container>
-                                                                    </small>
-                                                                </div>
+                    <li>
+                        <div class="rup-card mini procedimiento"
+                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': true}"
+                             (click)="clickSolicitud(registro)">
+
+                            <div class="rup-header">
+                                <div class="rup-border rup-border-procedimiento"
+                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': true}">
+                                    <div class="row p-0 m-0 border-secondary border-left-0">
+                                        <div class="col-10 p-0 m-0">
+                                            <div class="row m-0 p-0">
+                                                <div class="col-2 icon-rup drag-handle">
+                                                    <i class='icon icon-rup-semantic-plan'></i>
+                                                </div>
+                                                <div class="col p-0 pl-2 float-left">
+                                                    <ng-container *ngIf='registro.evoluciones'>
+                                                        {{ registro.concepto.term }}</ng-container>
+                                                    <ng-container *ngIf='!registro.evoluciones'>
+                                                        {{ registro.solicitud.registros[0].concepto.term }}
+                                                    </ng-container>
+                                                    <div class="row p-0 m-0">
+                                                        <div class="col-10 p-0 m-0">
+                                                            <div class="sugerido">
+                                                                <small>Creada:
+                                                                    <ng-container *ngIf='registro.evoluciones'>
+                                                                        {{ registro.evoluciones[0].fechaCarga | fecha }}
+                                                                    </ng-container>
+                                                                    <ng-container *ngIf='!registro.evoluciones'>
+                                                                        {{ registro.createdAt | fecha }}</ng-container>
+                                                                </small>
+                                                                <br>
+                                                                <small>Profesional:
+                                                                    <ng-container *ngIf='registro.evoluciones'>
+                                                                        {{ registro.evoluciones[0].profesional }}
+                                                                    </ng-container>
+                                                                    <ng-container *ngIf='!registro.evoluciones'>
+                                                                        {{ registro.solicitud.profesionalOrigen | profesional }}
+                                                                    </ng-container>
+                                                                </small>
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-2 p-0 m-0">
-                                                <div class="p-0 pt-1 pr-1 float-right">
-                                                    <small class="badge badge-info text-default p-1">
-                                                            <ng-container *ngIf='registro.evoluciones'>RUP</ng-container>
-                                                            <ng-container *ngIf='!registro.evoluciones'>TOP</ng-container>
-                                                    </small>
-                                                </div>
+                                        </div>
+                                        <div class="col-2 p-0 m-0">
+                                            <div class="p-0 pt-1 pr-1 float-right">
+                                                <small class="badge badge-info text-default p-1">
+                                                    <ng-container *ngIf='registro.evoluciones'>RUP</ng-container>
+                                                    <ng-container *ngIf='!registro.evoluciones'>TOP</ng-container>
+                                                </small>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                        </li>
-                    </ng-container>
+                        </div>
+                    </li>
+                </ng-container>
             </ul>
         </ng-container>
 
@@ -177,11 +178,11 @@
                 <ng-container *ngFor="let registro of hallazgos">
                     <li>
                         <div class="rup-card mini hallazgo"
-                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                            (click)="emitTabs(registro, 'concepto')">
+                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                             (click)="emitTabs(registro, 'concepto')">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-hallazgo"
-                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
+                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
@@ -225,11 +226,11 @@
                 <ng-container *ngFor="let registro of trastornos">
                     <li>
                         <div class="rup-card mini trastorno"
-                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                            (click)="emitTabs(registro, 'concepto')">
+                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                             (click)="emitTabs(registro, 'concepto')">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-trastorno"
-                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
+                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
@@ -258,14 +259,13 @@
                                             <div class="p-0 pt-1 pr-1 float-right">
                                                 <ng-container *ngIf="registro.evoluciones">
                                                     <small class="badge badge-success text-default p-1">
-                                                        {{ registro.evoluciones[registro.evoluciones.length-1].estado
-                                                        }}
+                                                        {{ registro.evoluciones[registro.evoluciones.length-1].estado }}
                                                     </small>
                                                 </ng-container>
                                                 <button class="btn btn-sm btn-primary btn-icon-rup p-0"
-                                                    *ngIf="emitirConceptos"
-                                                    (click)="devolverHallazgo(registro, 'hallazgo')"
-                                                    title="Agregar a la consulta" titlePosition="left">
+                                                        *ngIf="emitirConceptos"
+                                                        (click)="devolverHallazgo(registro, 'hallazgo')"
+                                                        title="Agregar a la consulta" titlePosition="left">
                                                     <i class="mdi mdi-plus"></i>
                                                 </button>
                                             </div>
@@ -285,17 +285,17 @@
                 <ng-container *ngFor="let registro of procedimientos; let iPrestacion = index">
                     <li>
                         <div class="rup-card mini procedimiento"
-                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                            (click)="emitTabs(registro, 'concepto')">
+                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                             (click)="emitTabs(registro, 'concepto')">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-procedimiento"
-                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
+                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
                                                 <div class="col-2 icon-rup drag-handle">
                                                     <i
-                                                        [ngClass]="{'icon icon-rup-semantic-procedimiento': !registro.isSolicitud, 'icon icon-rup-semantic-plan': registro.esSolicitud}"></i>
+                                                       [ngClass]="{'icon icon-rup-semantic-procedimiento': !registro.isSolicitud, 'icon icon-rup-semantic-plan': registro.esSolicitud}"></i>
                                                 </div>
                                                 <div class="col p-0 pl-2 float-left">
                                                     {{ registro.concepto.term }}
@@ -333,19 +333,19 @@
                 <div class="row">
                     <div class="col-12">
                         <plex-select [(ngModel)]="prestacionSeleccionada" label="Prestación" [data]="tiposPrestacion"
-                            idField="conceptId" labelField="term" (change)="filtrar()" [multiple]="true">
+                                     idField="conceptId" labelField="term" (change)="filtrar()" [multiple]="true">
                         </plex-select>
                     </div>
                 </div>
                 <div class="row pb-2">
                     <div class="col-6">
                         <plex-datetime type="date" [(ngModel)]="fechaInicio" (change)="filtrar()" name="fechaInicio"
-                            label="Fecha Desde">
+                                       label="Fecha Desde">
                         </plex-datetime>
                     </div>
                     <div class="col-6">
                         <plex-datetime type="date" [(ngModel)]="fechaFin" (change)="filtrar()" name="fechaFin"
-                            label="Fecha Hasta">
+                                       label="Fecha Hasta">
                         </plex-datetime>
                     </div>
                 </div>
@@ -355,11 +355,11 @@
                 <ng-container *ngFor="let prestacion of prestaciones">
                     <li>
                         <div class="rup-card mini solicitud"
-                            [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}"
-                            (click)="emitTabs(prestacion, prestacion.tipo)">
+                             [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}"
+                             (click)="emitTabs(prestacion, prestacion.tipo)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-solicitud"
-                                    [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}">
+                                     [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
@@ -419,9 +419,10 @@
                                             <div class="row m-0 p-0">
                                                 <ng-container *ngIf="emitirConceptos">
                                                     <div class="icon-rup" draggable [dragScope]="_dragScope"
-                                                        [dragClass]="_dragOverClass"
-                                                        [dragData]="{'tipo': 'producto','data': registro, 'huds': true}"
-                                                        (onDragStart)="dragStart($event)" (onDragEnd)="dragEnd($event)">
+                                                         [dragClass]="_dragOverClass"
+                                                         [dragData]="{'tipo': 'producto','data': registro, 'huds': true}"
+                                                         (onDragStart)="dragStart($event)"
+                                                         (onDragEnd)="dragEnd($event)">
                                                         <i class="icon icon-rup-semantic-producto"></i>
                                                     </div>
                                                 </ng-container>
@@ -431,7 +432,7 @@
                                                     </div>
                                                 </ng-container>
                                                 <div class="col p-0 pl-2 float-left"
-                                                    (click)="emitTabs(registro, 'concepto')">
+                                                     (click)="emitTabs(registro, 'concepto')">
                                                     {{ registro.concepto.term }}
                                                     <div class="row p-0 m-0">
                                                         <div class="col-10 p-0 m-0">
@@ -474,7 +475,7 @@
                     <ng-container *ngFor="let laboratorio of laboratorios">
                         <li>
                             <div class="rup-card mini laboratorio"
-                                [ngClass]="{'active': huds.isOpen(laboratorio.data, 'cda')}">
+                                 [ngClass]="{'active': huds.isOpen(laboratorio.data, 'cda')}">
                                 <div class="rup-header">
                                     <div class="rup-border rup-border-laboratorio">
                                         <div class="row p-0 m-0 border-secondary border-left-0">
@@ -482,10 +483,10 @@
                                                 <div class="row m-0 p-0">
                                                     <ng-container *ngIf="emitirConceptos">
                                                         <div class="icon-rup" draggable [dragScope]="_dragScope"
-                                                            [dragClass]="_dragOverClass"
-                                                            [dragData]="{'tipo': 'laboratorio','data': laboratorio, 'huds': true}"
-                                                            (onDragStart)="dragStart($event)"
-                                                            (onDragEnd)="dragEnd($event)">
+                                                             [dragClass]="_dragOverClass"
+                                                             [dragData]="{'tipo': 'laboratorio','data': laboratorio, 'huds': true}"
+                                                             (onDragStart)="dragStart($event)"
+                                                             (onDragEnd)="dragEnd($event)">
                                                             <i class="icon mdi mdi-flask-empty-outline"></i>
                                                         </div>
                                                     </ng-container>
@@ -495,7 +496,7 @@
                                                         </div>
                                                     </ng-container>
                                                     <div class="col p-0 pl-2 float-left"
-                                                        (click)="emitTabs(laboratorio, 'cda')">
+                                                         (click)="emitTabs(laboratorio, 'cda')">
                                                         {{ laboratorio?.prestacion.term }}
                                                         <div class="row p-0 m-0">
                                                             <div class="col-10 p-0 m-0">
@@ -542,9 +543,10 @@
                                                 <div class="row m-0 p-0">
                                                     <ng-container *ngIf="emitirConceptos">
                                                         <div class="icon-rup" draggable [dragScope]="_dragScope"
-                                                            [dragClass]="_dragOverClass"
-                                                            [dragData]="{'tipo': 'vacuna','data': unaVacuna, 'huds': true}"
-                                                            (onDragStart)="dragStart($e)" (onDragEnd)="dragEnd($event)">
+                                                             [dragClass]="_dragOverClass"
+                                                             [dragData]="{'tipo': 'vacuna','data': unaVacuna, 'huds': true}"
+                                                             (onDragStart)="dragStart($e)"
+                                                             (onDragEnd)="dragEnd($event)">
                                                             <i class="icon mdi mdi-eyedropper-variant"></i>
                                                         </div>
                                                     </ng-container>
@@ -554,7 +556,7 @@
                                                         </div>
                                                     </ng-container>
                                                     <div class="col p-0 pl-2 float-left"
-                                                        (click)="emitTabs(unaVacuna, 'cda')">
+                                                         (click)="emitTabs(unaVacuna, 'cda')">
                                                         {{ unaVacuna?.prestacion.term }}
                                                         <div class="row p-0 m-0">
                                                             <div class="col-10 p-0 m-0">

--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
@@ -114,8 +114,10 @@ export class PrestacionEjecucionComponent implements OnInit, OnDestroy {
     public scopePrivacy = [];
     public registrosHUDS = [];
 
-    verMasRelaciones = [];
-
+    // Historial HUDS de registros relacionados a un concepto
+    detalleConceptoHUDS: any;
+    detalleRegistrosHUDS: any;
+    verMasRelaciones: any[] = [];
     constructor(
         private obraSocialService: ObraSocialService,
         public servicioPrestacion: PrestacionesService,
@@ -269,6 +271,11 @@ export class PrestacionEjecucionComponent implements OnInit, OnDestroy {
 
     public onCloseTab(index) {
         this.huds.remove(index - 2);
+        if (this.detalleRegistrosHUDS && this.detalleConceptoHUDS) {
+            this.detalleRegistrosHUDS = null;
+            this.detalleConceptoHUDS = null;
+            this.activeIndex = 0;
+        }
     }
 
     /**
@@ -434,6 +441,9 @@ export class PrestacionEjecucionComponent implements OnInit, OnDestroy {
             if (this.confirmarDesvincular[registroId] && !this.confirmarDesvincular[registroId].cara) {
                 registroActual.relacionadoCon = registroActual.relacionadoCon.filter(rr => rr.id !== this.confirmarDesvincular[registroId].id && rr.concepto.conceptId !== this.confirmarDesvincular[registroId].concepto.conceptId);
             } else {
+
+                registroActual.relacionadoCon = this.elementosRUPService.desvincularOdontograma(this.confirmarDesvincular, registroActual, registroId);
+
                 const cara = this.confirmarDesvincular[registroId].cara;
                 const term = this.confirmarDesvincular[registroId].concepto.term;
                 registroActual.relacionadoCon = registroActual.relacionadoCon.filter(rr => rr.cara !== cara || rr.concepto.term !== term);
@@ -1041,18 +1051,14 @@ export class PrestacionEjecucionComponent implements OnInit, OnDestroy {
     }
 
     // Búsqueda que filtra según concepto
-    ejecutarAccion(data) {
-        // this.tipoBusqueda = [];
-        // if (data && data.conceptos) {
-        //     // tipoBusqueda
-        //     this.tipoBusqueda = data;
-        //     // this.registrosHuds = [...this.registrosHuds, data];
-        // } else {
-        //     this.tipoBusqueda = null;
-        //     this.filtroRefset = null;
-
-        // }
-
+    recibirAccion(datosRecibidos, destino = 'tab') {
+        if (destino === 'tab') {
+            this.detalleConceptoHUDS = datosRecibidos.evento.datos[0];
+            this.detalleConceptoHUDS['caraCuadrante'] = datosRecibidos.evento.datos[1];
+            this.detalleRegistrosHUDS = datosRecibidos.evento.datos[2];
+            this.activeIndex = this.activeIndex + 2;
+        }
+        datosRecibidos = null;
     }
 
     cargaItems(registroActual, indice) {

--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.html
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.html
@@ -1,376 +1,328 @@
-<form class="plex-layout" #form="ngForm" *ngIf="!showCambioPaciente">
+<plex-layout main="8">
     <!-- Sección principal -->
-    <section class="plex-layout prestacionEjecucion" *ngIf="!showCambioPaciente && prestacion && showPrestacion">
-        <div class="row">
-            <!-- Panel Principal -->
-            <div class="col-8 h-100">
-                <plex-box>
-                    <plex-tabs [hidden]="showDatosSolicitud" [activeIndex]="activeIndex" (close)="onCloseTab($event)">
-                        <plex-tab label="Registros de esta consulta">
-                            <div class="row"
-                                 *ngIf="prestacion.ejecucion && prestacion.ejecucion.registros && prestacion.ejecucion.registros.length">
-                                <div class="col-9">
-                                    <!-- Acciones sobre los registros -->
-                                </div>
-                                <div class="col-3 float-right text-right panel-acciones">
-                                    <button *ngIf="collapse" title="Collapsar los registros" titlePosition="left"
-                                            (click)="colapsarPrestaciones('collapse'); collapse = false;"
-                                            class="btn btn-primary">
-                                        <i class="mdi mdi-chevron-down" [ngClass]="{'spin' : !collapse}"></i>
-                                    </button>
-                                    <button *ngIf="!collapse" title="Expandir los registros" titlePosition="left"
-                                            (click)="colapsarPrestaciones(); collapse = true;" class="btn btn-primary">
-                                        <i class="mdi mdi-chevron-left" [ngClass]="{'spin' : !collapse}"></i>
-                                    </button>
-                                </div>
+    <plex-layout-main *ngIf="!showCambioPaciente && prestacion && showPrestacion">
+        <form #form="ngForm" *ngIf="!showCambioPaciente">
+            <div class="w-100 h-100">
+                <plex-tabs [hidden]="showDatosSolicitud" [activeIndex]="activeIndex" (close)="onCloseTab($event)">
+                    <plex-tab label="Registros de esta consulta">
+                        <div class="row"
+                             *ngIf="prestacion.ejecucion && prestacion.ejecucion.registros && prestacion.ejecucion.registros.length">
+                            <div class="col-9">
+                                <!-- Acciones sobre los registros -->
                             </div>
-
-                            <!-- Area droppable de la consulta -->
-                            <div *ngIf="!transformarProblema" droppable [dropScope]="'registros-rup'"
-                                 [dragOverClass]="'drag-target-border'" (onDrop)="onConceptoDrop($event)"
-                                 class="droppable drop-area" [hidden]="!isDraggingConcepto">
-                                <p>
-                                    Arrastre aquí para vincularlos a esta consulta
-                                </p>
+                            <div class="col-3 float-right text-right panel-acciones">
+                                <button *ngIf="collapse" title="Collapsar los registros" titlePosition="left"
+                                        (click)="colapsarPrestaciones('collapse'); collapse = false;"
+                                        class="btn btn-primary">
+                                    <i class="mdi mdi-chevron-down" [ngClass]="{'spin' : !collapse}"></i>
+                                </button>
+                                <button *ngIf="!collapse" title="Expandir los registros" titlePosition="left"
+                                        (click)="colapsarPrestaciones(); collapse = true;" class="btn btn-primary">
+                                    <i class="mdi mdi-chevron-left" [ngClass]="{'spin' : !collapse}"></i>
+                                </button>
                             </div>
-                            <!-- Registros de la prestación -->
-                            <div
-                                 *ngIf="prestacion.ejecucion && prestacion.ejecucion.registros && prestacion.ejecucion.registros.length && !showDatosSolicitud && itemsRegistros && !transformarProblema">
-                                <ng-container *ngFor="let registro of prestacion.ejecucion.registros; let i = index">
-                                    <!-- Drop area -->
-                                    <div droppable [dropScope]="'orden-registros-rup'"
-                                         (onDrop)="moverRegistro(i, $event)" [dragOverClass]="'drop-posicion-hover'"
-                                         [hidden]="!isDraggingRegistro" class="drop-posicion"
-                                         *ngIf="posicionOnDrag !== i">
-                                        Mover a esta posición
-                                    </div>
+                        </div>
 
-                                    <!-- Contenedor del registro RUP -->
-                                    <div
-                                         class="rup-card {{ (registro.esSolicitud) ? 'solicitud' : servicioPrestacion.getCssClass(registro.concepto) }}">
-                                        <div class="rup-header">
-                                            <div class="icon-rup drag-handle" draggable
-                                                 [dragScope]="['orden-registros-rup', 'vincular-registros-rup', 'borrar-registros-rup']"
-                                                 [dragClass]="'drag-target-border'" [dragData]="registro"
-                                                 (onDragStart)="draggingRegistro(i ,registro, true)"
-                                                 (onDragEnd)="draggingRegistro(i, registro, false)">
-                                                <i
-                                                   class="icon icon-rup-semantic-{{(registro.esSolicitud) ? servicioPrestacion.getIcon(registro.concepto, 'planes') : servicioPrestacion.getIcon(registro.concepto)}}"></i>
-                                            </div>
-
-                                            <div class="title text-capitalize">
-                                                {{ registro.nombre }}
-                                                <!-- vinculacion / desvinculacion -->
-                                                <div
-                                                     *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && registro.relacionadoCon[0] && !confirmarDesvincular[registro.id] && (!confirmarEliminar || (confirmarEliminar && indexEliminar != i))">
-
-                                                    <ng-container
-                                                                  *ngIf="registro?.relacionadoCon && registro?.relacionadoCon.length > 0">
-
-                                                        <b *ngIf="registro?.relacionadoCon">Relacionado con: </b>
-                                                        <div class="d-flex flex-wrap" *ngIf="registro?.relacionadoCon">
-
-                                                            <ng-container
-                                                                          *ngFor="let relacion of registro.relacionadoCon; let ir=index">
-                                                                <span class="mt-1" *ngIf="ir < 5">
-                                                                    <small class="badge badge-info">
-                                                                        {{ relacion | relacionRUP }}
-                                                                    </small>
-                                                                    <button (click)="desvincular(registro, relacion)"
-                                                                            class="desvincular btn btn-sm btn-primary btn-icon-relacion mr-2"
-                                                                            *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && !confirmarDesvincular[i] && !confirmarEliminar && !registro.valor?.origen"
-                                                                            title="Relación">
-                                                                        <i class="mdi mdi-link-variant-off"></i>
-                                                                    </button>
-                                                                </span>
-                                                                <span class="mt-1"
-                                                                      *ngIf="verMasRelaciones[i] && ir >= 5">
-                                                                    <small class="badge badge-info">
-                                                                        {{ relacion | relacionRUP }}
-                                                                    </small>
-                                                                    <button (click)="desvincular(registro, relacion)"
-                                                                            class="desvincular btn btn-sm btn-primary btn-icon-relacion mr-2"
-                                                                            *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && !confirmarDesvincular[i] && !confirmarEliminar && !registro.valor?.origen"
-                                                                            title="Relación">
-                                                                        <i class="mdi mdi-link-variant-off"></i>
-                                                                    </button>
-                                                                </span>
-                                                            </ng-container>
-                                                            <ng-container *ngIf="registro.relacionadoCon.length > 5">
-                                                                <plex-button type="primary btn-icon-relacion" size="sm"
-                                                                             label="{{ !verMasRelaciones[i] ? ('+' + (registro.relacionadoCon.length - 5) + ' ...') : '' }}"
-                                                                             icon="{{ !verMasRelaciones[i] ? '' : 'close' }}"
-                                                                             (click)="toggleVerMasRelaciones(i)">
-                                                                </plex-button>
-                                                            </ng-container>
-                                                        </div>
-                                                    </ng-container>
-                                                </div>
-                                            </div>
-                                            <div class="actions"
-                                                 *ngIf="!confirmarDesvincular[registro.id] && (!confirmarEliminar || (confirmarEliminar && indexEliminar != i) )">
-
-                                                <ng-container *ngIf="registro?.privacy?.scope">
-                                                    <span class="badge-info float-left"
-                                                          *ngIf="registro?.privacy?.scope !== 'public'">
-                                                        Registro Privado
-                                                    </span>
-                                                </ng-container>
-
-                                                <ng-container
-                                                              *ngIf="prestacion?.ejecucion?.registros !== null && prestacion?.ejecucion?.registros?.length > 1">
-                                                    <plex-dropdown type="primary" class="dropdown-inline" [right]="true"
-                                                                   icon="link-variant"
-                                                                   (onOpen)="cargaItems(registro, i)"
-                                                                   [items]="itemsRegistros[registro.id]?.items">
-                                                    </plex-dropdown>
-                                                </ng-container>
-
-                                                <ng-container
-                                                              *ngIf="registro.concepto.semanticTag === 'procedimiento' && !registro.esSolicitud">
-                                                    <ng-container
-                                                                  *ngIf="(ps.plantillas(registro.concepto.conceptId) | async) as plantillas">
-                                                        <plex-dropdown type="primary" class="dropdown-inline"
-                                                                       [right]="true" icon="playlist-plus"
-                                                                       [items]="plantillas"
-                                                                       title="Seleccionar plantilla"
-                                                                       titlePosition="left"
-                                                                       *ngIf="plantillas.length > 0">
-                                                        </plex-dropdown>
-                                                    </ng-container>
-                                                </ng-container>
-
-                                                <plex-button (click)="cambiaValorCollapse(registro.id)" size="sm"
-                                                             type="primary"
-                                                             icon="{{ itemsRegistros[registro.id]?.collapse ? 'chevron-down' : 'chevron-up'}}"
-                                                             class="collapse-card"
-                                                             title="{{ itemsRegistros[registro.id]?.collapse ? 'Expandir' : 'Colapsar'}}"
-                                                             titlePosition="left">
-                                                </plex-button>
-
-                                                <plex-button *ngIf="!existe(registro.concepto);" size="sm" type="danger"
-                                                             icon="delete"
-                                                             (click)="confirmarEliminarRegistro(registro, 'card')">
-                                                </plex-button>
-                                            </div>
-                                        </div>
-
-                                        <div class="rup-body" (click)="recuperaLosMasFrecuentes(registro.concepto)"
-                                             [hidden]="itemsRegistros[registro.id]?.collapse || confirmarEliminar || confirmarDesvincular[registro.id]">
-                                            <!-- ... Header -->
-                                            <div class="legend drag-handle" draggable
-                                                 [dragScope]="['orden-registros-rup', 'vincular-registros-rup', 'borrar-registros-rup']"
-                                                 [dragClass]="'drag-target-border'" [dragData]="registro"
-                                                 (onDragStart)="draggingRegistro(i ,registro, true)"
-                                                 (onDragEnd)="draggingRegistro(i, registro, false)">
-                                                <span>
-                                                    {{ (registro.esSolicitud) ? 'solicitud' :
-                                                    registro.concepto.semanticTag}}
-                                                </span>
-                                            </div>
-
-                                            <!-- ... Body -->
-                                            <div class="content"
-                                                 *ngIf="paciente || (prestacion.solicitud.tipoPrestacion.noNominalizada)">
-
-                                                <ng-container *ngIf="matchBusquedaGuiada(registro.concepto)">
-                                                    <div class="row">
-                                                        <div class="col-12">
-                                                            <span *ngFor="let rf of matchBusquedaGuiada(registro.concepto)"
-                                                                  class="badge badge-danger">
-                                                                {{ rf.nombre }}
-                                                            </span>
-                                                        </div>
-                                                    </div>
-                                                </ng-container>
-
-                                                <div *ngIf="mostrarMensajes && !registro.valido">
-                                                    <span class="badge badge-danger">
-                                                        Debe completar los datos
-                                                    </span>
-                                                </div>
-                                                <!-- RUP Loader -->
-                                                <rup [elementoRUP]="elementosRUPService.elementoRegistro(registro)"
-                                                     [prestacion]="prestacion" [paciente]="paciente"
-                                                     [registro]="registro" [soloValores]="false"
-                                                     (ejecutarConcepto)="ejecutarConcepto($event, registro)"
-                                                     [params]="elementosRUPService.getParams(registro)">
-                                                </rup>
-                                            </div>
-                                        </div>
-
-                                        <!-- Footer del registro -->
-                                        <div class="rup-footer" *ngIf="registro.relacionadoCon || confirmarEliminar">
-                                            <div class="type"></div>
-
-                                            <div class="text-center col"
-                                                 *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && confirmarDesvincular[registro.id]">
-
-                                                <div class="confirmarDesvincular">
-                                                    <span>
-                                                        ¿Quitar <b>relación</b> con
-                                                        <em
-                                                            class="text-capitalize">«{{ mostrarVinculacion(registro) | relacionRUP }}»</em>?
-                                                    </span>
-                                                    <div class="buttons">
-                                                        <a href="javascript:void(0);"
-                                                           (click)="cancelarDesvincular(registro.id)"
-                                                           class="btn btn-danger mr-1">
-                                                            No, Mantener relación
-                                                        </a>
-
-                                                        <a href="javascript:void(0);"
-                                                           (click)="confirmarDesvinculacion(registro, i)"
-                                                           class="btn btn-success ml-1">
-                                                            Si, Quitar relación
-                                                        </a>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            <div class="text-center col"
-                                                 *ngIf="confirmarEliminar && scopeEliminar === 'card' && indexEliminar == i">
-                                                <div class="confirmarDesvincular">
-                                                    <div>¿Quitar de esta consulta?</div>
-                                                    <div class="buttons">
-                                                        <plex-button type="danger" label="Cancelar"
-                                                                     (click)="confirmarEliminar = false;" class="hover">
-                                                        </plex-button>
-                                                        <plex-button type="success" label="Confirmar"
-                                                                     (click)="eliminarRegistro()" class="confirm hover">
-                                                        </plex-button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-
-                                </ng-container>
-
+                        <!-- Area droppable de la consulta -->
+                        <div *ngIf="!transformarProblema" droppable [dropScope]="'registros-rup'"
+                             [dragOverClass]="'drag-target-border'" (onDrop)="onConceptoDrop($event)"
+                             class="droppable drop-area" [hidden]="!isDraggingConcepto">
+                            <p>
+                                Arrastre aquí para vincularlos a esta consulta
+                            </p>
+                        </div>
+                        <!-- Registros de la prestación -->
+                        <div
+                             *ngIf="prestacion.ejecucion && prestacion.ejecucion.registros && prestacion.ejecucion.registros.length && !showDatosSolicitud && itemsRegistros && !transformarProblema">
+                            <ng-container *ngFor="let registro of prestacion.ejecucion.registros; let i = index">
                                 <!-- Drop area -->
-                                <div droppable [dropScope]="'orden-registros-rup'"
-                                     (onDrop)="moverRegistro(prestacion.ejecucion.registros.length, $event)"
+                                <div droppable [dropScope]="'orden-registros-rup'" (onDrop)="moverRegistro(i, $event)"
                                      [dragOverClass]="'drop-posicion-hover'" [hidden]="!isDraggingRegistro"
-                                     class="drop-posicion"
-                                     *ngIf="prestacion.ejecucion.registros && prestacion.ejecucion.registros.length && prestacion.ejecucion.registros.length !== posicionOnDrag">
+                                     class="drop-posicion" *ngIf="posicionOnDrag !== i">
                                     Mover a esta posición
                                 </div>
-                            </div>
 
-                            <div *ngIf="transformarProblema">
-                                <div class="rup-card">
-                                    <div class="rup-content">
+                                <!-- Contenedor del registro RUP -->
+                                <div
+                                     class="rup-card {{ (registro.esSolicitud) ? 'solicitud' : servicioPrestacion.getCssClass(registro.concepto) }}">
+                                    <div class="rup-header">
+                                        <div class="icon-rup drag-handle" draggable
+                                             [dragScope]="['orden-registros-rup', 'vincular-registros-rup', 'borrar-registros-rup']"
+                                             [dragClass]="'drag-target-border'" [dragData]="registro"
+                                             (onDragStart)="draggingRegistro(i ,registro, true)"
+                                             (onDragEnd)="draggingRegistro(i, registro, false)">
+                                            <i
+                                               class="icon icon-rup-semantic-{{(registro.esSolicitud) ? servicioPrestacion.getIcon(registro.concepto, 'planes') : servicioPrestacion.getIcon(registro.concepto)}}"></i>
+                                        </div>
+
+                                        <div class="title text-capitalize">
+                                            {{ registro.nombre }}
+                                            <!-- vinculacion / desvinculacion -->
+                                            <div
+                                                 *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && registro.relacionadoCon[0] && !confirmarDesvincular[registro.id] && (!confirmarEliminar || (confirmarEliminar && indexEliminar != i))">
+
+                                                <ng-container
+                                                              *ngIf="registro?.relacionadoCon && registro?.relacionadoCon.length > 0">
+
+                                                    <div class="float-left" *ngIf="registro?.relacionadoCon">
+                                                        <b class="clearfix" *ngIf="registro?.relacionadoCon">Relacionado
+                                                            con: </b>
+                                                        <ng-container
+                                                                      *ngFor="let relacion of registro.relacionadoCon; let r=index">
+                                                            <ng-container *ngIf="verMasRelaciones[i] || r <= 5">
+                                                                <small class="badge badge-info">
+                                                                    {{ registro.relacionadoCon[r] | relacionRUP }}
+                                                                </small>
+                                                                <button (click)="desvincular(registro, registro.relacionadoCon[r])"
+                                                                        class="desvincular"
+                                                                        *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && !confirmarDesvincular[i] && !confirmarEliminar && !registro.valor?.origen"
+                                                                        title="Desvincular"
+                                                                        class="btn btn-sm btn-primary">
+                                                                    <i class="mdi mdi-link-variant-off"></i>
+                                                                </button>
+                                                            </ng-container>
+
+                                                        </ng-container>
+                                                        <ng-container *ngIf="registro.relacionadoCon.length > 5">
+                                                            <plex-button type="primary btn-icon-relacion" size="sm"
+                                                                         label="{{ !verMasRelaciones[i] ? ('+' + (registro.relacionadoCon.length - 5) + ' ...') : '' }}"
+                                                                         icon="{{ !verMasRelaciones[i] ? '' : 'close' }}"
+                                                                         (click)="toggleVerMasRelaciones(i)">
+                                                            </plex-button>
+                                                        </ng-container>
+                                                    </div>
+                                                </ng-container>
+                                            </div>
+                                        </div>
+                                        <div class="actions"
+                                             *ngIf="!confirmarDesvincular[registro.id] && (!confirmarEliminar || (confirmarEliminar && indexEliminar != i) )">
+
+                                            <ng-container *ngIf="registro?.privacy?.scope">
+                                                <span class="badge-info float-left"
+                                                      *ngIf="registro?.privacy?.scope !== 'public'">
+                                                    Registro Privado
+                                                </span>
+                                            </ng-container>
+
+                                            <ng-container
+                                                          *ngIf="prestacion?.ejecucion?.registros !== null && prestacion?.ejecucion?.registros?.length > 1">
+                                                <plex-dropdown type="primary" class="dropdown-inline" [right]="true"
+                                                               icon="link-variant" (onOpen)="cargaItems(registro, i)"
+                                                               [items]="itemsRegistros[registro.id]?.items">
+                                                </plex-dropdown>
+                                            </ng-container>
+
+                                            <ng-container
+                                                          *ngIf="registro.concepto.semanticTag === 'procedimiento' && !registro.esSolicitud">
+                                                <ng-container
+                                                              *ngIf="(ps.plantillas(registro.concepto.conceptId) | async) as plantillas">
+                                                    <plex-dropdown type="primary" class="dropdown-inline" [right]="true"
+                                                                   icon="playlist-plus" [items]="plantillas"
+                                                                   title="Seleccionar plantilla" titlePosition="left"
+                                                                   *ngIf="plantillas.length > 0">
+                                                    </plex-dropdown>
+                                                </ng-container>
+                                            </ng-container>
+
+                                            <plex-button (click)="cambiaValorCollapse(registro.id)" size="sm"
+                                                         type="primary"
+                                                         icon="{{ itemsRegistros[registro.id]?.collapse ? 'chevron-down' : 'chevron-up'}}"
+                                                         class="collapse-card"
+                                                         title="{{ itemsRegistros[registro.id]?.collapse ? 'Expandir' : 'Colapsar'}}"
+                                                         titlePosition="left">
+                                            </plex-button>
+
+                                            <plex-button *ngIf="!existe(registro.concepto);" size="sm" type="danger"
+                                                         icon="delete"
+                                                         (click)="confirmarEliminarRegistro(registro, 'card')">
+                                            </plex-button>
+                                        </div>
+                                    </div>
+
+                                    <div class="rup-body" (click)="recuperaLosMasFrecuentes(registro.concepto)"
+                                         [hidden]="itemsRegistros[registro.id]?.collapse || confirmarEliminar || confirmarDesvincular[registro.id]">
                                         <!-- ... Header -->
-                                        <div class="header">
-                                            <div class="title">
-                                                Transformar problema: {{ registroATransformar.nombre }}
+                                        <div class="legend drag-handle" draggable
+                                             [dragScope]="['orden-registros-rup', 'vincular-registros-rup', 'borrar-registros-rup']"
+                                             [dragClass]="'drag-target-border'" [dragData]="registro"
+                                             (onDragStart)="draggingRegistro(i ,registro, true)"
+                                             (onDragEnd)="draggingRegistro(i, registro, false)">
+                                            <span>
+                                                {{ (registro.esSolicitud) ? 'solicitud' :
+                                                    registro.concepto.semanticTag}}
+                                            </span>
+                                        </div>
+
+                                        <!-- ... Body -->
+                                        <div class="content"
+                                             *ngIf="paciente || (prestacion.solicitud.tipoPrestacion.noNominalizada)">
+
+                                            <ng-container *ngIf="matchBusquedaGuiada(registro.concepto)">
+                                                <div class="row">
+                                                    <div class="col-12">
+                                                        <span *ngFor="let rf of matchBusquedaGuiada(registro.concepto)"
+                                                              class="badge badge-danger">
+                                                            {{ rf.nombre }}
+                                                        </span>
+                                                    </div>
+                                                </div>
+                                            </ng-container>
+
+                                            <div *ngIf="mostrarMensajes && !registro.valido">
+                                                <span class="badge badge-danger">
+                                                    Debe completar los datos
+                                                </span>
+                                            </div>
+                                            <!-- RUP Loader -->
+                                            <rup [elementoRUP]="elementosRUPService.elementoRegistro(registro)"
+                                                 [prestacion]="prestacion" [paciente]="paciente" [registro]="registro"
+                                                 [soloValores]="false"
+                                                 (ejecutarConcepto)="ejecutarConcepto($event, registro)"
+                                                 (ejecutarAccion)="recibirAccion($event, 'tab')"
+                                                 [params]="elementosRUPService.getParams(registro)">
+                                            </rup>
+                                        </div>
+                                    </div>
+
+                                    <!-- Footer del registro -->
+                                    <div class="rup-footer" *ngIf="registro.relacionadoCon || confirmarEliminar">
+                                        <div class="type"></div>
+
+                                        <div class="text-center col"
+                                             *ngIf="registro.relacionadoCon && registro.relacionadoCon.length > 0 && confirmarDesvincular[registro.id]">
+
+                                            <div class="confirmarDesvincular">
+                                                <span>
+                                                    ¿Quitar la relación con
+                                                    <em
+                                                        class="text-capitalize">«{{ mostrarVinculacion(registro) | relacionRUP }}»</em>?
+                                                </span>
+                                                <div class="buttons">
+                                                    <plex-button type="danger" label="Mantener relación"
+                                                                 (click)="cancelarDesvincular(registro, i)"
+                                                                 class="hover mr-2">
+                                                    </plex-button>
+                                                    <plex-button type="success" label="Quitar relación"
+                                                                 (click)="confirmarDesvinculacion(registro, i)"
+                                                                 class="hover">
+                                                    </plex-button>
+                                                </div>
                                             </div>
                                         </div>
-                                        <div class="rup-body">
-                                            <div droppable [dropScope]="'registros-rup'"
-                                                 [dragOverClass]="'drag-target-border'"
-                                                 (onDrop)="confirmaTransformar($event)" class="droppable drop-area">
-                                                <p>
-                                                    Arrastre aquí el nuevo Hallazgo
-                                                </p>
+
+                                        <div class="text-center col"
+                                             *ngIf="confirmarEliminar && scopeEliminar === 'card' && indexEliminar == i">
+                                            <div class="confirmarDesvincular">
+                                                <div>¿Quitar de esta consulta?</div>
+                                                <div class="buttons">
+                                                    <plex-button type="danger" label="Cancelar"
+                                                                 (click)="confirmarEliminar = false;" class="hover">
+                                                    </plex-button>
+                                                    <plex-button type="success" label="Confirmar"
+                                                                 (click)="eliminarRegistro()" class="confirm hover">
+                                                    </plex-button>
+                                                </div>
                                             </div>
-                                        </div>
-                                        <div class="rup-footer">
-                                            <a href="javascript:void(0);" (click)="cancelarTransformacion()"
-                                               class="confirm btn btn-danger">
-                                                Cancelar
-                                            </a>
                                         </div>
                                     </div>
                                 </div>
+
+
+                            </ng-container>
+
+                            <!-- Drop area -->
+                            <div droppable [dropScope]="'orden-registros-rup'"
+                                 (onDrop)="moverRegistro(prestacion.ejecucion.registros.length, $event)"
+                                 [dragOverClass]="'drop-posicion-hover'" [hidden]="!isDraggingRegistro"
+                                 class="drop-posicion"
+                                 *ngIf="prestacion.ejecucion.registros && prestacion.ejecucion.registros.length && prestacion.ejecucion.registros.length !== posicionOnDrag">
+                                Mover a esta posición
                             </div>
+                        </div>
+
+                        <div *ngIf="transformarProblema">
+                            <div class="rup-card">
+                                <div class="rup-content">
+                                    <!-- ... Header -->
+                                    <div class="header">
+                                        <div class="title">
+                                            Transformar problema: {{ registroATransformar.nombre }}
+                                        </div>
+                                    </div>
+                                    <div class="rup-body">
+                                        <div droppable [dropScope]="'registros-rup'"
+                                             [dragOverClass]="'drag-target-border'"
+                                             (onDrop)="confirmaTransformar($event)" class="droppable drop-area">
+                                            <p>
+                                                Arrastre aquí el nuevo Hallazgo
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div class="rup-footer">
+                                        <a href="javascript:void(0);" (click)="cancelarTransformacion()"
+                                           class="confirm btn btn-danger">
+                                            Cancelar
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </plex-tab>
+
+                    <plex-tab label="Resumen del Paciente" *ngIf="paciente">
+                        <rup-resumenPaciente-estatico [prestacion]="prestacion" [paciente]="paciente">
+                        </rup-resumenPaciente-estatico>
+                        <rup-resumenPaciente-dinamico-nino *ngIf="paciente.edad <= 6" [paciente]="paciente">
+                        </rup-resumenPaciente-dinamico-nino>
+                        <rup-resumenPaciente-dinamico *ngIf="paciente.edad > 6" [paciente]="paciente">
+                        </rup-resumenPaciente-dinamico>
+                    </plex-tab>
+                    <ng-container *ngFor="let registro of registrosHUDS">
+                        <plex-tab [allowClose]="true" [label]="registro.data.concepto.term"
+                                  [class]="registro.data.class" [color]="registro.data.class"
+                                  *ngIf="registro.tipo === 'concepto'">
+
+                            <vista-registro *ngIf="registro.data.class === 'hallazgo' || registro.data.class === 'trastorno'"
+                                            [registro]="registro.data" [paciente]="paciente">
+                            </vista-registro>
+
+                            <vista-procedimiento *ngIf="registro.data.class === 'plan' || registro.data.class === 'procedimiento' || registro.data.class === 'elementoderegistro' || registro.data.class === 'producto'"
+                                                 [registro]="registro.data" [paciente]="paciente">
+                            </vista-procedimiento>
+
                         </plex-tab>
 
-                        <plex-tab label="Resumen del Paciente" *ngIf="paciente">
-                            <rup-resumenPaciente-estatico [prestacion]="prestacion" [paciente]="paciente">
-                            </rup-resumenPaciente-estatico>
-                            <rup-resumenPaciente-dinamico-nino *ngIf="paciente.edad <= 6" [paciente]="paciente">
-                            </rup-resumenPaciente-dinamico-nino>
-                            <rup-resumenPaciente-dinamico *ngIf="paciente.edad > 6" [paciente]="paciente">
-                            </rup-resumenPaciente-dinamico>
+                        <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term"
+                                  [class]="registro.class" *ngIf="registro.tipo === 'solicitud'">
+                            <vista-solicitud-top [registro]="registro.data"></vista-solicitud-top>
                         </plex-tab>
-                        <ng-container *ngFor="let registro of registrosHUDS">
-                            <plex-tab [allowClose]="true" [label]="registro.data.concepto.term"
-                                      [class]="registro.data.class" [color]="registro.data.class"
-                                      *ngIf="registro.tipo === 'concepto'">
 
-                                <vista-registro *ngIf="registro.data.class === 'hallazgo' || registro.data.class === 'trastorno'"
-                                                [registro]="registro.data" [paciente]="paciente">
-                                </vista-registro>
+                        <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term"
+                                  [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'rup'">
+                            <vista-prestacion [prestacion]="registro.data" [paciente]="paciente">
+                            </vista-prestacion>
+                        </plex-tab>
 
-                                <vista-procedimiento *ngIf="registro.data.class === 'plan' || registro.data.class === 'procedimiento' || registro.data.class === 'elementoderegistro' || registro.data.class === 'producto'"
-                                       [registro]="registro.data" [paciente]="paciente">
-                                </vista-procedimiento>
+                        <plex-tab *ngIf="registro.tipo === 'cda'" [allowClose]="true"
+                                  [label]="registro.data.prestacion.snomed.term" [class]="registro.data.class">
+                            <vista-cda [registro]="registro"></vista-cda>
+                        </plex-tab>
+                    </ng-container>
 
-                            </plex-tab>
+                    <ng-container *ngIf="detalleRegistrosHUDS && detalleConceptoHUDS">
+                        <plex-tab [allowClose]="true" [label]="servicioPrestacion.getFriendlyName(detalleConceptoHUDS)">
+                            <vista-detalle-registro tipo="odontograma" [detalleRegistros]="detalleRegistrosHUDS"
+                                                    [detalleConcepto]="detalleConceptoHUDS">
+                            </vista-detalle-registro>
+                        </plex-tab>
+                    </ng-container>
 
-                            <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term" [class]="registro.class" *ngIf="registro.tipo === 'solicitud'">
-                                <vista-solicitud-top [registro]="registro.data"></vista-solicitud-top>
-                            </plex-tab>
-
-                            <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term"
-                                      [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'rup'">
-                                <vista-prestacion [prestacion]="registro.data" [paciente]="paciente"></vista-prestacion>
-                            </plex-tab>
-
-                            <plex-tab *ngIf="registro.tipo === 'cda'" [allowClose]="true"
-                                      [label]="registro.data.prestacion.snomed.term" [class]="registro.data.class">
-                                <vista-cda [registro]="registro"></vista-cda>
-                            </plex-tab>
-                        </ng-container>
-                    </plex-tabs>
-                </plex-box>
+                </plex-tabs>
             </div>
-
-            <!-- Panel Buscador SNOMED + HUDS -->
-            <div class="col-4 tabs-buscador-huds pr-0 h-100" *ngIf="prestacion">
-                <plex-box>
-                    <plex-tabs [activeIndex]="panelIndex" *ngIf="!prestacion.solicitud.tipoPrestacion.noNominalizada"
-                               size="full">
-                        <plex-tab label="Buscador" (click)="panelIndex = 0">
-                            <rup-buscador [prestacion]="prestacion" [frecuentesTipoPrestacion]="masFrecuentes"
-                                          [conceptoFrecuente]="conceptoFrecuente"
-                                          [showFrecuentesTipoPrestacion]="tengoResultado"
-                                          (tagBusqueda)="getTipoBusqueda($event)"
-                                          (tengoResultado)="recibeSitengoResultado($event)"
-                                          (evtData)="ejecutarConcepto($event, tipoBusqueda)"
-                                          (_onDragStart)="arrastrandoConcepto(true)"
-                                          (_onDragEnd)="arrastrandoConcepto(false)">
-                            </rup-buscador>
-                        </plex-tab>
-                        <plex-tab label="Historia de Salud" (click)="panelIndex = 1">
-                            <rup-hudsBusqueda [paciente]="prestacion?.paciente" [_dragScope]="'registros-rup'"
-                                              (evtData)="ejecutarConceptoHuds($event)"
-                                              (_onDragStart)="arrastrandoConcepto(true)"
-                                              (_onDragEnd)="arrastrandoConcepto(false)"></rup-hudsBusqueda>
-                        </plex-tab>
-                    </plex-tabs>
-                </plex-box>
-            </div>
-        </div>
-    </section>
-
-    <!-- Footer -->
-    <footer *ngIf="!showCambioPaciente">
+        </form>
         <div class="row">
 
-            <div class="col-4"
-                 *ngIf="!showCambioPaciente && prestacion && prestacion.solicitud.ambitoOrigen != 'internacion'">
-                <plex-button label="Punto de Inicio" (click)="volver(prestacion?.solicitud.ambitoOrigen)" type="info">
-                </plex-button>
-            </div>
-            <div class="col-4"
-                 *ngIf="!showCambioPaciente && prestacion && prestacion.solicitud.ambitoOrigen == 'internacion'">
-                <plex-button label="{{btnVolver}}" (click)="volver(prestacion?.solicitud.ambitoOrigen, rutaVolver)"
-                             type="info"></plex-button>
-            </div>
-            <div class="col-3 text-center">
+            <div class="col text-center">
                 <div droppable [dropScope]="'borrar-registros-rup'"
                      (onDrop)="confirmarEliminarRegistro($event, 'footer')" [dragOverClass]="'drop-posicion-hover'"
                      [hidden]="!isDraggingRegistro" class="p-3">
@@ -385,17 +337,53 @@
                 </div>
             </div>
 
-            <div class="col-3">
+            <div class="col">
                 <span *ngIf="!flagValid" class="badge badge-danger float-right">
                     Hay registros incompletos
                 </span>
             </div>
-
-            <div class="col-2" *ngIf="!showCambioPaciente">
-                <plex-button label="Guardar {{prestacion?.solicitud?.tipoPrestacion?.term}}"
-                             (click)="guardarPrestacion()" type="success" class="float-right"></plex-button>
-            </div>
         </div>
+    </plex-layout-main>
 
-    </footer>
-</form>
+    <plex-layout-sidebar *ngIf="prestacion">
+        <!-- Panel Buscador SNOMED + HUDS -->
+        <div class="tabs-buscador-huds pr-0 h-100">
+            <plex-tabs [activeIndex]="panelIndex" *ngIf="!prestacion.solicitud.tipoPrestacion.noNominalizada"
+                       size="full">
+                <plex-tab label="Buscador" (click)="panelIndex = 0">
+                    <rup-buscador [prestacion]="prestacion" [frecuentesTipoPrestacion]="masFrecuentes"
+                                  [conceptoFrecuente]="conceptoFrecuente"
+                                  [showFrecuentesTipoPrestacion]="tengoResultado"
+                                  (tagBusqueda)="getTipoBusqueda($event)"
+                                  (tengoResultado)="recibeSitengoResultado($event)"
+                                  (evtData)="ejecutarConcepto($event, tipoBusqueda)"
+                                  (_onDragStart)="arrastrandoConcepto(true)" (_onDragEnd)="arrastrandoConcepto(false)">
+                    </rup-buscador>
+                </plex-tab>
+                <plex-tab label="Historia de Salud" (click)="panelIndex = 1">
+                    <rup-hudsBusqueda [paciente]="prestacion?.paciente" [_dragScope]="'registros-rup'"
+                                      (evtData)="ejecutarConceptoHuds($event)"
+                                      (_onDragStart)="arrastrandoConcepto(true)"
+                                      (_onDragEnd)="arrastrandoConcepto(false)"></rup-hudsBusqueda>
+                </plex-tab>
+            </plex-tabs>
+        </div>
+    </plex-layout-sidebar>
+
+    <!-- Footer -->
+    <plex-layout-footer *ngIf="!showCambioPaciente">
+
+        <plex-button *ngIf="!showCambioPaciente && prestacion && prestacion.solicitud.ambitoOrigen != 'internacion'"
+                     position="left" label="Punto de Inicio" (click)="volver(prestacion?.solicitud.ambitoOrigen)"
+                     type="info">
+        </plex-button>
+        <plex-button *ngIf="!showCambioPaciente && prestacion && prestacion.solicitud.ambitoOrigen == 'internacion'"
+                     position="left" label="{{btnVolver}}"
+                     (click)="volver(prestacion?.solicitud.ambitoOrigen, rutaVolver)" type="info"></plex-button>
+
+        <plex-button *ngIf="!showCambioPaciente" position="right"
+                     label="Guardar {{prestacion?.solicitud?.tipoPrestacion?.term}}" (click)="guardarPrestacion()"
+                     type="success" class="float-right"></plex-button>
+
+    </plex-layout-footer>
+</plex-layout>

--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.scss
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.scss
@@ -1,5 +1,11 @@
 @import '../core/rup';
 
+::ng-root {
+    .plex-box-content {
+        padding-right: 0;
+    }
+}
+
 //
 .prestacionActual {
     background-color: #66666652;

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -107,8 +107,8 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         }
 
         this.ws.connect();
-        this.servicioTurnero.get({'fields': 'espaciosFisicos.id'}).subscribe((pantallas) => {
-            this.espaciosFisicosTurnero = pantallas.reduce((listado, p) => listado.concat(p.espaciosFisicos), []).map((espacio: any) => { return espacio.id; } );
+        this.servicioTurnero.get({ 'fields': 'espaciosFisicos.id' }).subscribe((pantallas) => {
+            this.espaciosFisicosTurnero = pantallas.reduce((listado, p) => listado.concat(p.espaciosFisicos), []).map((espacio: any) => { return espacio.id; });
         });
     }
 
@@ -402,7 +402,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         //     let planes = [];
         //     this.servicioPrestacion.crearPrestacion(paciente, snomedConcept, 'ejecucion', new Date(), turno).subscribe(prestacion => {
         //         if (prestacion) {
-        //             console.log('prestacion', prestacion);
         //             prestacion.ejecucion.registros.push({
         //                 esDiagnosticoPrincipal: true,
         //                 nombre: 'no asistió',
@@ -496,7 +495,7 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     }
 
     mostrarBotonTurnero(agenda, turno) {
-        return (agenda && agenda.espacioFisico && agenda.espacioFisico.id && (this.espaciosFisicosTurnero.findIndex((e) => e === agenda.espacioFisico.id) >= 0))  && turno.paciente &&  turno.paciente.id && this.verificarAsistencia(turno) && (turno.estado !== 'suspendido') && (!turno.prestacion || (turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente') );
+        return (agenda && agenda.espacioFisico && agenda.espacioFisico.id && (this.espaciosFisicosTurnero.findIndex((e) => e === agenda.espacioFisico.id) >= 0)) && turno.paciente && turno.paciente.id && this.verificarAsistencia(turno) && (turno.estado !== 'suspendido') && (!turno.prestacion || (turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente'));
     }
 
     routeTo(action, id) {

--- a/src/app/modules/rup/components/elementos/OdontogramaRefset.component.ts
+++ b/src/app/modules/rup/components/elementos/OdontogramaRefset.component.ts
@@ -4,7 +4,6 @@ import { RUPComponent } from './../core/rup.component';
 import { IPrestacionGetParams } from '../../interfaces/prestacionGetParams.interface';
 import { IPrestacionRegistro } from '../../interfaces/prestacion.registro.interface';
 import { RupElement } from '.';
-import swal from 'sweetalert2';
 
 @Component({
     selector: 'rup-OdontogramaRefset',
@@ -78,8 +77,6 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
     public cargandoUltimoOdontograma = true;
 
     ngOnInit() {
-
-        console.log(typeof this.params);
 
         // Traer EL odontograma, los dientes
         this.snomedService.getQuery({

--- a/src/app/modules/rup/components/elementos/OdontogramaRefset.component.ts
+++ b/src/app/modules/rup/components/elementos/OdontogramaRefset.component.ts
@@ -4,6 +4,7 @@ import { RUPComponent } from './../core/rup.component';
 import { IPrestacionGetParams } from '../../interfaces/prestacionGetParams.interface';
 import { IPrestacionRegistro } from '../../interfaces/prestacion.registro.interface';
 import { RupElement } from '.';
+import swal from 'sweetalert2';
 
 @Component({
     selector: 'rup-OdontogramaRefset',
@@ -78,6 +79,8 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
 
     ngOnInit() {
 
+        console.log(typeof this.params);
+
         // Traer EL odontograma, los dientes
         this.snomedService.getQuery({
             expression: `^${this.params.refsetId}`,
@@ -90,21 +93,21 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
                 let nroDiente = Number(diente.term.replace('ISO designation ', ''));
                 diente.term = nroDiente.toString();
                 if ((nroDiente >= 11 && nroDiente <= 18)) {
-                    this.odontograma.cuadranteSuperiorDerecho.push({ concepto: diente });
+                    this.odontograma.cuadranteSuperiorDerecho.push({ concepto: diente, cuadrante: 'TR' });
                 } else if (nroDiente >= 21 && nroDiente <= 28) {
-                    this.odontograma.cuadranteSuperiorIzquierdo.push({ concepto: diente });
+                    this.odontograma.cuadranteSuperiorIzquierdo.push({ concepto: diente, cuadrante: 'TL' });
                 } else if (nroDiente >= 41 && nroDiente <= 48) {
-                    this.odontograma.cuadranteInferiorDerecho.push({ concepto: diente });
+                    this.odontograma.cuadranteInferiorDerecho.push({ concepto: diente, cuadrante: 'BR' });
                 } else if (nroDiente >= 31 && nroDiente <= 38) {
-                    this.odontograma.cuadranteInferiorIzquierdo.push({ concepto: diente });
+                    this.odontograma.cuadranteInferiorIzquierdo.push({ concepto: diente, cuadrante: 'BL' });
                 } else if (nroDiente >= 51 && nroDiente <= 55) {
-                    this.odontograma.cuadranteSuperiorDerechoTemporal.push({ concepto: diente });
+                    this.odontograma.cuadranteSuperiorDerechoTemporal.push({ concepto: diente, cuadrante: 'TRT' });
                 } else if (nroDiente >= 61 && nroDiente <= 65) {
-                    this.odontograma.cuadranteSuperiorIzquierdoTemporal.push({ concepto: diente });
+                    this.odontograma.cuadranteSuperiorIzquierdoTemporal.push({ concepto: diente, cuadrante: 'TLT' });
                 } else if (nroDiente >= 81 && nroDiente <= 85) {
-                    this.odontograma.cuadranteInferiorDerechoTemporal.push({ concepto: diente });
+                    this.odontograma.cuadranteInferiorDerechoTemporal.push({ concepto: diente, cuadrante: 'BRT' });
                 } else if (nroDiente >= 71 && nroDiente <= 75) {
-                    this.odontograma.cuadranteInferiorIzquierdoTemporal.push({ concepto: diente });
+                    this.odontograma.cuadranteInferiorIzquierdoTemporal.push({ concepto: diente, cuadrante: 'BLT' });
                 }
             });
 
@@ -116,13 +119,6 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
             this.odontograma.cuadranteSuperiorIzquierdoTemporal.sort((a, b) => Number(a.concepto.term) - Number(b.concepto.term));
             this.odontograma.cuadranteInferiorDerechoTemporal.sort((a, b) => Number(b.concepto.term) - Number(a.concepto.term));
             this.odontograma.cuadranteInferiorIzquierdoTemporal.sort((a, b) => Number(a.concepto.term) - Number(b.concepto.term));
-
-            // Trae los hallazgos, procedimientos, etc...
-            if (this.params) {
-                this.snomedService.getQuery({ expression: `^${this.params.refsetId}` }).subscribe(resultado => {
-                    this.conceptos = resultado;
-                });
-            }
 
             let params: IPrestacionGetParams = {
                 idPaciente: this.paciente.id,
@@ -139,26 +135,37 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
                         }
                     }
                 });
-                // this.odontogramasHUDS = odontogramasPaciente;
+
+                let fechaConsulta = new Date();
                 if (this.odontogramasHUDS && this.odontogramasHUDS.length > 0) {
                     this.ultimoOdontograma = this.odontogramasHUDS[this.odontogramasHUDS.length - 1].ejecucion.registros.filter(x => x.concepto.conceptId === this.conceptoOdontograma)[0];
                     this.ultimoOdontogramaIndex = this.odontogramasHUDS.length - 1;
+                    fechaConsulta = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.fecha;
                 }
                 this.cargandoUltimoOdontograma = false;
-                this.armarRelaciones();
+
+                this.armarRelaciones(fechaConsulta);
+
             });
         });
 
     }
 
-    armarRelaciones() {
+    armarRelaciones(fecha: Date) {
 
         // Último Odontograma (si existe)
         if (this.odontogramasHUDS && this.odontogramasHUDS.length > 0) {
-
+            // hacemos una copia de la lista de odontogramas
+            let listaConceptosOdonto = this.odontogramasHUDS.slice();
             // Quito el odontograma porque se necesitan sólo los registros y sus relaciones
-            this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.registros.shift();
-            this.relaciones = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.registros;
+            this.relaciones = [];
+            // filtramos las consultas según la navegacion
+            listaConceptosOdonto = listaConceptosOdonto.filter(c => c.ejecucion.fecha <= fecha);
+            listaConceptosOdonto.forEach(unaConsulta => {
+                const registros = unaConsulta.ejecucion.registros.filter(c => c.concepto.conceptId !== this.conceptoOdontograma);
+                this.relaciones = [...this.relaciones, ...registros];
+            });
+
             this.relacionesActuales = this.registro.registros;
 
             // Se arma el último odontograma, con sus relaciones
@@ -191,29 +198,17 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
 
     odontogramaAnterior() {
         this.showUltimoOdontograma = false;
-        let params: IPrestacionGetParams = {
-            idPaciente: this.paciente.id,
-            conceptId: this.prestacion.solicitud.tipoPrestacion.conceptId,
-            estado: 'validada'
-        };
-        this.prestacionesService.get(params).subscribe(odontogramasPaciente => {
-            this.odontogramasHUDS = odontogramasPaciente.filter(unaPrestacion => {
-                let odonto = null;
-                if (odonto = unaPrestacion.ejecucion.registros.find(x => x.concepto.conceptId === this.conceptoOdontograma)) {
-                    if (odonto.valor) {
-                        return unaPrestacion;
-                    }
+        if (this.odontogramasHUDS && this.odontogramasHUDS.length > 0) {
+            if (this.ultimoOdontogramaIndex > 0) {
+                this.ultimoOdontogramaIndex--;
+                this.ultimoOdontograma = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.registros.filter(x => x.concepto.conceptId === this.conceptoOdontograma)[0];
+                if (this.ultimoOdontograma) {
+                    let fechaConsulta = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.fecha;
+                    this.armarRelaciones(fechaConsulta);
                 }
-            });
-            if (this.odontogramasHUDS && this.odontogramasHUDS.length > 0) {
-                if (this.ultimoOdontogramaIndex > 0) {
-                    this.ultimoOdontogramaIndex--;
-                    this.ultimoOdontograma = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.registros.filter(x => x.concepto.conceptId === this.conceptoOdontograma)[0];
-                    this.armarRelaciones();
-                    this.showUltimoOdontograma = true;
-                }
+                this.showUltimoOdontograma = true;
             }
-        });
+        }
 
     }
 
@@ -224,45 +219,64 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
             conceptId: this.prestacion.solicitud.tipoPrestacion.conceptId,
             estado: 'validada'
         };
-        this.prestacionesService.get(params).subscribe(odontogramasPaciente => {
-            this.odontogramasHUDS = odontogramasPaciente.filter(unaPrestacion => {
-                let odonto = null;
-                if (odonto = unaPrestacion.ejecucion.registros.find(x => x.concepto.conceptId === this.conceptoOdontograma)) {
-                    if (odonto.valor) {
-                        return unaPrestacion;
-                    }
-                }
+
+        if (this.odontogramasHUDS && this.odontogramasHUDS.length > 0) {
+            if (this.ultimoOdontogramaIndex < this.odontogramasHUDS.length - 1) {
+                this.ultimoOdontogramaIndex++;
+                this.ultimoOdontograma = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.registros.filter(x => x.concepto.conceptId === this.conceptoOdontograma)[0];
+                let fechaConsulta = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.fecha;
+                this.armarRelaciones(fechaConsulta);
+                this.showUltimoOdontograma = true;
+            }
+        }
+    }
+
+    // (click)
+    showDetail(diente, cara, huds = false, index = -1, nuevoRegistro = false) {
+
+        this.popOverText = {};
+
+        if (cara !== 'pieza') {
+            diente.piezaCompleta = false;
+        } else {
+            diente.piezaCompleta = true;
+        }
+
+        this.popOverText = diente;
+
+        if (cara !== 'anulada') {
+            let rel = !huds ? this.getRegistrosRel(diente, cara) : this.getRegistrosRelAnterior(diente, cara);
+            if (rel.length) {
+                this.popOverText.relacion = rel;
+            } else {
+                this.popOverText.relacion = {};
+                // Sólo para piezas
+            }
+        }
+        if (diente.piezaCompleta) {
+            this.popOverText['relacion'] = !huds ? this.getRegistrosRel(diente, 'pieza') : this.getRegistrosRelAnterior(diente, 'pieza');
+        }
+
+        let titulo = `<strong>Diente ${this.popOverText.concepto.term}</strong>`;
+        titulo += this.popOverText.cara && this.popOverText.cara !== 'pieza' && this.popOverText.cara !== 'anulada' ? ` (cara ${this.popOverText.cara})` : '';
+
+
+        let texto = '';
+        if (this.popOverText.relacion && this.popOverText.relacion.length > 0) {
+            this.popOverText.relacion.forEach(relacion => {
+                texto += `<div>${moment(relacion.createdAt).format('DD/MM/YYYY')}: (${relacion.concepto.semanticTag}) ${relacion.concepto.term} </div>`;
             });
-            if (this.odontogramasHUDS && this.odontogramasHUDS.length > 0) {
-                if (this.ultimoOdontogramaIndex < this.odontogramasHUDS.length - 1) {
-                    this.ultimoOdontogramaIndex++;
-                    this.ultimoOdontograma = this.odontogramasHUDS[this.ultimoOdontogramaIndex].ejecucion.registros.filter(x => x.concepto.conceptId === this.conceptoOdontograma)[0];
-                    this.armarRelaciones();
-                    this.showUltimoOdontograma = true;
-                }
-            }
-        });
-    }
+        }
 
-    getRelacion(cuadrante, diente, cara) {
-        return this.ultimoOdontograma.valor.odontograma[String(cuadrante)].find(z => z.cara === cara);
+        this.popOverText.cara = cara;
+        this.showPopOver = true;
+        this.showRelacion = true;
 
-    }
-
-    classRelacion(diente, cara) {
-        return this.relaciones.find(x => {
-            if (x.relacionadoCon) {
-                return x.relacionadoCon.find(y => {
-                    return y.concepto.conceptId === diente.concepto.conceptId && y.cara === cara;
-                });
-            }
-        });
     }
 
     // (mouseenter)
     showTooltip(diente, cara, huds = false, index = -1) {
         this.popOverText = {};
-
         if (cara !== 'pieza') {
             diente.piezaCompleta = false;
         } else {
@@ -283,12 +297,9 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
         if (diente.piezaCompleta) {
             this.popOverText['relacion'] = !huds ? this.getRegistrosRel(diente, 'pieza')[index] : this.getRegistrosRelAnterior(diente, 'pieza')[index];
         }
-
-
         this.popOverText.cara = cara;
         this.showPopOver = true;
         this.showRelacion = true;
-
     }
 
     // (mouseleave)
@@ -308,7 +319,29 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
         }
     }
 
+    classRelacion(diente, cara) {
+        return this.relaciones.find(x => {
+            if (x.relacionadoCon) {
+                return x.relacionadoCon.find(y => {
+                    return y.concepto.conceptId === diente.concepto.conceptId && y.cara === cara;
+                });
+            }
+        });
+    }
+
     getRegistrosRel(diente, cara) {
+        return this.relaciones.filter(x => {
+            if (x.relacionadoCon) {
+                return x.relacionadoCon.find(y => {
+                    if (y && y.concepto) {
+                        return y.concepto.conceptId === diente.concepto.conceptId && y.cara === cara;
+                    }
+                });
+            }
+        });
+    }
+
+    getRegistrosEjecucion(diente, cara) {
         return this.prestacion.ejecucion.registros.filter(x => {
             if (x.relacionadoCon) {
                 return x.relacionadoCon.find(y => {
@@ -503,5 +536,10 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
 
     esCuadranteInferior(cuadrante) {
         return cuadrante.indexOf('Inferior') === -1;
+    }
+
+    seleccionarUnaPieza(diente, cuadrante) {
+        this.jumpToId(this.getClassRegistro(diente, (this.esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')).concepto.conceptId);
+        this.showTooltip(diente, (this.esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, 0);
     }
 }

--- a/src/app/modules/rup/components/elementos/OdontogramaRefset.html
+++ b/src/app/modules/rup/components/elementos/OdontogramaRefset.html
@@ -1,34 +1,35 @@
-<ng-container *ngIf="conceptos?.length > 0 && params && !soloValores">
+<ng-container *ngIf="params && !soloValores">
     <div class="container odontograma no-gutters p-0">
-
-        <div *ngIf="ultimoOdontograma || odontograma" class="row">
-            <div class="col-12">
-                <div class="ngx-pop">
-                    &nbsp;
-                    <span *ngIf="popOverText?.concepto">
-                        Diente {{ popOverText.concepto.term }}
-                        <span *ngIf="popOverText?.cara && popOverText?.cara === 'anulada'">(pieza ausente)</span>
-                        <span *ngIf="popOverText?.cara && popOverText?.cara === 'pieza'">(pieza completa)</span>
-                        <span
-                              *ngIf="popOverText?.cara && popOverText?.cara !== 'pieza' && popOverText?.cara !== 'anulada'">(cara
-                            {{ popOverText.cara }})</span>
-                        <ng-container *ngIf="popOverText?.relacion?.length > 0 && showRelacion">
-                            <span *ngFor="let rel of popOverText?.relacion">
-                                <span *ngIf="rel?.concepto?.term"> - {{ rel.concepto.term }} ({{
-                                    rel.concepto.semanticTag }})</span>
-                            </span>
-                        </ng-container>
-                        <ng-container *ngIf="popOverText?.relacion?.concepto && showRelacion">
-                            - {{ popOverText.relacion.concepto.term }} ({{ popOverText.relacion.concepto.semanticTag
-                            }})
-                        </ng-container>
-                    </span>
+        <div>
+            <div *ngIf="ultimoOdontograma || odontograma" class="row">
+                <div class="col-12">
+                    <div class="ngx-pop">
+                        &nbsp;
+                        <span *ngIf="popOverText?.concepto">
+                            Diente {{ popOverText.concepto.term }}
+                            <span *ngIf="popOverText?.cara && popOverText?.cara === 'anulada'">(pieza ausente)</span>
+                            <span *ngIf="popOverText?.cara && popOverText?.cara === 'pieza'">(pieza completa)</span>
+                            <span
+                                  *ngIf="popOverText?.cara && popOverText?.cara !== 'pieza' && popOverText?.cara !== 'anulada'">(cara
+                                {{ popOverText.cara }})</span>
+                            <ng-container *ngIf="popOverText?.relacion?.length > 0 && showRelacion">
+                                <span *ngFor="let rel of popOverText?.relacion">
+                                    <span *ngIf="rel?.concepto?.term"> - {{ rel.concepto.term }} ({{
+                                        rel.concepto.semanticTag }})</span>
+                                </span>
+                            </ng-container>
+                            <ng-container *ngIf="popOverText?.relacion?.concepto && showRelacion">
+                                - {{ popOverText.relacion.concepto.term }}
+                                ({{ popOverText.relacion.concepto.semanticTag }})
+                            </ng-container>
+                        </span>
+                    </div>
                 </div>
             </div>
         </div>
 
         <!-- ÚLTIMO ODONTOGRAMA -->
-        <div class="row no-gutters cargando-odontograma" *ngIf="cargandoUltimoOdontograma">
+        <div class=" row no-gutters cargando-odontograma" *ngIf="cargandoUltimoOdontograma">
             <div class="col-12">
                 Cargando último odontograma...
             </div>
@@ -41,8 +42,8 @@
                 <h6>
                     <a *ngIf="ultimoOdontogramaIndex > 0" (click)="odontogramaAnterior()"
                        class="hover text-warning text-bold mdi mdi-24px mdi-chevron-left"></a>
-                    {{ ultimoOdontogramaIndex === odontogramasHUDS.length - 1 ? 'Último odontograma' : 'Odontograma
-                    del' }} {{ (ultimoOdontograma.createdAt | fecha)}}
+                    {{ ultimoOdontogramaIndex === odontogramasHUDS.length - 1 ? 'Último odontograma' : 'Odontograma del' }}
+                    {{ (ultimoOdontograma.createdAt | fecha)}}
                     <a *ngIf="ultimoOdontogramaIndex < odontogramasHUDS.length - 1" (click)="odontogramaSiguiente()"
                        class="hover text-warning text-bold mdi mdi-24px mdi-chevron-right"></a>
                 </h6>
@@ -61,8 +62,8 @@
                                      height="32px" x="0px" y="0px" baseProfile="basic" version="1.1" viewBox="0 0 55 50"
                                      xml:space="preserve">
                                     <!-- DISTAL/MESIAL -->
-                                    <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), true)"
-                                          (mouseleave)="hideTooltip()"
+                                    <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), true, 0)"
                                           d="M18.042,27.5c0-2.197,0.89-4.187,2.33-5.627l-9.339-9.339c-3.831,3.83-6.2,9.122-6.2,14.966c0,5.845,2.369,11.137,6.2,14.967l9.34-9.34C18.933,31.687,18.042,29.698,18.042,27.5z"
                                           class="diente distal"
                                           [ngClass]="'diente-' + classRelacion(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto?.semanticTag"
@@ -71,17 +72,20 @@
                                                   *ngIf="getRegistrosRelAnterior(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.length">
                                         <ng-container
                                                       *ngFor="let reldistal of getRegistrosRelAnterior(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')); let d=index">
-                                            <path [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')) !== -1}"
+                                            <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')) !== -1}"
                                                   d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
-                                                  class="diente distal {{ 'diente-' + reldistal.concepto.semanticTag }} diente-offset-{{d}}"
+                                                  class="diente distal {{ 'diente-' + reldistal.concepto.semanticTag }}"
                                                   title="(esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')"
-                                                  (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), true, d)"
-                                                  (mouseleave)="hideTooltip()" />
+                                                  (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), true, d)" />
+                                            <text (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  fill="#FFFFFF" x="8" y="31"
+                                                  font-size="14">{{ getRegistrosRelAnterior(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')).length }}</text>
                                         </ng-container>
                                     </ng-container>
                                     <!-- VESTIBULAR/LINGUAL -->
-                                    <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), true)"
-                                          (mouseleave)="hideTooltip()"
+                                    <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), true, 0)"
                                           d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
                                           class="diente vestibular"
                                           [ngClass]="'diente-' + classRelacion(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto?.semanticTag"
@@ -90,17 +94,20 @@
                                                   *ngIf="getRegistrosRelAnterior(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.length">
                                         <ng-container
                                                       *ngFor="let relvestibular of getRegistrosRelAnterior(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')); let v=index">
-                                            <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), true, v)"
-                                                  (mouseleave)="hideTooltip()"
+                                            <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), true, v)"
                                                   [ngClass]="{'registrada': caraValor(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')) !== -1}"
                                                   d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
-                                                  class="diente vestibular {{ 'diente-' + relvestibular.concepto.semanticTag }} diente-offset-{{v}}"
+                                                  class="diente vestibular {{ 'diente-' + relvestibular.concepto.semanticTag }}"
                                                   title="(esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')" />
+                                            <text (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  fill="#FFFFFF" x="21" y="17"
+                                                  font-size="14">{{ getRegistrosRelAnterior(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')).length }}</text>
                                         </ng-container>
                                     </ng-container>
                                     <!-- MESIAL/DISTAL -->
-                                    <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), true)"
-                                          (mouseleave)="hideTooltip()"
+                                    <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), true, 0)"
                                           d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                           class="diente mesial"
                                           [ngClass]="'diente-' + classRelacion(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto?.semanticTag"
@@ -109,17 +116,20 @@
                                                   *ngIf="getRegistrosRelAnterior(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.length">
                                         <ng-container
                                                       *ngFor="let relMesial of getRegistrosRelAnterior(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')); let m=index">
-                                            <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), true, m)"
-                                                  (mouseleave)="hideTooltip()"
+                                            <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), true, m)"
                                                   [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')) !== -1}"
                                                   d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
-                                                  class="diente mesial {{ 'diente-' + relMesial.concepto.semanticTag }} diente-offset-{{m}}"
+                                                  class="diente mesial {{ 'diente-' + relMesial.concepto.semanticTag }}"
                                                   title="(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')" />
                                         </ng-container>
                                     </ng-container>
+                                    <text (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          fill="#FFFFFF" x="37" y="32"
+                                          font-size="14">{{ getRegistrosRelAnterior(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')).length }}</text>
                                     <!-- PALATINA/VESTIBULAR -->
-                                    <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), true)"
-                                          (mouseleave)="hideTooltip()"
+                                    <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), true, 0)"
                                           d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z"
                                           class="diente palatina"
                                           [ngClass]="'diente-' + classRelacion(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto?.semanticTag"
@@ -128,16 +138,19 @@
                                                   *ngIf="getRegistrosRelAnterior(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.length">
                                         <ng-container
                                                       *ngFor="let relpalatina of getRegistrosRelAnterior(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')); let p=index">
-                                            <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), true, p)"
-                                                  (mouseleave)="hideTooltip()"
+                                            <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), true, p)"
                                                   [ngClass]="{'registrada': caraValor(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')) !== -1}"
                                                   d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z"
-                                                  class="diente palatina {{ 'diente-' + relpalatina.concepto.semanticTag }} diente-offset-{{p}}"
+                                                  class="diente palatina {{ 'diente-' + relpalatina.concepto.semanticTag }}"
                                                   title="(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')" />
                                         </ng-container>
                                     </ng-container>
-                                    <path (mouseenter)="showTooltip(diente, 'oclusal', true)"
-                                          (mouseleave)="hideTooltip()"
+                                    <text (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          fill="#FFFFFF" x="22" y="46"
+                                          font-size="14">{{ getRegistrosRelAnterior(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')).length }}</text>
+                                    <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          (mouseenter)="showTooltip(diente, 'oclusal', true, 0)"
                                           d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z"
                                           class="diente oclusal"
                                           [ngClass]="'diente-' + classRelacion(diente, 'oclusal')?.concepto?.semanticTag"
@@ -145,22 +158,28 @@
                                     <ng-container *ngIf="getRegistrosRelAnterior(diente, 'oclusal')?.length">
                                         <ng-container
                                                       *ngFor="let reloclusal of getRegistrosRelAnterior(diente, 'oclusal'); let o=index">
-                                            <path (mouseenter)="showTooltip(diente, 'oclusal', false, o)"
-                                                  (mouseleave)="hideTooltip()"
-                                                  [ngClass]="{ 'registrada': caraValor(diente, 'oclusal') !==- 1}"
+                                            <path (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  (mouseenter)="showTooltip(diente, 'oclusal', false, o)"
+                                                  [ngClass]="{ 'registrada': caraValor(diente, 'oclusal') !== -1}"
                                                   d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z "
-                                                  class="diente oclusal {{ 'diente-' + reloclusal.concepto.semanticTag }} diente-offset-{{o}} "
+                                                  class="diente oclusal {{ 'diente-' + reloclusal.concepto.semanticTag }}"
                                                   title="oclusal" />
                                         </ng-container>
                                     </ng-container>
+                                    <text (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                          fill="#FFFFFF" x="22" y="32"
+                                          font-size="14">{{ getRegistrosRelAnterior(diente, 'oclusal').length }}</text>
                                     <ng-container
                                                   *ngFor="let relClass of getRegistrosRelAnterior(diente, 'pieza'); let a=index">
                                         <g class="pieza" title="pieza completa">
                                             <!-- Círculo MINI -->
                                             <circle (mouseenter)="showTooltip(diente, 'pieza', true, a)"
-                                                    (mouseleave)="hideTooltip()" class="evolucionada" cx="46.285"
-                                                    cy="7.311" r="5.801"
-                                                    [ngClass]="'diente-' + relClass.concepto.semanticTag + ' rotate-' + a" />
+                                                    (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                    class="evolucionada" cx="46.285" cy="7.311" r="5.801"
+                                                    [ngClass]="'diente-' + relClass.concepto.semanticTag" />
+                                            <text (click)="emitEjecutarAccion($event, [diente, cuadrante, odontogramasHUDS])"
+                                                  fill="#FFFFFF" x="43" y="12"
+                                                  font-size="14">{{ getRegistrosRelAnterior(diente, 'pieza').length }}</text>
                                         </g>
                                         <!-- Círculo GRANDE -->
                                         <circle *ngIf="ultimoOdontograma && tieneEvolucion(diente, 'pieza')" cx="26"
@@ -172,7 +191,7 @@
                                      xmlns:xlink="http://www.w3.org/1999/xlink" id="cuadrante-sup-der" width="32px"
                                      height="32px" x="0px" y="0px" baseProfile="basic" version="1.1" viewBox="0 0 55 50"
                                      xml:space="preserve">
-                                    <g (mouseenter)="showTooltip(diente, 'anulada')" (mouseleave)="hideTooltip()">
+                                    <g (mouseenter)="showTooltip(diente, 'anulada')">
                                         <circle class="pieza-anulada" cx="26" cy="27.5" r="22.246">
                                         </circle>
                                         <line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" stroke-width="3"
@@ -196,7 +215,6 @@
                 <h6>Odontograma de esta consulta</h6>
             </div>
             <ng-container *ngFor="let cuadrante of cuadrantes">
-
                 <!-- CUADRANTE -->
                 <div class="col-6 no-gutters {{ cuadrante }}" *ngIf="odontograma[cuadrante].length">
                     <ng-container *ngFor="let diente of odontograma[cuadrante]; let i=index">
@@ -209,21 +227,17 @@
                                  xml:space="preserve">
 
                                 <!-- DISTAL/MESIAL -->
-                                <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
-                                      (click)="seleccionarDiente(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))"
+                                <path (click)="seleccionarDiente(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, 0, true)"
                                       [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))}"
                                       d="M18.042,27.5c0-2.197,0.89-4.187,2.33-5.627l-9.339-9.339c-3.831,3.83-6.2,9.122-6.2,14.966c0,5.845,2.369,11.137,6.2,14.967l9.34-9.34C18.933,31.687,18.042,29.698,18.042,27.5z"
                                       class="diente distal {{ 'diente-' + getClassRegistro(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto.semanticTag }}"
                                       title="(esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')" />
 
                                 <ng-container
-                                              *ngIf="getRegistrosRel(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.length">
+                                              *ngIf="getRegistrosEjecucion(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.length">
                                     <ng-container
-                                                  *ngFor="let reldistal of getRegistrosRel(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')); let d=index">
-                                        <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, d)"
-                                              (mouseleave)="hideTooltip()"
-                                              (click)="seleccionarDiente(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))"
+                                                  *ngFor="let reldistal of getRegistrosEjecucion(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')); let d=index">
+                                        <path (click)="seleccionarDiente(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, d, true)"
                                               [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))}"
                                               d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                               class="diente distal {{ 'diente-' + reldistal.concepto.semanticTag }} diente-offset-{{d}}"
@@ -232,44 +246,37 @@
                                 </ng-container>
 
                                 <!-- VESTIBULAR/LINGUAL -->
-                                <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
-                                      (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))"
+                                <path (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, 0, true)"
                                       [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))}"
                                       d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
                                       class="diente vestibular {{ 'diente-' + getClassRegistro(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto.semanticTag }}"
                                       title="(esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')" />
 
                                 <ng-container
-                                              *ngIf="getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina'))?.length">
+                                              *ngIf="getRegistrosEjecucion(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.length">
                                     <ng-container
-                                                  *ngFor="let relvestibular of getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina')); let v=index">
-                                        <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina'), false, v)"
-                                              (mouseleave)="hideTooltip()"
-                                              (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina'))"
-                                              [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina'))}"
+                                                  *ngFor="let relvestibular of getRegistrosEjecucion(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')); let v=index">
+                                        <path (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, v, true)"
+                                              [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))}"
                                               d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
                                               class="diente vestibular {{ 'diente-' + relvestibular.concepto.semanticTag }} diente-offset-{{v}}"
-                                              title="(esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina')" />
+                                              title="(esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')" />
                                     </ng-container>
                                 </ng-container>
 
                                 <!-- MESIAL/DISTAL -->
-                                <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
-                                      (click)="seleccionarDiente(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))"
+                                <path (click)="seleccionarDiente(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, 0, true)"
                                       [ngClass]="{'seleccionada': estaSeleccionada(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))}"
                                       d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                       class="diente mesial {{ 'diente-' + getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto.semanticTag }}"
                                       title="(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')" />
 
+
                                 <ng-container
-                                              *ngIf="getRegistrosRel(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.length">
+                                              *ngIf="getRegistrosEjecucion(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.length">
                                     <ng-container
-                                                  *ngFor="let relMesial of getRegistrosRel(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')); let m=index">
-                                        <path (mouseenter)="showTooltip(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, m)"
-                                              (mouseleave)="hideTooltip()"
-                                              (click)="seleccionarDiente(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))"
+                                                  *ngFor="let relMesial of getRegistrosEjecucion(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')); let m=index">
+                                        <path (click)="seleccionarDiente(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')); showTooltip(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, m, true)"
                                               [ngClass]="{'seleccionada': estaSeleccionada(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))}"
                                               d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                               class="diente mesial {{ 'diente-' + relMesial.concepto.semanticTag }} diente-offset-{{m}}"
@@ -278,22 +285,18 @@
                                 </ng-container>
 
                                 <!-- PALATINA/VESTIBULAR -->
-                                <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
-                                      (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))"
+                                <path (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, 0, true)"
                                       [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))}"
                                       d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z"
-                                      class="diente palatina {{ 'diente-' + getClassRegistro(diente,(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto.semanticTag }}"
+                                      class="diente palatina {{ 'diente-' + diente?.concepto.semanticTag }}"
                                       title="(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')" />
 
                                 <ng-container
-                                              *ngIf="getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.length">
+                                              *ngIf="getRegistrosEjecucion(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.length">
                                     <ng-container
-                                                  *ngFor="let relpalatina of getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')); let p=index">
-                                        <path (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, p)"
-                                              (mouseleave)="hideTooltip()"
-                                              (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))"
-                                              [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))}"
+                                                  *ngFor="let relpalatina of getRegistrosEjecucion(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')); let p=index">
+                                        <path (click)="seleccionarDiente(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, p, true)"
+                                              [ngClass]="{'seleccionada': estaSeleccionada(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'palatina'))}"
                                               d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z"
                                               class="diente palatina {{ 'diente-' + relpalatina.concepto.semanticTag }} diente-offset-{{p}}"
                                               title="(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')" />
@@ -301,19 +304,16 @@
                                 </ng-container>
 
                                 <!-- OCLUSAL -->
-                                <path (mouseenter)="showTooltip(diente, 'oclusal', false, 0)"
-                                      (mouseleave)="hideTooltip()" (click)="seleccionarDiente(diente, 'oclusal')"
+                                <path (click)="seleccionarDiente(diente, 'oclusal'); showTooltip(diente, 'oclusal', false, 0, true)"
                                       [ngClass]="{'seleccionada': estaSeleccionada(diente, 'oclusal')}"
                                       d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z"
                                       class="diente oclusal {{ 'diente-' + getClassRegistro(diente, 'oclusal')?.concepto.semanticTag }}"
                                       title="oclusal" />
-                                <ng-container *ngIf="getRegistrosRel(diente, 'oclusal')?.length">
+                                <ng-container *ngIf="getRegistrosEjecucion(diente, 'oclusal')?.length">
                                     <ng-container
-                                                  *ngFor="let reloclusal of getRegistrosRel(diente, 'oclusal'); let o=index">
-                                        <path (mouseenter)="showTooltip(diente, 'oclusal', false, o)"
-                                              (mouseleave)="hideTooltip()"
-                                              (click)="seleccionarDiente(diente, 'oclusal')"
-                                              [ngClass]="{'seleccionada': estaSeleccionada(diente, 'oclusal')}"
+                                                  *ngFor="let reloclusal of getRegistrosEjecucion(diente, 'oclusal'); let o=index">
+                                        <path (click)="seleccionarDiente(diente, 'oclusal'); showTooltip(diente, 'oclusal', false, o, true)"
+                                              [ngClass]="{ 'registrada': caraValor(diente, 'oclusal') !==- 1}"
                                               d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z "
                                               class="diente oclusal {{ 'diente-' + reloclusal.concepto.semanticTag }} diente-offset-{{o}} "
                                               title="oclusal" />
@@ -321,10 +321,12 @@
                                 </ng-container>
 
                                 <!-- PIEZA -->
-                                <g class="pieza" (click)="seleccionarPieza(diente, 'pieza')" title="pieza completa"
-                                   (mouseenter)="showTooltip(diente, false, 0)" (mouseleave)="hideTooltip()">
+                                <g class="pieza"
+                                   (click)="seleccionarPieza(diente, 'pieza'); showTooltip(diente, 'pieza', false, 0, true)"
+                                   title="pieza completa">
                                     <!-- Círculo MINI -->
-                                    <circle class="st1" [ngClass]="{'seleccionada': estaSeleccionada(diente, 'pieza')}"
+                                    <circle class="st1"
+                                            [ngClass]="{'seleccionada': estaSeleccionada(diente, 'pieza', false, -1, true)}"
                                             cx="46.285" cy="7.311" r="5.801" />
                                     <path [ngClass]="{'seleccionada': estaSeleccionada(diente, 'pieza')}"
                                           d="M50.668,5.782l-2.925,1.534l2.925,1.542l-0.674,1.25l-2.951-1.631v3.049h-1.507V8.477l-2.961,1.631l-0.674-1.25l2.961-1.542l-2.961-1.534l0.674-1.25l2.961,1.613V3.096h1.507v3.049l2.951-1.613L50.668,5.782z" />
@@ -332,14 +334,13 @@
                                     <circle cx="26" cy="27.5" r="22.246"
                                             [ngClass]="{'seleccionada-outline': estaSeleccionada(diente, 'pieza')}" />
                                 </g>
-                                <ng-container *ngIf="getRegistrosRel(diente, 'pieza')?.length">
+                                <ng-container *ngIf="getRegistrosEjecucion(diente, 'pieza')?.length">
                                     <ng-container
-                                                  *ngFor="let relClass of getRegistrosRel(diente, 'pieza'); let pc=index">
+                                                  *ngFor="let relClass of getRegistrosEjecucion(diente, 'pieza'); let pc=index">
                                         <g title="pieza completa">
                                             <!-- Círculo MINI -->
-                                            <circle (mouseenter)="showTooltip(diente, 'pieza', false, pc)"
-                                                    (mouseleave)="hideTooltip()"
-                                                    class="st1 {{ 'diente-' + relClass.concepto.semanticTag + ' rotate-' + pc }} {{ 'diente-' + getClassRegistro(diente, 'pieza')?.concepto.semanticTag }}"
+                                            <circle (click)="showTooltip(diente, 'pieza', false, pc, true)"
+                                                    class="st1 {{ 'diente-' + relClass.concepto.semanticTag + ' rotate-' + pc }}"
                                                     [ngClass]="{'seleccionada': estaSeleccionada(diente, 'pieza')}"
                                                     cx="46.285" cy="7.311" r="5.801" />
                                             <!-- Asterisco -->
@@ -358,7 +359,7 @@
                                  xmlns:xlink="http://www.w3.org/1999/xlink" id="cuadrante-sup-der" width="32px"
                                  height="32px" x="0px" y="0px" baseProfile="basic" version="1.1" viewBox="0 0 55 50"
                                  xml:space="preserve">
-                                <g (mouseenter)="showTooltip(diente, 'anulada')" (mouseleave)="hideTooltip()">
+                                <g (click)="showTooltip(diente, 'anulada', false, -1, true)">
                                     <circle class="pieza completa pieza-anulada" cx="26" cy="27.5" r="22.246">
                                     </circle>
                                     <line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" stroke-width="3" x1="8"
@@ -435,9 +436,7 @@
                                  height="32px" x="0px" y="0px" baseProfile="basic" version="1.1" viewBox="0 0 55 50"
                                  xml:space="preserve">
                                 <!-- DISTAL/MESIAL -->
-                                <path (click)="jumpToId(getClassRegistro(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto.conceptId)"
-                                      (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
+                                <path (click)="jumpToId(getClassRegistro(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto.conceptId); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, 0)"
                                       [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')) !== -1}"
                                       d="M18.042,27.5c0-2.197,0.89-4.187,2.33-5.627l-9.339-9.339c-3.831,3.83-6.2,9.122-6.2,14.966c0,5.845,2.369,11.137,6.2,14.967l9.34-9.34C18.933,31.687,18.042,29.698,18.042,27.5z"
                                       class="diente distal {{ 'diente-' + getClassRegistro(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto.semanticTag }}"
@@ -446,9 +445,7 @@
                                               *ngIf="getRegistrosRel(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.length">
                                     <ng-container
                                                   *ngFor="let reldistal of getRegistrosRel(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')); let d=index">
-                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto.conceptId)"
-                                              (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, d)"
-                                              (mouseleave)="hideTooltip()"
+                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'))?.concepto.conceptId); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial'), false, d);"
                                               [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'distal' : 'mesial')) !== -1}"
                                               d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                               class="diente distal {{ 'diente-' + reldistal.concepto.semanticTag }} diente-offset-{{d}}"
@@ -456,9 +453,7 @@
                                     </ng-container>
                                 </ng-container>
                                 <!-- VESTIBULAR/LINGUAL -->
-                                <path (click)="jumpToId(getClassRegistro(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto.conceptId)"
-                                      (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
+                                <path (click)="jumpToId(getClassRegistro(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto.conceptId); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, 0)"
                                       [ngClass]="{'registrada': caraValor(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')) !== -1}"
                                       d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
                                       class="diente vestibular {{ 'diente-' + getClassRegistro(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto.semanticTag }}"
@@ -467,9 +462,7 @@
                                               *ngIf="getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.length">
                                     <ng-container
                                                   *ngFor="let relvestibular of getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')); let v=index">
-                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto.conceptId)"
-                                              (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, v)"
-                                              (mouseleave)="hideTooltip()"
+                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'))?.concepto.conceptId); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual'), false, v)"
                                               [ngClass]="{'registrada': caraValor(diente, (esCuadranteInferior(cuadrante) ? 'vestibular' : 'lingual')) !== -1}"
                                               d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
                                               class="diente vestibular {{ 'diente-' + relvestibular.concepto.semanticTag }} diente-offset-{{v}}"
@@ -477,9 +470,7 @@
                                     </ng-container>
                                 </ng-container>
                                 <!-- MESIAL/DISTAL -->
-                                <path (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
-                                      (click)="jumpToId(getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto.conceptId)"
+                                <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto.conceptId); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, 0)"
                                       [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')) !== -1}"
                                       d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                       class="diente mesial {{ 'diente-' + getClassRegistro(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto.semanticTag }}"
@@ -488,9 +479,7 @@
                                               *ngIf="getRegistrosRel(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.length">
                                     <ng-container
                                                   *ngFor="let relMesial of getRegistrosRel(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')); let m=index">
-                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto.conceptId)"
-                                              (mouseenter)="showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, m)"
-                                              (mouseleave)="hideTooltip()"
+                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'))?.concepto.conceptId); showTooltip(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal'), false, m)"
                                               [ngClass]="{'registrada': caraValor(diente, (esCuadranteIzquierdo(cuadrante) ? 'mesial' : 'distal')) !== -1}"
                                               d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
                                               class="diente mesial {{ 'diente-' + relMesial.concepto.semanticTag }} diente-offset-{{m}}"
@@ -498,9 +487,7 @@
                                     </ng-container>
                                 </ng-container>
                                 <!-- PALATINA/VESTIBULAR -->
-                                <path (click)="jumpToId(getClassRegistro(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto.conceptId)"
-                                      (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, 0)"
-                                      (mouseleave)="hideTooltip()"
+                                <path (click)="jumpToId(getClassRegistro(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto.conceptId); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, 0)"
                                       [ngClass]="{'registrada': caraValor(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')) !== -1}"
                                       d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z "
                                       class="diente palatina {{ caraValor(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')) !==- 1 ? 'diente-' + getClassRegistro(diente,(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto.semanticTag : '' }}"
@@ -509,9 +496,7 @@
                                               *ngIf="getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.length">
                                     <ng-container
                                                   *ngFor="let relpalatina of getRegistrosRel(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')); let p=index">
-                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto.conceptId)"
-                                              (mouseenter)="showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, p)"
-                                              (mouseleave)="hideTooltip()"
+                                        <path (click)="jumpToId(getClassRegistro(diente,(esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'))?.concepto.conceptId); showTooltip(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular'), false, p)"
                                               [ngClass]="{ 'registrada': caraValor(diente, (esCuadranteInferior(cuadrante) ? 'palatina' : 'vestibular')) !==- 1}"
                                               d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z "
                                               class="diente palatina {{ 'diente-' + relpalatina.concepto.semanticTag }} diente-offset-{{p}} "
@@ -519,9 +504,7 @@
                                     </ng-container>
                                 </ng-container>
                                 <!-- OCLUSAL -->
-                                <path (click)="jumpToId(getClassRegistro(diente,'oclusal')?.concepto.conceptId)"
-                                      (mouseenter)="showTooltip(diente, 'oclusal', false, 0)"
-                                      (mouseleave)="hideTooltip()"
+                                <path (click)="jumpToId(getClassRegistro(diente,'oclusal')?.concepto.conceptId); showTooltip(diente, 'oclusal', false, 0)"
                                       [ngClass]="{ 'registrada': caraValor(diente, 'oclusal') !==- 1} "
                                       d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z "
                                       class="diente oclusal {{ 'diente-' + getClassRegistro(diente, 'oclusal')?.concepto.semanticTag }} "
@@ -529,9 +512,7 @@
                                 <ng-container *ngIf="getRegistrosRel(diente, 'oclusal')?.length">
                                     <ng-container
                                                   *ngFor="let reloclusal of getRegistrosRel(diente, 'oclusal'); let o=index">
-                                        <path (click)="jumpToId(getClassRegistro(diente,'oclusal')?.concepto.conceptId)"
-                                              (mouseenter)="showTooltip(diente, 'oclusal', false, o)"
-                                              (mouseleave)="hideTooltip()"
+                                        <path (click)="jumpToId(getClassRegistro(diente,'oclusal')?.concepto.conceptId); showTooltip(diente, 'oclusal', false, o)"
                                               [ngClass]="{ 'registrada': caraValor(diente, 'oclusal') !==- 1}"
                                               d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z "
                                               class="diente oclusal {{ 'diente-' + reloclusal.concepto.semanticTag }} diente-offset-{{o}} "
@@ -541,8 +522,7 @@
 
                                 <!-- PIEZA COMPLETA -->
                                 <g class="pieza" title="pieza completa"
-                                   (click)="jumpToId(getClassRegistro(diente,'pieza')?.concepto.conceptId)"
-                                   (mouseenter)="showTooltip(diente, 'pieza', false, 0)">
+                                   (click)="jumpToId(getClassRegistro(diente,'pieza')?.concepto.conceptId); showTooltip(diente, 'pieza', false, 0)">
                                     <!-- Círculo MINI -->
                                     <circle class="st1"
                                             [ngClass]="piezaCompletaValor(diente, 'pieza') !== -1 ? 'diente-' + getClassRegistro(diente, 'pieza')?.concepto.semanticTag : '' "
@@ -554,8 +534,8 @@
                                 <ng-container *ngIf="getRegistrosRel(diente, 'pieza')?.length">
                                     <ng-container
                                                   *ngFor="let relClass of getRegistrosRel(diente, 'pieza'); let a=index">
-                                        <g (mouseenter)="showTooltip(diente, 'pieza', false, a)"
-                                           (mouseleave)="hideTooltip()" class="pieza" title="pieza completa">
+                                        <g (click)="showTooltip(diente, 'pieza', false, a)" class="pieza"
+                                           title="pieza completa">
                                             <!-- Círculo MINI -->
                                             <circle *ngIf="relClass?.concepto?.semanticTag" cx="46.285" cy="7.311"
                                                     r="5.801" class="st1"
@@ -573,7 +553,7 @@
                                  xmlns:xlink="http://www.w3.org/1999/xlink" id="cuadrante-sup-der" width="32px"
                                  height="32px" x="0px" y="0px" baseProfile="basic" version="1.1 " viewBox="0 0 55 50"
                                  xml:space="preserve">
-                                <g (mouseenter)="showTooltip(diente, 'anulada')" (mouseleave)="hideTooltip()">
+                                <g (click)="showTooltip(diente, 'anulada')" (mouseleave)="hideTooltip()">
                                     <circle class="pieza completa pieza-anulada" cx="26" cy="27.5" r="22.246">
                                     </circle>
                                     <line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" stroke-width="3" x1="8"

--- a/src/app/modules/rup/components/elementos/OdontogramaRefset.scss
+++ b/src/app/modules/rup/components/elementos/OdontogramaRefset.scss
@@ -1,4 +1,5 @@
 @import '../variables';
+
 @mixin ultimo-odontograma-container {
     background: rgba(133, 133, 133, 0.4);
     border-radius: 5px;
@@ -20,8 +21,10 @@
     height: 285px;
     padding: 15px 0;
     @include ultimo-odontograma-container();
+
     .title {
         height: 35px;
+
         h6 {
             display: flex;
             align-items: center;
@@ -29,15 +32,18 @@
             margin: 0;
         }
     }
+
     .toggle-último {
         display: inline-block;
         position: relative;
         right: 7px;
     }
+
     &.hidden {
         height: 43px;
         transition: height ease 600ms;
     }
+
     &.visible {
         height: 285px;
         transition: height ease 600ms;
@@ -70,6 +76,13 @@
 
 svg {
     overflow: visible;
+    text {
+        cursor: pointer;
+        pointer-events: auto;
+        &:focus {
+            outline: none;
+        }
+    }
 }
 
 svg#cuadrante-sup-der {
@@ -82,8 +95,13 @@ svg#cuadrante-sup-der {
     stroke-width: 3px solid #4776d3;
     stroke-miterlimit: 10;
     cursor: pointer;
+
     &:hover {
         fill: #4776d3;
+    }
+
+    &:focus {
+        outline: none;
     }
 }
 
@@ -148,6 +166,7 @@ svg#cuadrante-sup-der {
     stroke: rgb(133, 133, 133);
     stroke-width: 1;
     stroke-miterlimit: 10;
+
     &.seleccionada {
         stroke: #36877f !important;
     }
@@ -173,15 +192,19 @@ svg#cuadrante-sup-der {
 
 .registrada {
     fill: rgb(133, 133, 133);
+
     &.pieza-hallazgo {
         fill: $hallazgo
     }
+
     &.pieza-trastorno {
         fill: $trastorno
     }
+
     &.pieza-procedimiento {
         fill: $procedimiento
     }
+
     &.pieza-plan {
         fill: $solicitud
     }
@@ -193,34 +216,43 @@ circle {
 
 $angles: (13deg: 10px, 26deg: 17px, 39deg: 20px, 51deg: 23px, 56deg: 26px);
 $i: 1;
+
 @each $rotation,
 $translation in $angles {
     .rotate-#{$i} {
         transform: scale(1.025, 1.025) translateX(-#{$i}px) rotateZ($rotation) translateX($translation);
     }
+
     .diente-offset-#{$i} {
         &.vestibular {
             transform: scale(1, 1) translateY(-#{$i * 8}px);
         }
+
         &.mesial {
             transform: scale(1, 1) translate(#{$i * 8}px);
         }
+
         &.distal {
             transform: scale(-1, 1) translate(-#{$i * 45}px);
         }
+
         &.palatina {
             transform: scale(1, 1) translateY(#{$i * 8}px);
         }
+
         &.oclusal {
             transform: scale(1, 1) translateX(#{$i * 6}px) translateY(#{$i * 6}px);
         }
+
         z-index: #{$i * 10};
     }
+
     $i: ($i+1);
 }
 
 .pieza {
     cursor: pointer;
+
     &:hover {
         fill: #4776d3;
     }
@@ -230,6 +262,7 @@ $translation in $angles {
     display: inline-block;
     width: 40px;
     font-size: 12px;
+
     .text-diente {
         font-size: 16px;
     }
@@ -240,6 +273,7 @@ $translation in $angles {
     color: black;
     padding: 10px;
     text-align: center;
+
     .readonly,
     span {
         display: inline-block !important;
@@ -252,4 +286,35 @@ $translation in $angles {
 
 .margin-fix {
     bottom: 3px;
+}
+
+
+/* Tooltip container */
+.tooltip {
+    position: relative;
+    display: inline-block;
+    border-bottom: 1px dotted black;
+    /* If you want dots under the hoverable text */
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+    visibility: hidden;
+    width: 120px;
+    background-color: #555;
+    color: #fff;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;
+
+    /* Position the tooltip text */
+    position: absolute;
+    z-index: 1;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -60px;
+
+    /* Fade in tooltip */
+    opacity: 0;
+    transition: opacity 0.3s;
 }

--- a/src/app/modules/rup/components/huds/vistaDetalleRegistro.html
+++ b/src/app/modules/rup/components/huds/vistaDetalleRegistro.html
@@ -1,0 +1,120 @@
+<ng-container class="" *ngIf="detalleConcepto && tipo === 'odontograma'">
+    <div justify class="w-100">
+        <div class="w-25 mr-4">
+            <div class="card d-flex align-items-center justify-content-center">
+                <svg class="card-img-top" *ngIf="true" xmlns="http://www.w3.org/2000/svg"
+                     xmlns:xlink="http://www.w3.org/1999/xlink" id="cuadrante-sup-der" width="200px" height="200px"
+                     x="0px" y="0px" baseProfile="basic" version="1.1" viewBox="0 0 50 50" xml:space="preserve">
+                    <!-- DISTAL/MESIAL -->
+                    <path d="M18.042,27.5c0-2.197,0.89-4.187,2.33-5.627l-9.339-9.339c-3.831,3.83-6.2,9.122-6.2,14.966c0,5.845,2.369,11.137,6.2,14.967l9.34-9.34C18.933,31.687,18.042,29.698,18.042,27.5z"
+                          class="diente {{ detalleConcepto.cara }}" data-id="{{ detalleConcepto.cara }}"
+                          [ngClass]="(detalleConcepto.cara === 'distal' && !esCuadranteIzquierdo(detalleConcepto.caraCuadrante)) || (detalleConcepto.cara === 'mesial' && esCuadranteIzquierdo(detalleConcepto.caraCuadrante)) ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag : ''" />
+
+                    <!-- VESTIBULAR/LINGUAL -->
+                    <path d="M26,19.542c2.197,0,4.187,0.891,5.627,2.331l9.34-9.339c-3.831-3.831-9.122-6.2-14.967-6.2c-5.845,0-11.137,2.369-14.967,6.2l9.339,9.339C21.813,20.433,23.802,19.542,26,19.542z"
+                          class="diente {{ detalleConcepto.cara }}"
+                          [ngClass]="(detalleConcepto.cara === 'vestibular' && !esCuadranteInferior(detalleConcepto.caraCuadrante)) || (detalleConcepto.cara === 'lingual' && esCuadranteInferior(detalleConcepto.caraCuadrante)) ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag : ''"
+                          title="" />
+
+                    <!-- MESIAL/DISTAL -->
+                    <path d="M40.967,12.533l-9.34,9.339c1.44,1.44,2.331,3.43,2.331,5.627c0,2.198-0.891,4.188-2.332,5.628l9.34,9.34c3.831-3.831,6.2-9.123,6.2-14.968C47.167,21.655,44.797,16.363,40.967,12.533z"
+                          class="diente {{ detalleConcepto.cara }}"
+                          [ngClass]="((detalleConcepto.cara === 'mesial' && !esCuadranteIzquierdo(detalleConcepto.caraCuadrante)) || (detalleConcepto.cara === 'distal' && esCuadranteIzquierdo(detalleConcepto.caraCuadrante))) ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag : ''"
+                          title="" />
+
+                    <!-- PALATINA/VESTIBULAR -->
+                    <path d="M26,35.458c-2.198,0-4.188-0.891-5.627-2.331l-9.34,9.34c3.831,3.831,9.122,6.2,14.967,6.2c5.845,0,11.136-2.369,14.966-6.199l-9.34-9.34C30.187,34.567,28.198,35.458,26,35.458z"
+                          class="diente {{ detalleConcepto.cara }}"
+                          [ngClass]="(detalleConcepto.cara === 'palatina' && !esCuadranteInferior(detalleConcepto.caraCuadrante)) || (detalleConcepto.cara === 'vestibular' && esCuadranteInferior(detalleConcepto.caraCuadrante)) ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag : ''"
+                          title="" />
+
+                    <!-- OCLUSAL -->
+                    <path d="M26,19.542c-2.198,0-4.188,0.891-5.628,2.331c-1.44,1.44-2.33,3.43-2.33,5.627c0,2.198,0.891,4.188,2.331,5.627s3.429,2.331,5.627,2.331c2.197,0,4.187-0.89,5.626-2.33c1.44-1.44,2.332-3.43,2.332-5.628c0-2.197-0.891-4.187-2.331-5.627C30.188,20.433,28.198,19.542,26,19.542z"
+                          class="diente {{ detalleConcepto.cara }}"
+                          [ngClass]="detalleConcepto.cara === 'oclusal' ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag : ''"
+                          title="oclusal" />
+
+                    <!-- PIEZA COMPLETA -->
+                    <g class="pieza" title="pieza completa">
+                        <!-- Círculo MINI -->
+                        <circle class="evolucionada" cx="46.285" cy="7.311" r="5.801"
+                                [ngClass]="detalleConcepto?.cara === 'pieza' ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag : ''">
+                        </circle>
+                    </g>
+                    <!-- Círculo GRANDE -->
+                    <circle *ngIf="true" cx="26" cy="27.5" r="22.246"
+                            [ngClass]="detalleConcepto?.cara === 'pieza' ? 'diente-' + detalleConcepto?.relacion?.concepto?.semanticTag + '-outline' : ''">
+                    </circle>
+                </svg>
+                <div class="card-body d-flex justify-content-center mt-4">
+                    <h5 class="card-title">Diente {{ detalleConcepto.concepto.term }} - ({{ detalleConcepto.cara }})
+                    </h5>
+                </div>
+            </div>
+        </div>
+
+        <div class="w-75" *ngIf="historial.length > 0">
+
+            <div class="w-100" justify>
+                <div class="col-2 font-weight-bold">Historial</div>
+                <div class="col font-weight-bold">Registro</div>
+                <div class="col-3 font-weight-bold">Profesional</div>
+                <div class="col-2 font-weight-bold">Tipo</div>
+            </div>
+            <ng-container *ngFor="let registro of relaciones; let i=index">
+                <div *ngIf="registro?.concepto" class="w-100 hover pr-3" justify
+                     [ngClass]="(estaSeleccionado(registro, detalleConcepto) ? 'selected selected-' + registro.semanticTag : 'dummy-border')"
+                     (mouseenter)="mostrarRegistro(i)">
+                    <div class="col-2 d-flex align-items-center mr-1">
+                        <span class="badge badge-primary" *ngIf="registro?.updatedAt">
+                            {{ registro?.updatedAt | date:'dd/mm/yyyy HH:mm' }}
+                            <span class="join-items" *ngIf="i < relaciones.length-1">
+                                <span class="join-line"></span>
+                            </span>
+                        </span>
+                        <span class="badge badge-primary" *ngIf="!registro?.updatedAt">
+                            {{ registro?.createdAt | date:'dd/mm/yyyy HH:mm' }}
+                            <span class="join-items">
+                                <span class="join-line"></span>
+                            </span>
+                        </span>
+                    </div>
+                    <div class="col text-capitalize line-height-12 d-flex align-items-center">
+                        <small>
+                            {{ registro.term }}
+                        </small>
+                    </div>
+                    <div class="col-3 text-capitalize">
+                        <small>
+                            {{ registro.profesional | profesional }}
+                        </small>
+                    </div>
+                    <div class="col-2 d-flex align-items-center">
+                        <span class="badge badge-{{ registro?.semanticTag }}">
+                            {{ registro?.semanticTag }}
+                        </span>
+                    </div>
+                </div>
+            </ng-container>
+        </div>
+        <!-- <plex-list class="w-75" [striped]="true">
+                    <plex-heading>
+                        <b label>Historial</b>
+                        <b label>Concepto</b>
+                        <b label>Profesional</b>
+                        <b label>Tipo</b>
+                    </plex-heading>
+                    <plex-item *ngFor="let registro of relaciones; let i=index">
+                        <plex-label *ngIf="registro?.updatedAt">{{ registro.updatedAt | fecha }}</plex-label>
+                        <plex-label *ngIf="!registro?.updatedAt">{{ registro.createdAt | fecha }}</plex-label>
+                        <plex-label [tituloBold]="false" [titulo]="detalleConcepto.relacion.concepto.term">
+                        </plex-label>
+                        <plex-label>
+                            {{ registro.profesional | profesional }}
+                        </plex-label>
+                        <span badge class="badge badge-{{ registro.semanticTag }}">
+                            {{ registro.semanticTag }}</span>
+                    </plex-item>
+                </plex-list> -->
+    </div>
+</ng-container>

--- a/src/app/modules/rup/components/huds/vistaDetalleRegistro.scss
+++ b/src/app/modules/rup/components/huds/vistaDetalleRegistro.scss
@@ -1,0 +1,7 @@
+
+.dummy-border {
+    border: 1px solid transparent;
+}
+.line-height-12 {
+    line-height: 12px;
+}

--- a/src/app/modules/rup/components/huds/vistaDetalleRegistro.ts
+++ b/src/app/modules/rup/components/huds/vistaDetalleRegistro.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit, ViewEncapsulation, Input, OnChanges } from '@angular/core';
+import { IElementoRUP } from '../../interfaces/elementoRUP.interface';
+import { IPrestacion } from '../../interfaces/prestacion.interface';
+
+@Component({
+    selector: 'vista-detalle-registro',
+    templateUrl: 'vistaDetalleRegistro.html',
+    styleUrls: [
+        `../elementos/OdontogramaRefset.scss`,
+        `../variables.scss`,
+        'vistaDetalleRegistro.scss'
+    ]
+})
+
+export class VistaDetalleRegistroComponent implements OnChanges {
+
+    @Input() detalleRegistros: any;
+    @Input() detalleConcepto: any;
+    @Input() tipo: any;
+    @Input() indice = 0;
+    historial: any[] = [];
+    relaciones: any[] = [];
+
+    constructor() { }
+
+    ngOnChanges() {
+        this.historial = [];
+        this.relaciones = [];
+        this.detalleRegistros.map(huds => {
+            return huds.ejecucion.registros.map(registros => {
+                return registros.relacionadoCon.map(relacion => {
+                    if (relacion.concepto.conceptId === this.detalleConcepto.concepto.conceptId) {
+                        this.historial.push(registros);
+                    }
+                });
+            });
+        });
+
+        this.detalleRegistros.forEach(unaConsulta => {
+            let registros = unaConsulta.ejecucion.registros.filter(c => c.concepto.conceptId !== '3561000013109');
+            this.relaciones = [...this.relaciones, ...registros];
+        });
+
+
+
+        this.relaciones = this.relaciones.map(x => {
+            return ({
+                conceptos: x.relacionadoCon.filter(y => {
+                    return y.concepto.conceptId === this.detalleConcepto.concepto.conceptId;
+                }).map(z =>
+                    z = ({ ...z, ...x.concepto, ...{ createdAt: x.createdAt }, ...{ updatedAt: x.updatedAt }, ...{ profesional: x.createdBy } }))
+            });
+        });
+
+        this.relaciones = this.relaciones.reduce((acc, val) => acc.concat(val.conceptos), []).sort((a, b) => b.createdAt - a.createdAt);
+
+    }
+
+
+    getRegistrosRelAnterior(st, cara) {
+        return this.relaciones.find(x => {
+            if (x.relacionadoCon) {
+                return x.relacionadoCon.find(y => {
+                    return y.cara === cara;
+                });
+            }
+        });
+    }
+
+    datosPieza(registro, cara) {
+        return registro.relacionadoCon.find(x => x.cara === cara);
+    }
+
+    mostrarRegistro(idx) {
+        this.detalleConcepto['cara'] = this.relaciones[idx].cara;
+        this.detalleConcepto['relacion'] = this.relaciones[idx];
+        this.detalleConcepto['relacion']['concepto'] = {
+            term: this.relaciones[idx].term,
+            fsn: this.relaciones[idx].fsn,
+            conceptId: this.relaciones[idx].conceptId,
+            semanticTag: this.relaciones[idx].semanticTag,
+            refsetIds: this.relaciones[idx].term
+        };
+        this.detalleConcepto['createdAt'] = this.relaciones[idx].createdAt;
+        this.detalleConcepto['updatedAt'] = this.relaciones[idx].updatedAt;
+
+    }
+
+    estaSeleccionado(seleccion, actual) {
+        return seleccion.cara === actual.cara && seleccion.semanticTag === actual.relacion.semanticTag;
+    }
+
+    esCuadranteIzquierdo(cuadrante) {
+        return cuadrante.indexOf('Izquierdo') > -1;
+    }
+
+    esCuadranteInferior(cuadrante) {
+        return cuadrante.indexOf('Inferior') > -1;
+    }
+
+}
+

--- a/src/app/modules/rup/components/huds/vistaSolicitudTop.ts
+++ b/src/app/modules/rup/components/huds/vistaSolicitudTop.ts
@@ -22,7 +22,6 @@ export class VistaSolicitudTopComponent implements OnInit {
         if (this.estado === 'rechazada') {
             this.motivoRechazo = this.registro.estados[this.registro.estados.length - 1].motivoRechazo;
         }
-        console.log('estado ', this.estado);
         if (this.registro.solicitud.turno) {
             let params = {
                 id: this.registro.solicitud.turno

--- a/src/app/modules/rup/components/variables.scss
+++ b/src/app/modules/rup/components/variables.scss
@@ -35,8 +35,6 @@ $rup_colors: (problema: $problema,
     solicitud: $solicitud,
     plan: $solicitud,
     producto: $producto,
-    'medicamento.clínico': $producto,
-    'objeto.físico': $producto,
     adjunto: $adjunto,
     vacuna: $vacuna,
     elemento: $registro,
@@ -55,11 +53,27 @@ $rup_colors: (problema: $problema,
     border: 1px solid !important;
 }
 
-.btn-icon-relacion {
-    padding: .15rem;
+// Items
+@mixin selected($color) {
+    border: 1px solid $color;
+    background: transparentize($color, .90);
 }
 
-// Hacer que los badges sean del mismo ancho, más legibles cuando son muchos
-.badge-170 {
-    min-width: 170px;
+@each $tag,
+$color in $rup_colors {
+    .selected.selected-#{$tag} {
+        @include selected($color);
+    }
+}
+
+.join-items {
+    .join-line {
+        width: 2px;
+        height: 100%;
+        background: #0275d8;
+        z-index: 0;
+        position: absolute;
+        left: 45%;
+        top: 20px;
+    }
 }

--- a/src/app/modules/rup/interfaces/prestacion.registro.interface.ts
+++ b/src/app/modules/rup/interfaces/prestacion.registro.interface.ts
@@ -4,7 +4,7 @@ import { ObjectID } from 'bson';
 import { IPaciente } from '../../../core/mpi/interfaces/IPaciente';
 
 export class IRegistroPrivacy {
-    scope: String;
+    scope: string;
 }
 
 export class IPrestacionRegistro {

--- a/src/app/modules/rup/services/elementosRUP.service.ts
+++ b/src/app/modules/rup/services/elementosRUP.service.ts
@@ -209,5 +209,15 @@ export class ElementosRUPService {
         return conceptosInternacion;
     }
 
+    desvincularOdontograma(registrosRelacionados, regitroActual, registroId) {
+        if (registrosRelacionados[registroId] && registrosRelacionados[registroId].cara) {
+            const cara = registrosRelacionados[registroId].cara;
+            const term = registrosRelacionados[registroId].concepto.term;
+            return regitroActual.relacionadoCon.filter(rr => rr.cara !== cara || rr.concepto.term !== term);
+        } else {
+            return regitroActual.relacionadoCon;
+        }
+    }
+
 
 }

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -922,4 +922,16 @@ export class PrestacionesService {
         return this.server.get(this.prestacionesUrl + '/sincama', { params: params, showError: true });
     }
 
+    getFriendlyName(registro) {
+        let nombre = (registro && registro.concepto && registro.concepto.term) ? registro.concepto.term : '';
+
+        // Odontograma?
+        if (registro && registro.cara) {
+            nombre = `Diente ${nombre} (${registro.cara !== 'pieza completa' ? registro.cara : `cara ${registro.cara}`})`;
+        }
+
+        return nombre;
+
+    }
+
 }

--- a/src/app/services/turnos/configPrestacion.service.ts
+++ b/src/app/services/turnos/configPrestacion.service.ts
@@ -24,7 +24,6 @@ export class ConfigPrestacionService {
         alert('Reimplementar con Server');
         throw new Error('Reimplementar con Server');
         // let bodyString = JSON.stringify(prestacion); // Stringify payload
-        // console.log(bodyString);
         // let headers = new Headers({ 'Content-Type': 'application/json' }); // ... Set content type to JSON
         // let options = new RequestOptions({ headers: headers }); // Create a request option
         // return this.http.post(this.configPrestacionUrl, bodyString, options) // ...using post request

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -6,7 +6,7 @@ export const environment = {
   production: false,
   environmentName: 'development',
   WS: '//localhost:3002',
-  API: '//localhost:3002/api',
+  API: 'https://demo.andes.gob.ar/api',
   APIStatusCheck: false,
   version: _package.version,
   MAPS_KEY: apiKeys.develop

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
-    "extends": ["codelyzer"],
+    "extends": [
+        "codelyzer"
+    ],
     "rules": {
         "callable-types": true,
         "class-name": true,
@@ -30,7 +32,11 @@
         ],
         "no-arg": true,
         "no-bitwise": true,
-        "no-console": [false, "log", "error"],
+        "no-console": [
+            true,
+            "log",
+            "error"
+        ],
         "no-construct": true,
         "no-debugger": true,
         "no-duplicate-variable": true,


### PR DESCRIPTION
### Requerimiento
https://pm.andes.gob.ar/projects/rup/work_packages/741/activity

### Funcionalidad desarrollada 
1. Se agregó un componente que muestra detalles de una pieza dental y visualiza los registros históricos de la misma, de manera interactiva
2. Se cambió la manera en que se muestran los odontogramas validados, se muestra el número de registros con dígitos en lugar de elementos SVG.

### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [X] No

![image](https://user-images.githubusercontent.com/11394455/62728994-68ec0300-b9f3-11e9-9f06-123bad3d97e1.png)

