### PR TITLE
AGENDAS - Restricción de búsqueda de prestaciones

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -28,10 +28,10 @@
                 <div *ngIf="!showPrestacion" class='col-2'>
                     <label>
                         <!--Spacer-->&nbsp;</label>
-                    <plex-button type="success" label="Buscar" (click)="refreshSelection($event, 'filter')">
+                    <plex-button type="success" label="Buscar" (click)="refreshSelection($event, 'filter')" [disabled]='botonGuardarDisabled' >
                     </plex-button>
                 </div>
-                <div *ngIf="!showPrestacion" class='col text-right'>
+                <div *ngIf="!showPrestacion" class='col text-right'>    
                     <label>
                         <!--Spacer-->&nbsp;</label>
                     <plex-button type="default" [icon]="mostrarMasOpciones ? 'chevron-up' : 'chevron-down'" (click)="mostrarMasOpciones = !mostrarMasOpciones"


### PR DESCRIPTION
Restringe la búsqueda de prestaciones, de manera cada búsqueda se pueda hacer solo dentro de único mes y habiendo seleccionado filtro de prestaciones o documento de paciente. Adicionalmente, cancela requests pendientes si es que se va a enviar uno nuevo

<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
Restringe la búsqueda de prestaciones con el fin de agilizar las consultas.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Condiciona la búsqueda por fecha dentro de un solo mes.
2. Habilita el botón de búsqueda solo si se asigna valor al filtro de documento o de prestaciones.
3. Se desuscribe a los request que estén pendientes cada vez que se va a iniciar un nuevo request.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
