### PR TITLE
Audita automáticamente agendas de prestaciones no auditables 

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -238,7 +238,12 @@ export class BotonesAgendaComponent implements OnInit {
 
     puedoRevisar() {
         let agenda = this.agendasSeleccionadas[0];
-        return ((agenda.estado === 'pendienteAsistencia' || agenda.estado === 'pendienteAuditoria' || agenda.estado === 'publicada' || agenda.estado === 'auditada') && moment(agenda.horaFin).isBefore(moment(new Date())));
+        let auditable = true;
+        for (let i = 0; i < agenda.bloques.length; i++) {
+            auditable = auditable && agenda.bloques[i].turnos.some((t: any) => t.auditable === false);
+        }
+        auditable = !auditable;
+        return (auditable && (agenda.estado === 'pendienteAsistencia' || agenda.estado === 'pendienteAuditoria' || agenda.estado === 'publicada' || agenda.estado === 'auditada') && moment(agenda.horaFin).isBefore(moment(new Date())));
     }
 
     puedoImprimirCarpetas() {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
@@ -795,7 +795,8 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
                         let turno = {
                             estado: 'disponible',
                             horaInicio: this.combinarFechas(this.fecha, new Date(bloque.horaInicio.getTime() + i * bloque.duracionTurno * 60000)),
-                            tipoTurno: undefined
+                            tipoTurno: undefined,
+                            auditable: !bloque.tipoPrestaciones.some(p => !p.auditable)
                         };
 
                         if (bloque.pacienteSimultaneos) {


### PR DESCRIPTION
### Requerimiento
https://pm.andes.gob.ar/projects/citas/work_packages/803/activity

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al planificar una agenda se setea a cada turno el valor "auditable" correspondiente al atributo con mismo nombre del tipoPrestación asignado al bloque.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
Agregar a los conceptos turneables con conceptId 34043003 y 861000013109 el atributo `auditable` en `false`
`db.getCollection('conceptoTurneable').updateMany({$or: [{conceptId: '34043003'}, {conceptId: '861000013109'}]}, { $set: {auditable: false}})`

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si
- [ ] No
https://github.com/andes/api/pull/794

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
