### PR TITLE
fix(citas): remove space in html attribute

### DIFF
--- a/src/app/core/mpi/components/paciente-cru.html
+++ b/src/app/core/mpi/components/paciente-cru.html
@@ -212,7 +212,7 @@
                                 <div class="row">
                                     <div class="col">
                                         <plex-text label="Dirección" [(ngModel)]="pacienteModel.direccion[0].valor"
-                                                   (change)="checkDisableGeolocalizar($event)" name=" direccion"
+                                                   (change)="checkDisableGeolocalizar($event)" name="direccion"
                                                    placeholder="Ej: Avenida las Flores 1200">
                                         </plex-text>
                                         <!--table>


### PR DESCRIPTION
### Requerimiento
Se rompieron 5 test de cypress porque se introdujo un espacio en un atributo html.
https://github.com/andes/app/pull/1419/files#diff-5bb58586b9985f865cd6750980ffb3e9R215
### Funcionalidad desarrollada 
1. Se remueve el espacio.

### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

 