### PR TITLE
fix(citas): se resetean parámetros skip y limit en query de agendas

### DIFF
--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -360,6 +360,8 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
         this.showListadoTurnos = false;
         this.showCarpetas = false;
         if (this.parametros) {
+            this.parametros.skip = 0;
+            this.parametros.limit = 15;
             this.getAgendas();
         } else {
             this.loadAgendas();


### PR DESCRIPTION
### Requerimiento
#1453 

### Funcionalidad desarrollada 
1. Luego de crear una agenda, se resetean los parámetros skip y limit quedando con estos valores:
```
skip: 0,
limit: 15
```

### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [X] No