### PR TITLE
TOP: limpia opciones de Selects

### DIFF
--- a/src/app/components/top/solicitudes/nuevaSolicitud.component.ts
+++ b/src/app/components/top/solicitudes/nuevaSolicitud.component.ts
@@ -197,18 +197,23 @@ export class NuevaSolicitudComponent implements OnInit {
     }
 
     onSelect() {
-        if (this.tipoSolicitud === 'salida' && this.auth.organizacion.id && this.modelo.solicitud.tipoPrestacionOrigen && this.modelo.solicitud.tipoPrestacionOrigen.conceptId) {
-            this.servicioReglas.get({ organizacionOrigen: this.auth.organizacion.id, prestacionOrigen: this.modelo.solicitud.tipoPrestacionOrigen.conceptId })
-                .subscribe(
-                    res => {
-                        this.arrayReglasDestino = res;
-                        this.dataReglasDestino = res.map(elem => { return { id: elem.destino.prestacion.conceptId, nombre: elem.destino.prestacion.term }; });
-                        this.dataOrganizacionesDestino = res.map(elem => { return { id: elem.destino.organizacion.id, nombre: elem.destino.organizacion.nombre }; });
-
-                    }
-                );
+        if (this.tipoSolicitud === 'salida') {
+            if (this.auth.organizacion.id && this.modelo.solicitud.tipoPrestacionOrigen && this.modelo.solicitud.tipoPrestacionOrigen.conceptId) {
+                this.servicioReglas.get({ organizacionOrigen: this.auth.organizacion.id, prestacionOrigen: this.modelo.solicitud.tipoPrestacionOrigen.conceptId })
+                    .subscribe(
+                        res => {
+                            this.arrayReglasDestino = res;
+                            this.dataReglasDestino = res.map(elem => { return { id: elem.destino.prestacion.conceptId, nombre: elem.destino.prestacion.term }; });
+                            this.dataOrganizacionesDestino = res.map(elem => { return { id: elem.destino.organizacion.id, nombre: elem.destino.organizacion.nombre }; });
+                        }
+                    );
+            } else {
+                this.dataOrganizacionesDestino = [];
+                this.modelo.solicitud.organizacion = null;
+            }
         }
-        if (this.tipoSolicitud === 'entrada' && this.auth.organizacion.id && this.modelo.solicitud.tipoPrestacion && this.modelo.solicitud.tipoPrestacion.conceptId) {
+
+        if (this.tipoSolicitud === 'entrada' && this.auth.organizacion.id) {
             if (this.prestacionOrigen) {
                 let regla: any = this.arrayReglasOrigen.find((rule: any) => { return rule.prestacion.conceptId === this.prestacionOrigen.id; });
 
@@ -218,6 +223,9 @@ export class NuevaSolicitudComponent implements OnInit {
                     this.modelo.estados.push({ tipo: 'pendiente' });
                 }
                 this.modelo.solicitud.tipoPrestacionOrigen = regla.prestacion;
+            } else {
+                this.prestacionOrigen = null;
+                this.modelo.solicitud.tipoPrestacionOrigen = null;
             }
         }
     }
@@ -229,6 +237,12 @@ export class NuevaSolicitudComponent implements OnInit {
                 this.arrayReglasOrigen = regla.origen.prestaciones;
                 this.dataTipoPrestacionesOrigen = regla.origen.prestaciones.map(elem => { return { id: elem.prestacion.conceptId, nombre: elem.prestacion.term }; });
             }
+        } else {
+            if (!this.modelo.solicitud.tipoPrestacion) {
+                this.dataOrganizacionesOrigen = [];
+            }
+            this.dataReglasDestino = [];
+            this.prestacionOrigen = null;
         }
     }
 
@@ -236,17 +250,18 @@ export class NuevaSolicitudComponent implements OnInit {
         if (this.tipoSolicitud === 'salida') {
             if (this.modelo.solicitud.organizacion) {
                 this.servicioReglas.get({
-                    organizacionOrigen: this.auth.organizacion.id,
-                    organizacionDestino: this.modelo.solicitud.organizacion.id,
-                    prestacionOrigen: this.modelo.solicitud.tipoPrestacionOrigen.conceptId
-                })
-                    .subscribe(
-                        res => {
-                            this.dataReglasDestino = res.map(elem => { return { id: elem.destino.prestacion.conceptId, nombre: elem.destino.prestacion.term }; });
-                        }
-                    );
+                organizacionOrigen: this.auth.organizacion.id,
+                organizacionDestino: this.modelo.solicitud.organizacion.id,
+                prestacionOrigen: this.modelo.solicitud.tipoPrestacionOrigen.conceptId })
+                .subscribe( res => this.dataReglasDestino = res.map(elem => { return { id: elem.destino.prestacion.conceptId, nombre: elem.destino.prestacion.term }; }));
+            } else {
+                if (!this.modelo.solicitud.tipoPrestacionOrigen) {
+                    this.dataOrganizacionesDestino = [];
+                    this.modelo.solicitud.organizacion = null;
+                }
+                this.dataReglasDestino = [];
+                this.prestacionDestino = null;
             }
-
         }
     }
 
@@ -259,7 +274,14 @@ export class NuevaSolicitudComponent implements OnInit {
                         this.dataOrganizacionesOrigen = res.map(elem => { return { id: elem.origen.organizacion.id, nombre: elem.origen.organizacion.nombre }; });
                     }
                 );
+        } else {
+            this.clearOrganizacionesOrigen();
         }
+    }
+
+    clearOrganizacionesOrigen() {
+        this.dataOrganizacionesOrigen = [];
+        this.modelo.solicitud.organizacionOrigen = null;
     }
 
     onSelectPrestacionDestino() {
@@ -272,6 +294,8 @@ export class NuevaSolicitudComponent implements OnInit {
             } else {
                 this.modelo.estados.push({ tipo: 'pendiente' });
             }
+        } else if (!this.modelo.solicitud.organizacion) {
+            this.dataReglasDestino = [];
         }
     }
 

--- a/src/app/components/top/solicitudes/nuevaSolicitud.html
+++ b/src/app/components/top/solicitudes/nuevaSolicitud.html
@@ -80,7 +80,7 @@
                         <div class="row">
                             <div class="col" *ngIf="!autocitado">
                                 <plex-select [(ngModel)]="prestacionOrigen" [data]="dataTipoPrestacionesOrigen"
-                                    name="tipoPrestacion" (change)="onSelect()" label="Tipos de Prestación Origen"
+                                    name="tipoPrestacionOrigen" (change)="onSelect()" label="Tipos de Prestación Origen"
                                     placeholder="Tipos de Prestación Origen" [required]="true">
                                 </plex-select>
                             </div>


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
#1449
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Además de lo solicitado en la #1449, también se aplicó el cambio para las prestaciones destino de salida y para los combos de solicitudes de entrada
2. Dado el comportamiento de plex select que deja la opción previamente seleccionada dentro de las opciones del select una vez que se limpió el data de dicho select, fue preciso implementar un workaround en los plexselects para que toda vez que la selección sea nula, vuelva a auto asignarse el null y vaciar el array de opciones, para limpiar el remanente de las opciones del componente


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
