### PR TITLE
CITAS - Edición domicilio en punto de inicio

### DIFF
--- a/src/app/components/turnos/dashboard/update-contacto-direccion.component.ts
+++ b/src/app/components/turnos/dashboard/update-contacto-direccion.component.ts
@@ -201,7 +201,7 @@ export class UpdateContactoDireccionComponent implements OnInit {
         if (valid.formValid) {
             this.eliminarContactosVacios();
             this.paciente.contacto = this.arrayContactos;
-            this.paciente.direccion = [this.direccion];
+            this.paciente.direccion[0] = this.direccion;
 
             this.pacienteService.save(this.paciente).subscribe();
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
En el esquema de pacientes la dirección es un arreglo de direcciones. Siempre estuvimos guardando una sola, ahora se empieza a guardar una segunda, la legal, al validar con renaper. No se muestra por pantalla pero queda guardada en la base de datos.
Lo que corrige este PR es que en la edición del domicilio del paciente en el punto de inicio de citas ya no se pisa más el arreglo de direcciones sino que se pisa el primer ítem del arreglo, dejando intacta la dirección legal
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
