### PR TITLE
fix(turnero): se quita evento reconnect_attempt

### DIFF
--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -26,10 +26,6 @@ export class WebSocketService {
             this.events.next({ event: data[0], data: data[1] });
         });
 
-        this.socket.on('reconnect_attempt', () => {
-            this.socket.io.opts.transports = ['polling', 'websocket'];
-        });
-
         this.socket.on('connect', () => {
             if (this.token) {
                 this.emitAuth();


### PR DESCRIPTION
### Requerimiento
Se quita evento reconnect_attempt en servicio de websocket

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Elimina evento reconnect_attempt

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
