### PR TITLE
feat(gestor-usuario): add visibility attribute

### DIFF
--- a/src/app/apps/gestor-usuarios/components/arbol-permisos/arbol-permisos-item.component.html
+++ b/src/app/apps/gestor-usuarios/components/arbol-permisos/arbol-permisos-item.component.html
@@ -1,4 +1,4 @@
-<plex-accordion *ngIf="item.child">
+<plex-accordion *ngIf="item.child" [hidden]="isHidden">
     <plex-panel (toggle)="expand($event)" #panel>
         <div plex-accordion-title class="d-flex justify-content-between align-items-center">
             <span>
@@ -26,7 +26,7 @@
         </ng-container>
     </plex-panel>
 </plex-accordion>
-<div *ngIf="item.type">
+<div *ngIf="item.type" [hidden]="isHidden">
 
     <plex-bool [(ngModel)]="state" *ngIf="item.type === 'boolean'" [label]="item.title" type="slide"
                (change)="selectChange()"> </plex-bool>

--- a/src/app/apps/gestor-usuarios/components/arbol-permisos/arbol-permisos-item.component.ts
+++ b/src/app/apps/gestor-usuarios/components/arbol-permisos/arbol-permisos-item.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, ViewChildren, QueryList, OnChanges, AfterViewInit, Vi
 import { PlexPanelComponent } from '@andes/plex/src/lib/accordion/panel.component';
 import { OrganizacionService } from '../../../../services/organizacion.service';
 import { TipoPrestacionService } from '../../../../services/tipoPrestacion.service';
+import { Auth } from '@andes/auth';
 // import { IPermiso } from '../interfaces/IPermiso';
 let shiroTrie = require('shiro-trie');
 
@@ -37,9 +38,21 @@ export class ArbolPermisosItemComponent implements OnInit, OnChanges, AfterViewI
 
     constructor(
         private servicioTipoPrestacion: TipoPrestacionService,
-        private organizacionService: OrganizacionService
+        private organizacionService: OrganizacionService,
+        private auth: Auth
     ) { }
 
+    get isHidden() {
+        if (this.item.visibility) {
+            if (this.item.visibility === 'hidden') {
+                return true;
+            } else if (this.item.visibility === 'restricted') {
+                const permitido = this.auth.getPermissions(this.makePermission() + ':?').length > 0;
+                return !permitido;
+            }
+        }
+        return false;
+    }
     expand($event) {
         if ($event) {
             if (this.allModule) {


### PR DESCRIPTION
### Requerimiento
Poder setear distintos niveles de visibilidad en el gestor de usuarios:

- _public_: cualquier puede asignar ese permiso.
- _restricted_: Solo si tenes ese permiso podes asignarlo a otros usuarios.
- _hidden_: Invisible para todos, se gestiona desde base de datos.

Con esta funcionalidad, solo los que tienen permiso de matriculaciones pueden dar permisos para matriculaciones. Si no tenes permisos y estás editando un usuarios, no se lo pisas como pasaba antes.

### Funcionalidad desarrollada 
Del lado de la APP, se ocultan los accordion correspondiente al nivel de visibilidad, permitiendo al gestor de usuarios poder mantener el permiso si estaba habilitado.

### UserStories llegó a completarse
- [ ] Si
- [ ] No

PR API: https://github.com/andes/api/pull/865/files

