### PR TITLE
fix(huds): wrong snomed expresssion Riesgo Cardiovascular

### DIFF
--- a/src/app/modules/rup/components/ejecucion/resumen-paciente/resumenPaciente-dinamico.component.ts
+++ b/src/app/modules/rup/components/ejecucion/resumen-paciente/resumenPaciente-dinamico.component.ts
@@ -66,7 +66,7 @@ export class ResumenPacienteDinamicoComponent implements OnInit {
         // Loopeamos los conceptos que no son graficos y recupermaos su ultimo registro
         for (let concepto of this.conceptos) {
             this.elementos = [...this.elementos, this.elementosRUPService.buscarElemento(concepto, false)];
-            this.prestacionesService.getRegistrosHuds(this.paciente.id, '>>' + concepto.conceptId).subscribe(prestaciones => {
+            this.prestacionesService.getRegistrosHuds(this.paciente.id, '<<' + concepto.conceptId).subscribe(prestaciones => {
                 if (prestaciones.length) {
                     this.registros = [...this.registros, prestaciones[prestaciones.length - 1]];
                 }


### PR DESCRIPTION
### Requerimiento
La expresión estaba al revés, buscaba los padres y no los descendientes. Se ve que con mongo no pasaba nada, pero con Snowstorm la query empezó a funcionar como corresponde y provocaba que la HUDS no  ciertos pacientes no se vean. Con los que tienen colonoscopía.
 
### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [x] No
 