### PR TITLE
CITAS: Se agrega la organizacion al no asignar turno

### DIFF
--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -1139,7 +1139,6 @@ export class DarTurnosComponent implements OnInit {
     }
 
     noSeAsignaTurno() {
-        console.log(this.opciones.tipoPrestacion);
         let listaEspera: any;
         let operacion: Observable<IListaEspera>;
         let datosPrestacion = this.opciones.tipoPrestacion;

--- a/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
+++ b/src/app/components/turnos/dar-turnos/dar-turnos.component.ts
@@ -1139,12 +1139,10 @@ export class DarTurnosComponent implements OnInit {
     }
 
     noSeAsignaTurno() {
+        console.log(this.opciones.tipoPrestacion);
         let listaEspera: any;
         let operacion: Observable<IListaEspera>;
-        let datosPrestacion = !this.opciones.tipoPrestacion ? null : {
-            id: this.opciones.tipoPrestacion.id,
-            nombre: this.opciones.tipoPrestacion.nombre
-        };
+        let datosPrestacion = this.opciones.tipoPrestacion;
         let datosProfesional = !this.opciones.profesional ? null : {
             id: this.opciones.profesional.id,
             nombre: this.opciones.profesional.nombre,
@@ -1156,12 +1154,17 @@ export class DarTurnosComponent implements OnInit {
             apellido: this.paciente.apellido,
             documento: this.paciente.documento
         };
+        let organizacion = !this.auth.organizacion ? null : {
+            id: this.auth.organizacion.id,
+            nombre: this.auth.organizacion.nombre
+        };
         listaEspera = !this.agenda ? null : {
             fecha: this.agenda.horaInicio,
             estado: 'Demanda Rechazada',
             tipoPrestacion: datosPrestacion,
             profesional: datosProfesional,
             paciente: datosPaciente,
+            organizacion: organizacion
         };
         if (listaEspera !== null) {
             operacion = this.serviceListaEspera.post(listaEspera);


### PR DESCRIPTION
### Requerimiento

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al momento de hacer click en el boton ' NO SE ASIGNA TURNO ' se guarda la organizacion en una variable para insertarla en la lista de espera


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si https://github.com/andes/api/pull/869
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si https://github.com/andes/andes-test-integracion/pull/59
- [ ] No

