### PR TITLE
feat(home): agrega menu analytics

### DIFF
--- a/src/app/components/inicio/inicio.component.ts
+++ b/src/app/components/inicio/inicio.component.ts
@@ -18,6 +18,7 @@ export class InicioComponent implements AfterViewInit {
     public solicitudes = '';
     public prestamosHC = '';
     public dashboard = false;
+    public analytics = '';
     public usuarios = '';
     public denied = false;
     public accessList: any = [];
@@ -43,6 +44,11 @@ export class InicioComponent implements AfterViewInit {
 
             if (this.auth.getPermissions('mpi:?').length > 0) {
                 this.mpi = 'mpi';
+                this.denied = false;
+            }
+
+            if (this.auth.getPermissions('analytics:?').length > 0) {
+                this.analytics = 'analytics';
                 this.denied = false;
             }
 
@@ -77,5 +83,10 @@ export class InicioComponent implements AfterViewInit {
                 this.denied = false;
             }
         });
+    }
+
+    anlytics() {
+        const token = this.auth.getToken();
+        window.location.assign(`https://analytics.andes.gob.ar/auth/login?token=${token}`);
     }
 }

--- a/src/app/components/inicio/inicio.html
+++ b/src/app/components/inicio/inicio.html
@@ -96,7 +96,15 @@
                         <div class="detalle">Visualice datos estadísticos<br>en gráficos y tablas</div>
                     </div>
                 </div>
-
+                <div *ngIf="analytics" class="col-xs-12 col-sm-6 col-md-4">
+                    <div class="boton analytics" (click)="anlytics()">
+                        <i class="icono mdi mdi-poll"></i>
+                        <div class="titulo">Analytics</div>
+                        <div class="subtitulo">Navegador HUDS<br>&nbsp;</div>
+                        <div class="detalle">Permite la búsqueda, visualización y refinamiento<br>de datos de salud
+                            registrados en ANDES</div>
+                    </div>
+                </div>
 
             </div>
 

--- a/src/app/components/inicio/inicio.scss
+++ b/src/app/components/inicio/inicio.scss
@@ -117,6 +117,13 @@ $andes-naranja-claro: #f4a03b;
     &.color-verde-oscuro:hover {
         background: darken($color-verde-oscuro, 10%);
     }
+
+    &.analytics {
+        background: #662482;
+    }
+    &.analytics:hover {
+        background: darken(#662482, 10%);
+    }
 }
 
 .contenedor-marca-h {


### PR DESCRIPTION
### Requerimiento
Agrega cuadrado para Analtytics bajo permisos. La URL viene hardcodeada por el momento, la idea es reestructurar esa pantalla para que sea dinámica, configurable desde alguna colección. 

### Funcionalidad desarrollada 
1. Se agrega un cuadrado al home. 

### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
 