### PR TITLE
MPI: Muestra financiador SUMAR al dar un turno

### DIFF
--- a/src/app/components/turnos/dashboard/estadisticas-pacientes.html
+++ b/src/app/components/turnos/dashboard/estadisticas-pacientes.html
@@ -77,7 +77,7 @@
                 </div>
             </div>
             <div class="row" *ngIf="paciente?.financiador?.length">
-                <div class="col-6" *ngIf="paciente?.financiador[0].nombre">
+                <div class="col-6" *ngIf="paciente?.financiador[0].financiador">
                     {{paciente.financiador[0].financiador}}
                 </div>
                 <div class="col-6" *ngIf="paciente?.financiador[0].numeroAfiliado">


### PR DESCRIPTION
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al dar un turno a un paciente que se encuentra dentro del programa SUMAR, en el sidebar mostraba el financiador vacio. Ahora muestra el nombre correctamente 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->

Antes:

![local](https://user-images.githubusercontent.com/56874534/70932010-78b9ca80-2017-11ea-85fc-e9aa368b1271.png)

Despues:
![local2](https://user-images.githubusercontent.com/56874534/70932032-82433280-2017-11ea-8b56-f915e4b001df.png)

