### PR TITLE
TURNERO: sumado tipo a la configuración de pantallas

### DIFF
--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -108,119 +108,119 @@ import { CampaniaSaludComponent } from './apps/campaniaSalud/components/campania
 import { TurnosPrestacionesComponent } from './components/buscadorTurnosPrestaciones/turnos-prestaciones.component';
 
 const appRoutes: Routes = [
-  // Tablas maestras
-  { path: 'tm/organizacion', component: OrganizacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/organizacion/:id/sectores', component: OrganizacionSectoresComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/organizacion/:id/ofertas_prestacionales', component: OrganizacionOfertaPrestacionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/organizacion/cama/:idCama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/organizacion/cama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/profesional', component: ProfesionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/profesional/create', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/profesional/create/:id', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/especialidad', component: EspecialidadComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/espacio_fisico', component: EspacioFisicoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'tm/mapa_espacio_fisico', component: MapaEspacioFisicoVistaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Tablas maestras
+    { path: 'tm/organizacion', component: OrganizacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/organizacion/:id/sectores', component: OrganizacionSectoresComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/organizacion/:id/ofertas_prestacionales', component: OrganizacionOfertaPrestacionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/organizacion/cama/:idCama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/organizacion/cama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/profesional', component: ProfesionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/profesional/create', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/profesional/create/:id', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/especialidad', component: EspecialidadComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/espacio_fisico', component: EspacioFisicoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'tm/mapa_espacio_fisico', component: MapaEspacioFisicoVistaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // MPI
-  { path: 'apps/mpi/busqueda', component: BusquedaMpiComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/bebe', component: BebeCruComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/paciente', component: PacienteCruComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/extranjero', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/bebe/:origen', component: BebeCruComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/extranjero/:origen', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/paciente/:opcion/:origen', component: PacienteCruComponent, canActivate: [RoutingGuard] },
-  { path: 'apps/mpi/auditoria/vincular-pacientes', component: VincularPacientesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'apps/mpi/auditoria', component: AuditoriaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // MPI
+    { path: 'apps/mpi/busqueda', component: BusquedaMpiComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/bebe', component: BebeCruComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/paciente', component: PacienteCruComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/extranjero', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/bebe/:origen', component: BebeCruComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/extranjero/:origen', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/paciente/:opcion/:origen', component: PacienteCruComponent, canActivate: [RoutingGuard] },
+    { path: 'apps/mpi/auditoria/vincular-pacientes', component: VincularPacientesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'apps/mpi/auditoria', component: AuditoriaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Obras sociales
-  { path: 'puco', component: PucoComponent, canActivate: [RoutingNavBar] },
+    // Obras sociales
+    { path: 'puco', component: PucoComponent, canActivate: [RoutingNavBar] },
 
-  // Turnos
-  { path: 'citas', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/clonarAgenda', component: ClonarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/gestor_agendas', component: GestorAgendasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/panelEspacio', component: PanelEspacioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/agendas', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/agenda', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/turnos', component: DarTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/listaEspera', component: ListaEsperaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/punto-inicio', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/punto-inicio/:idPaciente', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Turnos
+    { path: 'citas', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/clonarAgenda', component: ClonarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/gestor_agendas', component: GestorAgendasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/panelEspacio', component: PanelEspacioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/agendas', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/agenda', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/turnos', component: DarTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/listaEspera', component: ListaEsperaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/punto-inicio', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/punto-inicio/:idPaciente', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  { path: 'citas/revision_agenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/revision_agenda/:idAgenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  // { path: 'citas/sobreturnos', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/sobreturnos/:idAgenda', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'citas/paciente/:idAgenda', component: AgregarPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  // RUP
-  { path: 'rup', component: PuntoInicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/crear/:opcion', component: PrestacionCrearComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/crear', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/crear/:id', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/ocuparCama/:idCama/:idInternacion', component: OcuparCamaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/ejecucion/:id', component: PrestacionEjecucionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/validacion/:id', component: PrestacionValidacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/auditoriaRUP', component: AuditoriaPrestacionPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/llavesTipoPrestacion', component: LlavesTipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/vista/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/huds/paciente/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/censo', component: CensoDiarioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/censo/mensual', component: CensoMensualComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/listado', component: ListadoInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/internacion/listaEspera', component: ListaEsperaInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'rup/plantillas', component: PlantillasRUPComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/revision_agenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/revision_agenda/:idAgenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // { path: 'citas/sobreturnos', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/sobreturnos/:idAgenda', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'citas/paciente/:idAgenda', component: AgregarPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // RUP
+    { path: 'rup', component: PuntoInicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/crear/:opcion', component: PrestacionCrearComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/crear', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/crear/:id', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/ocuparCama/:idCama/:idInternacion', component: OcuparCamaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/ejecucion/:id', component: PrestacionEjecucionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/validacion/:id', component: PrestacionValidacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/auditoriaRUP', component: AuditoriaPrestacionPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/llavesTipoPrestacion', component: LlavesTipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/vista/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/huds/paciente/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/censo', component: CensoDiarioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/censo/mensual', component: CensoMensualComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/listado', component: ListadoInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/internacion/listaEspera', component: ListaEsperaInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'rup/plantillas', component: PlantillasRUPComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
 
-  // Configuraciones / ABM
-  { path: 'configuracionPrestacion', component: ConfiguracionPrestacionVisualizarComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Configuraciones / ABM
+    { path: 'configuracionPrestacion', component: ConfiguracionPrestacionVisualizarComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Mapa de camas
-  { path: 'internacion/camas', component: MapaDeCamasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'internacion/inicio', component: PuntoInicioInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Mapa de camas
+    { path: 'internacion/camas', component: MapaDeCamasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'internacion/inicio', component: PuntoInicioInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Préstamos HC
-  { path: 'prestamosHC', component: PrestamosHcComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Préstamos HC
+    { path: 'prestamosHC', component: PrestamosHcComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // formulario terapeutico
-  { path: 'formularioTerapeutico', component: FormTerapeuticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // formulario terapeutico
+    { path: 'formularioTerapeutico', component: FormTerapeuticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Reportes
-  { path: 'reportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'consultaDiagnostico', component: ConsultaDiagnosticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'encabezadoReportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'cantidadConsultaXPrestacion', component: CantidadConsultaXPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Reportes
+    { path: 'reportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'consultaDiagnostico', component: ConsultaDiagnosticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'encabezadoReportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'cantidadConsultaXPrestacion', component: CantidadConsultaXPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // ReportesDiarios
-  { path: 'reportesDiarios', component: EncabezadoReportesDiariosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // ReportesDiarios
+    { path: 'reportesDiarios', component: EncabezadoReportesDiariosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Solicitudes
-  { path: 'solicitudes', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Solicitudes
+    { path: 'solicitudes', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Buscador de turnos y prestaciones
-  { path: 'buscador', component: TurnosPrestacionesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Buscador de turnos y prestaciones
+    { path: 'buscador', component: TurnosPrestacionesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // TOP
-  { path: 'top/reglas', component: ReglasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'top/reglasVisualizacion', component: VisualizacionReglasTopComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // TOP
+    { path: 'top/reglas', component: ReglasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'top/reglasVisualizacion', component: VisualizacionReglasTopComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
   // TODO: Verificar si estas rutas todavía son válidas, y ubicarlas en los módulos correspondientes
   /* VERIFICAR ==> */ { path: 'tipoprestaciones', component: TipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // Principal
-  { path: 'inicio', component: InicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'auth', loadChildren: './apps/auth/auth.module#AuthAppModule' },
+    // Principal
+    { path: 'inicio', component: InicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'auth', loadChildren: './apps/auth/auth.module#AuthAppModule' },
 
-  { path: 'estadisticas', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'dashboard', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
-  { path: 'gestor-usuarios', loadChildren: './apps/gestor-usuarios/gestor-usuarios.module#GestorUsuariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
-  // Campañas Salud
-  { path: 'campaniasSalud', component: CampaniaSaludComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-  // Turnero
-  { path: 'turnero', loadChildren: './apps/turnero/turnero.module#TurneroModule', canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'estadisticas', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'dashboard', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
+    { path: 'gestor-usuarios', loadChildren: './apps/gestor-usuarios/gestor-usuarios.module#GestorUsuariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
+    // Campañas Salud
+    { path: 'campaniasSalud', component: CampaniaSaludComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+    // Turnero
+    { path: 'pantallas', loadChildren: './apps/turnero/turnero.module#TurneroModule', canActivate: [RoutingNavBar, RoutingGuard] },
 
-  // dejar siempre al último porque no encuentra las url después de esta
-  { path: '**', redirectTo: 'inicio' }
+    // dejar siempre al último porque no encuentra las url después de esta
+    { path: '**', redirectTo: 'inicio' }
 ];
 
 export const appRoutingProviders: any[] = [];

--- a/src/app/apps/turnero/services/pantalla.service.ts
+++ b/src/app/apps/turnero/services/pantalla.service.ts
@@ -12,50 +12,50 @@ export class PantallaService {
 
     constructor(private server: Server, public auth: Auth) { }
 
-    list (params = null) {
+    list(params = null) {
         return this.server.get(this.baseURL, { params }).subscribe((data) => {
             this.pantallas = data;
         });
     }
 
-    save (pantalla) {
+    save(pantalla) {
         if (pantalla.id) {
             return this.server.patch(this.baseURL + '/' + pantalla.id, pantalla).pipe(
                 tap((p) => {
-                let index = this.pantallas.findIndex((value) => value.id === pantalla.id );
+                    let index = this.pantallas.findIndex((value) => value.id === pantalla.id);
+                    if (index >= 0) {
+                        this.pantallas.splice(index, 1, p);
+                        this.pantallas = [...this.pantallas];
+                    }
+                }));
+        } else {
+            return this.server.post(this.baseURL, pantalla).pipe(
+                tap((p) => {
+                    this.pantallas = [...this.pantallas, p];
+                }));
+        }
+    }
+
+    retoken(pantalla) {
+        return this.server.post(this.baseURL + '/' + pantalla.id + '/retoken', {}).pipe(
+            tap((p) => {
+                let index = this.pantallas.findIndex((value) => value.id === pantalla.id);
                 if (index >= 0) {
                     this.pantallas.splice(index, 1, p);
                     this.pantallas = [...this.pantallas];
                 }
             }));
-        } else {
-            return this.server.post(this.baseURL, pantalla).pipe(
-                tap((p) => {
-                this.pantallas = [...this.pantallas, p];
-            }));
-        }
     }
 
-    retoken (pantalla) {
-        return this.server.post(this.baseURL + '/' + pantalla.id + '/retoken' , {}).pipe(
-            tap((p) => {
-            let index = this.pantallas.findIndex((value) => value.id === pantalla.id );
-            if (index >= 0) {
-                this.pantallas.splice(index, 1, p);
-                this.pantallas = [...this.pantallas];
-            }
-        }));
-    }
-
-    remove (pantalla) {
+    remove(pantalla) {
         return this.server.delete(this.baseURL + '/' + pantalla.id).pipe(
             tap(() => {
-            let index = this.pantallas.findIndex((value) => value.id === pantalla.id );
-            if (index >= 0) {
-                this.pantallas.splice(index, 1);
-                this.pantallas = [...this.pantallas];
-            }
-        }));
+                let index = this.pantallas.findIndex((value) => value.id === pantalla.id);
+                if (index >= 0) {
+                    this.pantallas.splice(index, 1);
+                    this.pantallas = [...this.pantallas];
+                }
+            }));
     }
 
 }

--- a/src/app/apps/turnero/turnero.routing.ts
+++ b/src/app/apps/turnero/turnero.routing.ts
@@ -16,7 +16,7 @@ let routes = [
             component: PantallaDetalleComponent
         }]
     },
-    { path: '', redirectTo: 'turnero', pathMatch: 'full' }
+    { path: '', redirectTo: 'pantallas', pathMatch: 'full' }
 ];
 
 

--- a/src/app/apps/turnero/views/pantalla-detalle.component.ts
+++ b/src/app/apps/turnero/views/pantalla-detalle.component.ts
@@ -12,6 +12,9 @@ import { EspacioFisicoService } from './../../../services/turnos/espacio-fisico.
 })
 export class PantallaDetalleComponent implements OnInit, OnDestroy {
     public espaciosFisicos = [];
+    public turnero = false;
+    public listaTipos = [];
+    public esTurnero = false;
 
     @Output() ocultarDetalleEmmiter: EventEmitter<any> = new EventEmitter<any>();
     @Input() pantalla: any;
@@ -34,6 +37,8 @@ export class PantallaDetalleComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.espacioFisicoService.get({ organizacion: this.auth.organizacion.id }).subscribe(data => this.espaciosFisicos = data);
+        this.listaTipos = [{ id: 'totem', nombre: 'Totem' }, { id: 'turnero', nombre: 'Turnero' }];
+        this.esTurnero = this.pantalla.tipo === 'turnero';
     }
 
     ngOnDestroy() {
@@ -45,6 +50,15 @@ export class PantallaDetalleComponent implements OnInit, OnDestroy {
             this.plex.toast('success', 'Pantalla guardada correctamente', 'Pantalla guardada', 100);
             this.back();
         });
+    }
+
+    changeTipo(event) {
+        this.pantalla.tipo = event.value.id;
+        if (this.pantalla.tipo === 'totem') {
+            this.esTurnero = false;
+        } else {
+            this.esTurnero = true;
+        }
     }
 
     back() {

--- a/src/app/apps/turnero/views/pantalla-detalle.html
+++ b/src/app/apps/turnero/views/pantalla-detalle.html
@@ -1,23 +1,36 @@
-<header>
-    <div class="row" *ngIf="pantalla">
-        <div class="col-md-7">
-            <div class="clearfix">
-                <div class="page-title float-left">Detalle</div>
+<plex-title main titulo="Detalle de pantallas" size="sm">
+    <plex-button label="Cancelar" type="danger" (click)="back()" size="sm"></plex-button>
+    <plex-button label="Guardar" type="success" (click)="guardar()" size="sm"></plex-button>
+</plex-title>
+<div *ngIf="pantalla">
+    <fieldset>
+        <div class="row">
+            <div class="col-md">
+                <plex-text label="Nombre" placeholder="Nombre identificatorio" [(ngModel)]="pantalla.nombre"
+                           name="usuario" [required]="true"></plex-text>
             </div>
         </div>
-        <div class="col d-flex justify-content-end">
-            <plex-button label="Cancelar" type="danger" (click)="back()"></plex-button>
-            <plex-button label="Guardar" type="success" (click)="guardar()"></plex-button>
+        <div class="row">
+            <div class="col-md">
+                <plex-select name="tipoPantalla" [required]="true" [data]="listaTipos" idField="id" labelField="nombre"
+                             [(ngModel)]="pantalla.tipo" label="Tipo de pantalla" (change)="changeTipo($event)">
+                </plex-select>
+
+            </div>
         </div>
-    </div>
-</header>
-<div *ngIf="pantalla">
-    <plex-text label="Nombre" placeholder="Nombre identificatorio" [(ngModel)]="pantalla.nombre" name="usuario"
-        [required]="true"></plex-text>
+        <div class="row">
+            <div class="col-md">
+                <plex-text label="Contenido digital" *ngIf="esTurnero" placeholder="Código playlist youtube"
+                           [(ngModel)]="pantalla.playlist" name="playlist" [required]="false"></plex-text>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md">
+                <plex-select [(ngModel)]="consultorios" *ngIf="esTurnero" multiple="true" [data]="espaciosFisicos"
+                             name="select" [required]="true" label="Espacios físicos">
+                </plex-select>
+            </div>
+        </div>
+    </fieldset>
 
-    <plex-text label="Contenido digital" placeholder="Código playlist youtube" [(ngModel)]="pantalla.playlist"
-        name="playlist" [required]="false"></plex-text>
-
-    <plex-select [(ngModel)]="consultorios" multiple="true" [data]="espaciosFisicos" name="select" [required]="true"
-        label="Espacios físicos"></plex-select>
 </div>

--- a/src/app/apps/turnero/views/pantallas.component.ts
+++ b/src/app/apps/turnero/views/pantallas.component.ts
@@ -8,7 +8,8 @@ import { PantallaService } from '../services/pantalla.service';
 
 
 @Component({
-    templateUrl: 'pantallas.html'
+    templateUrl: 'pantallas.html',
+    styleUrls: ['pantallas.scss'],
 })
 export class PantallasComponent implements OnInit, OnDestroy {
     private sub;
@@ -33,7 +34,7 @@ export class PantallasComponent implements OnInit, OnDestroy {
     ) { }
 
     ngOnInit() {
-        this.plex.updateTitle('Configuración de turneros');
+        this.plex.updateTitle('Configuración de pantallas interactivas');
         let temp;
         this.ws.connect();
         this.ws.join(`turnero-${this.auth.organizacion.id}`);
@@ -84,20 +85,23 @@ export class PantallasComponent implements OnInit, OnDestroy {
     edit(pantalla) {
         this.pantalla = pantalla;
         this.mostrarDetalle = true;
-        this.router.navigate(['/turnero/edit/' + pantalla.id]);
+        this.router.navigate(['/pantallas/edit/' + pantalla.id]);
     }
 
     renovar(pantalla) {
-        this.pantallasService.retoken(pantalla).subscribe(() => { });
+        this.pantallasService.retoken(pantalla).subscribe(() => {
+            this.plex.toast('success', 'Pantalla renovada correctamente', 'Pantalla renovada', 1000);
+        });
     }
 
     nueva() {
         this.pantalla = {
             nombre: '',
-            espaciosFisicos: []
+            espaciosFisicos: [],
+            organizacion: this.auth.organizacion.id
         };
         this.mostrarDetalle = true;
-        this.router.navigate(['/turnero/create']);
+        this.router.navigate(['/pantallas/create']);
     }
 
     eliminar(p) {

--- a/src/app/apps/turnero/views/pantallas.html
+++ b/src/app/apps/turnero/views/pantallas.html
@@ -1,36 +1,40 @@
 <plex-layout main="{{ mostrarDetalle ? 8 : 12 }}">
     <plex-layout-main>
-        <plex-button type="info" class="float-right mb-3" size="sm" (click)="nueva()"> Nueva pantalla </plex-button>
+        <plex-button type="success" class="float-right mb-3" size="sm" (click)="nueva()"> Nueva pantalla </plex-button>
         <table class="table table-striped">
             <thead>
                 <tr>
                     <th> Nombre </th>
-                    <th> Token </th>
+                    <th> Tipo </th>
+                    <th> Código </th>
                     <th> Esp. Físicos </th>
                     <th> Activación </th>
-                    <th> Acciones </th>
+                    <th *ngIf="muestraAcciones"> Acciones </th>
                 </tr>
             </thead>
-            <tr *ngFor="let pantalla of pantallas">
+            <tr *ngFor="let pantalla of pantallas" [ngClass]="{'bg-inverse': pantalla.bloqueada}">
                 <td> {{pantalla.nombre}} </td>
+                <td> {{pantalla.tipo}} </td>
                 <td> {{pantalla.token ? pantalla.token : 'Activado' }} </td>
-                <td> 
+                <td>
+                    {{pantalla.tipo == 'totem' ? 'No corresponde' : '' }}
                     <ng-container *ngFor='let e of pantalla.espaciosFisicos; let i = index'>
                         {{e.nombre}}<ng-container *ngIf='pantalla.espaciosFisicos[i+1]'>,&nbsp;</ng-container>
-                    </ng-container> 
+                    </ng-container>
                 </td>
                 <td>
-                    <span *ngIf="pantalla.expirationTime && !vencido(pantalla.expirationTime)">
+                    <span *ngIf=" pantalla.expirationTime && !vencido(pantalla.expirationTime) && !pantalla.bloqueada">
                         {{pantalla.expirationTime ? 'Hasta ' + (pantalla.expirationTime  | date: "HH:mm") : ''}}
                     </span>
-                    <span *ngIf="!pantalla.expirationTime || vencido(pantalla.expirationTime)">
+                    <span *ngIf="(!pantalla.expirationTime || vencido(pantalla.expirationTime))">
                         <plex-button type="info" (click)="renovar(pantalla)"> Renovar </plex-button>
                     </span>
                 </td>
                 <td>
                     <ng-container *ngIf="muestraAcciones">
-                        <plex-button icon="delete" type="danger" (click)="eliminar(pantalla)" class="mr-3"></plex-button>
-                        <plex-button icon="pencil" type="info" (click)="edit(pantalla)"></plex-button>
+                        <plex-button icon="delete" type="danger" (click)="eliminar(pantalla)" class="mr-3">
+                        </plex-button>
+                        <plex-button icon="pencil" type="info" (click)="edit(pantalla)" class="mr-3"></plex-button>
                     </ng-container>
                 </td>
             </tr>

--- a/src/app/apps/turnero/views/pantallas.scss
+++ b/src/app/apps/turnero/views/pantallas.scss
@@ -1,0 +1,4 @@
+.table .bg-inverse {
+    background-color: #002738 !important;
+    color: white;
+}


### PR DESCRIPTION
### Requerimiento
Permitir configurar los totems de la misma forma que las pantallas del turnero. Se deberá especificar al cargar una nueva de qué tipo es (totem/turnero).

### Funcionalidad desarrollada 
1. Se cambiaron textos en la pantalla de configuración
2. Se agregó un select al cargar pantallas para seleccionar el tipo
3. Se muestran/ocultan campos dependiendo el tipo

### UserStories llegó a completarse
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la API | PR n° 873
- [X] Si
- [ ] No

![image](https://user-images.githubusercontent.com/7090371/71667097-5d063200-2d42-11ea-8acb-1874a36dc8d9.png)

