### PR TITLE
fix(CITAS): no deja ingresar numero de pacientes negativos al citar por segmento

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.html
@@ -10,59 +10,81 @@
                     </header>
                     <div class="row">
                         <div class="col-4">
-                            <plex-datetime type="date" [(ngModel)]="modelo.fecha" [required]="true" [autoFocus]="autoFocus" (change)="validarTodo()" name="modelo.fecha" label="Fecha">
+                            <plex-datetime type="date" [(ngModel)]="modelo.fecha" [required]="true"
+                                           [autoFocus]="autoFocus" (change)="validarTodo()" name="modelo.fecha"
+                                           label="Fecha">
                             </plex-datetime>
                         </div>
                         <div *ngIf="modelo.fecha" class="col-4">
-                            <plex-datetime type="time" [(ngModel)]="modelo.horaInicio" [required]="true" (change)="validarTodo()" name="modelo.horaInicio" label="Inicio">
+                            <plex-datetime type="time" [(ngModel)]="modelo.horaInicio" [required]="true"
+                                           (change)="validarTodo()" name="modelo.horaInicio" label="Inicio">
                             </plex-datetime>
                         </div>
                         <div *ngIf="modelo.fecha" class="col-4">
-                            <plex-datetime type="time" [(ngModel)]="modelo.horaFin" [min]="horaInicioPlus()" [required]="true" (change)="validarTodo()" name="modelo.horaFin" label="Fin">
+                            <plex-datetime type="time" [(ngModel)]="modelo.horaFin" [min]="horaInicioPlus()"
+                                           [required]="true" (change)="validarTodo()" name="modelo.horaFin" label="Fin">
                             </plex-datetime>
                         </div>
                     </div>
                     <div *ngIf="modelo.horaInicio && modelo.horaFin" class="row">
                         <div class="col-12">
-                            <plex-select [(ngModel)]="modelo.tipoPrestaciones" name="modelo.tipoPrestaciones" label="Tipos de prestación" (getData)="loadTipoPrestaciones($event)" [multiple]="true" [required]="true" (change)="cambioPrestaciones()" [closeAfterSelect]="true">
+                            <plex-select [(ngModel)]="modelo.tipoPrestaciones" name="modelo.tipoPrestaciones"
+                                         label="Tipos de prestación" (getData)="loadTipoPrestaciones($event)"
+                                         [multiple]="true" [required]="true" (change)="cambioPrestaciones()"
+                                         [closeAfterSelect]="true">
                             </plex-select>
                         </div>
                     </div>
                     <div *ngIf="modelo.horaInicio && modelo.horaFin" class="row">
                         <div class="col-12">
-                            <plex-select [(ngModel)]="modelo.profesionales" label="Equipo de Salud" name="modelo.profesionales" (getData)="loadProfesionales($event)" [multiple]="true" labelField="apellido + ' ' + nombre" (change)="validarTodo()" [closeAfterSelect]="true">
+                            <plex-select [(ngModel)]="modelo.profesionales" label="Equipo de Salud"
+                                         name="modelo.profesionales" (getData)="loadProfesionales($event)"
+                                         [multiple]="true" labelField="apellido + ' ' + nombre" (change)="validarTodo()"
+                                         [closeAfterSelect]="true">
                             </plex-select>
                         </div>
                     </div>
                     <!--Opcion agenda no nominalizada o dinamica-->
                     <div *ngIf="modelo.horaInicio && modelo.horaFin" class="row">
                         <div class="col">
-                            <plex-bool [(ngModel)]="dinamica" name="dinamica" label="Dinámica" (change)="seleccionarDinamica($event)">
+                            <plex-bool [(ngModel)]="dinamica" name="dinamica" label="Dinámica"
+                                       (change)="seleccionarDinamica($event)">
                             </plex-bool>
                         </div>
                     </div>
 
                     <br>
-                    <div *ngIf="modelo.horaInicio && modelo.horaFin && showBloque && modelo.bloques && modelo.bloques.length > 0" class="row">
+                    <div *ngIf="modelo.horaInicio && modelo.horaFin && showBloque && modelo.bloques && modelo.bloques.length > 0"
+                         class="row">
                         <div class="col-12">
                             <fieldset>
                                 <legend>Espacio físico</legend>
                             </fieldset>
                             <div class="row">
                                 <div class="col text-left">
-                                    <plex-bool [(ngModel)]="espacioFisicoPropios" name="espacioFisicoPropios" type="slide" label="{{textoEspacio}}" (change)="filtrarEspacioFisico()">
+                                    <plex-bool [(ngModel)]="espacioFisicoPropios" name="espacioFisicoPropios"
+                                               type="slide" label="{{textoEspacio}}" (change)="filtrarEspacioFisico()">
                                     </plex-bool>
                                 </div>
                             </div>
                             <div class="row" *ngIf="espacioFisicoPropios">
                                 <div class="col">
-                                    <plex-select [(ngModel)]="modelo.espacioFisico" name="espacioFisico" (getData)="loadEspaciosFisicos($event)" label="Seleccione un espacio físico del efector" placeholder="Seleccione un espacio físico" labelField="nombre + ' ' + (servicio.nombre ? servicio.nombre : '') + (edificio.descripcion ? edificio.descripcion : '')" (change)="validarTodo()">
+                                    <plex-select [(ngModel)]="modelo.espacioFisico" name="espacioFisico"
+                                                 (getData)="loadEspaciosFisicos($event)"
+                                                 label="Seleccione un espacio físico del efector"
+                                                 placeholder="Seleccione un espacio físico"
+                                                 labelField="nombre + ' ' + (servicio.nombre ? servicio.nombre : '') + (edificio.descripcion ? edificio.descripcion : '')"
+                                                 (change)="validarTodo()">
                                     </plex-select>
                                 </div>
                             </div>
                             <div class="row" *ngIf="!espacioFisicoPropios">
                                 <div class="col">
-                                    <plex-select [(ngModel)]="modelo.espacioFisico" name="otrosEspacios" (getData)="loadEspaciosFisicos($event)" label="Seleccione un espacio físico" placeholder="Seleccione un espacio físico" labelField="nombre" (change)="validarTodo()">
+                                    <plex-select [(ngModel)]="modelo.espacioFisico" name="otrosEspacios"
+                                                 (getData)="loadEspaciosFisicos($event)"
+                                                 label="Seleccione un espacio físico"
+                                                 placeholder="Seleccione un espacio físico" labelField="nombre"
+                                                 (change)="validarTodo()">
                                     </plex-select>
                                 </div>
                             </div>
@@ -73,17 +95,21 @@
                     <div *ngIf="showBloque && modelo.bloques && modelo.bloques.length > 0" class="pt-3">
                         <fieldset>
                             <legend>Bloques
-                                <plex-button *ngIf="!dinamica" class="float-right" icon="plus" type="success btn-sm" title="Agregar Bloque" (click)="addBloque()">
+                                <plex-button *ngIf="!dinamica" class="float-right" icon="plus" type="success btn-sm"
+                                             title="Agregar Bloque" (click)="addBloque()">
                                 </plex-button>
                             </legend>
                             <div class="list-group">
-                                <div *ngFor="let unBloque of modelo.bloques; let i=index" class="list-group-item justify-content-between hover" [ngClass]="{active: i==bloqueActivo}" (click)="activarBloque(i)">
+                                <div *ngFor="let unBloque of modelo.bloques; let i=index"
+                                     class="list-group-item justify-content-between hover"
+                                     [ngClass]="{active: i==bloqueActivo}" (click)="activarBloque(i)">
                                     <div>
                                         <span *ngIf="unBloque.horaInicio && unBloque.horaFin">{{unBloque.horaInicio |
                                             date: 'HH:mm'}} a {{unBloque.horaFin | date: 'HH:mm'}}</span>
                                     </div>
                                     <div *ngIf="unBloque.descripcion">{{unBloque.descripcion}}</div>
-                                    <plex-button *ngIf="!dinamica && modelo.bloques.length > 1" icon="delete" type="primary" (click)="deleteBloque(i)">
+                                    <plex-button *ngIf="!dinamica && modelo.bloques.length > 1" icon="delete"
+                                                 type="primary" (click)="deleteBloque(i)">
                                     </plex-button>
                                 </div>
                             </div>
@@ -101,28 +127,38 @@
                         <div class="col-6">
                             <div class="row">
                                 <div class="col-12">
-                                    <plex-text [(ngModel)]="elementoActivo.descripcion" name="descripcion" label="Descripción">
+                                    <plex-text [(ngModel)]="elementoActivo.descripcion" name="descripcion"
+                                               label="Descripción">
                                     </plex-text>
                                 </div>
                             </div>
                             <div class="row" *ngIf="!modelo.intercalar">
                                 <div class="col-6">
-                                    <plex-datetime type="time" [(ngModel)]="elementoActivo.horaInicio" [name]="'horaInicio' + bloqueActivo" [required]="true" (blur)="cambioHoraBloques( 'inicio' )" label="Hora Inicio">
+                                    <plex-datetime type="time" [(ngModel)]="elementoActivo.horaInicio"
+                                                   [name]="'horaInicio' + bloqueActivo" [required]="true"
+                                                   (blur)="cambioHoraBloques( 'inicio' )" label="Hora Inicio">
                                     </plex-datetime>
                                 </div>
                                 <div class="col-6">
-                                    <plex-datetime type="time" [(ngModel)]="elementoActivo.horaFin" name="horaFin" [required]="true" (blur)="cambioHoraBloques( 'fin' )" label="Hora Fin">
+                                    <plex-datetime type="time" [(ngModel)]="elementoActivo.horaFin" name="horaFin"
+                                                   [required]="true" (blur)="cambioHoraBloques( 'fin' )"
+                                                   label="Hora Fin">
                                     </plex-datetime>
                                 </div>
                             </div>
                             <ng-container *ngIf="modelo.nominalizada">
                                 <div class="row">
                                     <div class="col-6">
-                                        <plex-int [(ngModel)]="elementoActivo.cantidadTurnos" name="cantidadTurnos" (keyup)="cambiaTurnos( 'cantidad' )" label="Cantidad de Turnos" [required]="true" min=1 placeholder="Ingrese un valor">
+                                        <plex-int [(ngModel)]="elementoActivo.cantidadTurnos" name="cantidadTurnos"
+                                                  (keyup)="cambiaTurnos( 'cantidad' )" label="Cantidad de Turnos"
+                                                  [required]="true" min=1 placeholder="Ingrese un valor">
                                         </plex-int>
                                     </div>
                                     <div class="col-6">
-                                        <plex-int [(ngModel)]="elementoActivo.duracionTurno" name="duracionTurno" (keyup)="cambiaTurnos( 'duracion' )" label="Duración del Turno" suffix="minutos" [required]="true" min=1 placeholder="Ingrese un valor">
+                                        <plex-int [(ngModel)]="elementoActivo.duracionTurno" name="duracionTurno"
+                                                  (keyup)="cambiaTurnos( 'duracion' )" label="Duración del Turno"
+                                                  suffix="minutos" [required]="true" min=1
+                                                  placeholder="Ingrese un valor">
                                         </plex-int>
                                     </div>
                                     <div *ngIf="elementoActivo.duracionTurno" class="container">
@@ -151,11 +187,16 @@
                                             <label>Del día</label>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoDelDia" [min]="0" [required]="true" (keyup)="cambiaCantTipo( 'accesoDirectoDelDia' )" name="accesoDirectoDelDia">
+                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoDelDia" [min]="0"
+                                                      [required]="true"
+                                                      (keyup)="cambiaCantTipo( 'accesoDirectoDelDia' )"
+                                                      name="accesoDirectoDelDia">
                                             </plex-int>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoDelDiaPorc" [min]="0" (keyup)="cambiaPorcentajeTipo( 'accesoDirectoDelDia' )" name="accesoDirectoDelDiaPorc" suffix="%">
+                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoDelDiaPorc" [min]="0"
+                                                      (keyup)="cambiaPorcentajeTipo( 'accesoDirectoDelDia' )"
+                                                      name="accesoDirectoDelDiaPorc" suffix="%">
                                             </plex-int>
                                         </div>
                                     </div>
@@ -164,11 +205,16 @@
                                             <label>Programados</label>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoProgramado" [min]="0" [required]="true" (keyup)="cambiaCantTipo( 'accesoDirectoProgramado' )" name="accesoDirectoProgramado">
+                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoProgramado" [min]="0"
+                                                      [required]="true"
+                                                      (keyup)="cambiaCantTipo( 'accesoDirectoProgramado' )"
+                                                      name="accesoDirectoProgramado">
                                             </plex-int>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoProgramadoPorc" [min]="0" (keyup)="cambiaPorcentajeTipo( 'accesoDirectoProgramado' )" name="accesoDirectoProgramadoPorc" suffix="%">
+                                            <plex-int [(ngModel)]="elementoActivo.accesoDirectoProgramadoPorc" [min]="0"
+                                                      (keyup)="cambiaPorcentajeTipo( 'accesoDirectoProgramado' )"
+                                                      name="accesoDirectoProgramadoPorc" suffix="%">
                                             </plex-int>
                                         </div>
                                     </div>
@@ -182,11 +228,15 @@
                                             <label>Con llave</label>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.reservadoGestion" [min]="0" [required]="true" (keyup)="cambiaCantTipo( 'reservadoGestion')" name="reservadoGestion">
+                                            <plex-int [(ngModel)]="elementoActivo.reservadoGestion" [min]="0"
+                                                      [required]="true" (keyup)="cambiaCantTipo( 'reservadoGestion')"
+                                                      name="reservadoGestion">
                                             </plex-int>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.reservadoGestionPorc" [min]="0" (keyup)="cambiaPorcentajeTipo( 'reservadoGestion')" name="reservadoGestionporc" suffix="%">
+                                            <plex-int [(ngModel)]="elementoActivo.reservadoGestionPorc" [min]="0"
+                                                      (keyup)="cambiaPorcentajeTipo( 'reservadoGestion')"
+                                                      name="reservadoGestionporc" suffix="%">
                                             </plex-int>
                                         </div>
                                     </div>
@@ -195,11 +245,16 @@
                                             <label class="no-wrap">Para profesional</label>
                                         </div>
                                         <div class="col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.reservadoProfesional" [min]="0" [required]="true" (keyup)="cambiaCantTipo( 'reservadoProfesional')" name="reservadoProfesional">
+                                            <plex-int [(ngModel)]="elementoActivo.reservadoProfesional" [min]="0"
+                                                      [required]="true"
+                                                      (keyup)="cambiaCantTipo( 'reservadoProfesional')"
+                                                      name="reservadoProfesional">
                                             </plex-int>
                                         </div>
                                         <div class=" col-4">
-                                            <plex-int [(ngModel)]="elementoActivo.reservadoProfesionalPorc" [min]="0" (keyup)="cambiaPorcentajeTipo( 'reservadoProfesional')" name="progReservadoPorc" suffix="%">
+                                            <plex-int [(ngModel)]="elementoActivo.reservadoProfesionalPorc" [min]="0"
+                                                      (keyup)="cambiaPorcentajeTipo( 'reservadoProfesional')"
+                                                      name="progReservadoPorc" suffix="%">
                                             </plex-int>
                                         </div>
                                     </div>
@@ -208,28 +263,40 @@
                         </div>
                         <div class="row pt-3">
                             <div class="col-4">
-                                <plex-bool *ngIf="elementoActivo.accesoDirectoProgramado > 0 && mobileEnabled" [(ngModel)]="elementoActivo.turnosMobile" label="Ventanilla virtual" name="turnosMobile"></plex-bool>
+                                <plex-bool *ngIf="elementoActivo.accesoDirectoProgramado > 0 && mobileEnabled"
+                                           [(ngModel)]="elementoActivo.turnosMobile" label="Ventanilla virtual"
+                                           name="turnosMobile"></plex-bool>
                             </div>
-                            <div class="col-4" *ngIf="elementoActivo.turnosMobile && elementoActivo.accesoDirectoProgramado > 0 && mobileEnabled">
-                                <plex-int [(ngModel)]="elementoActivo.cupoMobile" [max]="elementoActivo.accesoDirectoProgramado" name="cupoMobile" suffix="Turnos" title="Este no es un cupo extra, es parte del cupo de programados" titlePosition="top">
+                            <div class="col-4"
+                                 *ngIf="elementoActivo.turnosMobile && elementoActivo.accesoDirectoProgramado > 0 && mobileEnabled">
+                                <plex-int [(ngModel)]="elementoActivo.cupoMobile"
+                                          [max]="elementoActivo.accesoDirectoProgramado" name="cupoMobile"
+                                          suffix="Turnos"
+                                          title="Este no es un cupo extra, es parte del cupo de programados"
+                                          titlePosition="top">
                                 </plex-int>
                             </div>
                         </div>
                         <div class="row">
                             <div *ngIf="!elementoActivo.citarPorBloque" class="col-4">
-                                <plex-bool [(ngModel)]="elementoActivo.pacienteSimultaneos" label="Pacientes simultáneos" name="pacienteSimultaneos"></plex-bool>
+                                <plex-bool [(ngModel)]="elementoActivo.pacienteSimultaneos"
+                                           label="Pacientes simultáneos" name="pacienteSimultaneos"></plex-bool>
                             </div>
                             <div *ngIf="elementoActivo.pacienteSimultaneos" class="col-4">
-                                <plex-int [(ngModel)]="elementoActivo.cantidadSimultaneos" name="cantidadSimultaneos" suffix="Pacientes" required>
+                                <plex-int [(ngModel)]="elementoActivo.cantidadSimultaneos" name="cantidadSimultaneos"
+                                          suffix="Pacientes" [min]=1 required>
                                 </plex-int>
                             </div>
                         </div>
                         <div class="row">
                             <div *ngIf="!elementoActivo.pacienteSimultaneos" class="col-4">
-                                <plex-bool [(ngModel)]="elementoActivo.citarPorBloque" label="Citar por segmento" name="citarPorBloque"></plex-bool>
+                                <plex-bool [(ngModel)]="elementoActivo.citarPorBloque" label="Citar por segmento"
+                                           name="citarPorBloque"></plex-bool>
                             </div>
                             <div *ngIf="elementoActivo.citarPorBloque" class="col-4">
-                                <plex-int [(ngModel)]="elementoActivo.cantidadBloque" [max]="elementoActivo.cantidadTurnos" name="cantidadBloque" suffix="Pacientes" required>
+                                <plex-int [(ngModel)]="elementoActivo.cantidadBloque" [min]=1
+                                          [max]="elementoActivo.cantidadTurnos" name="cantidadBloque" suffix="Pacientes"
+                                          required>
                                 </plex-int>
                             </div>
                         </div>
@@ -276,9 +343,11 @@
             <div class="col text-right">
                 <plex-button type="danger" label="Cancelar" (click)="cancelar()">
                 </plex-button>
-                <plex-button *ngIf="!hideGuardar && !alertas.length && form.valid" label="Guardar" validateForm="true" type="success" (click)="onSave($event, false)" title="Guardar">
+                <plex-button *ngIf="!hideGuardar && !alertas.length && form.valid" label="Guardar" validateForm="true"
+                             type="success" (click)="onSave($event, false)" title="Guardar">
                 </plex-button>
-                <plex-button *ngIf="!hideGuardar && !alertas.length && form.valid" label="Guardar y clonar" validateForm="true" type="primary" (click)="onSave($event, true)">
+                <plex-button *ngIf="!hideGuardar && !alertas.length && form.valid" label="Guardar y clonar"
+                             validateForm="true" type="primary" (click)="onSave($event, true)">
                 </plex-button>
             </div>
         </div>


### PR DESCRIPTION
### Funcionalidad desarrollada 

1. Se agrego el campo [min] al plex-int para restringir que no se ingresen números de pacientes negativos al citar por segmento (Linea 297)
2. Se agrego el campo [min] al plex-int para restringir que no se ingresen números de pacientes negativos al citar pacientes simultáneos (Linea 287)

Observación: Agrego las lineas porque los demás cambios son de linteo.


### UserStory llegó a completarse

- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

