### PR TITLE
CITAS: Al suspender una agenda en el gestor no se actualiza el estado

### DIFF
--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -666,7 +666,8 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
         this.showListadoTurnos = false;
         this.showAgregarNotaAgenda = false;
         if (agenda) {
-            this.getAgendas();
+            this.loadAgendas();
+            this.verAgenda(agenda, false, null);
         }
     }
 

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -666,9 +666,17 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
         this.showListadoTurnos = false;
         this.showAgregarNotaAgenda = false;
         if (agenda) {
-            this.loadAgendas();
+            this.actualizarAgenda(agenda);
             this.verAgenda(agenda, false, null);
         }
+    }
+
+    actualizarAgenda(agenda) {
+        const res = this.agendas.filter(function (element) {
+            return (element.id === agenda.id);
+        });
+        let indice = this.agendas.indexOf(res[0]);
+        this.agendas[indice] = agenda;
     }
 
     auditarFueraAgenda() {


### PR DESCRIPTION
### Requerimiento
[https://proyectos.andes.gob.ar/browse/CIT-28](url)

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al suspender una agenda se refresca la vista del gestor de agendas y se llama a la función _verAgenda_ para que se muestre el estado actualizado

### UserStory llegó a completarse

- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos

- [ ] Si
- [x] No

### Requiere actualizaciones en la API

- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion

- [x] Si https://github.com/andes/andes-test-integracion/pull/134
- [ ] No

GLPI asociado: [https://glpisalud.neuquen.gov.ar/front/ticket.form.php?id=4571](url)