### PR TITLE
CITAS: Pasar control de estados de agendas para operaciones que estan en app a la api

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -71,20 +71,20 @@ export class BotonesAgendaComponent implements OnInit {
             };
             this.serviceAgenda.patch(agenda.id, patch).subscribe((resultado: any) => {
                 // Si son múltiples, esperar a que todas se actualicen
-                if (resultado.mensaje === undefined) {
-                    agenda.estado = resultado.estado;
-                    if (alertCount === 0) {
-                        if (this.cantidadSeleccionadas === 1) {
-                            this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                            this.actualizarEstadoEmit.emit(estado);
-                        } else {
-                            this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                            this.actualizarEstadoEmit.emit(estado);
-                        }
-                        alertCount++;
+                agenda.estado = resultado.estado;
+                if (alertCount === 0) {
+                    if (this.cantidadSeleccionadas === 1) {
+                        this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
+                        this.actualizarEstadoEmit.emit(estado);
+                    } else {
+                        this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
+                        this.actualizarEstadoEmit.emit(estado);
                     }
-                } else {
-                    this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', resultado.mensaje);
+                    alertCount++;
+                }
+            }, err => {
+                if (err) {
+                    this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', err);
                     this.actualizarEstadoEmit.emit(estado);
                 }
             });

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -293,7 +293,16 @@ export class BotonesAgendaComponent implements OnInit {
 
     // Botón editar agenda
     editarAgenda() {
-        this.editarAgendaEmit.emit(this.agendasSeleccionadas[0]);
+        let select = this.agendasSeleccionadas[0];
+        this.serviceAgenda.getById(select.id).subscribe((agenda: any) => {
+            if (agenda.estado === select.estado) {
+                this.editarAgendaEmit.emit(select);
+            } else {
+                this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', 'Operacion no exitosa');
+                this.actualizarEstadoEmit.emit(agenda.estado);
+            }
+        });
+
     }
 
     // Botón clonar, emite que se va a clonar la agenda

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -69,19 +69,23 @@ export class BotonesAgendaComponent implements OnInit {
                 'op': estado,
                 'estado': estado
             };
-
             this.serviceAgenda.patch(agenda.id, patch).subscribe((resultado: any) => {
                 // Si son múltiples, esperar a que todas se actualicen
-                agenda.estado = resultado.estado;
-                if (alertCount === 0) {
-                    if (this.cantidadSeleccionadas === 1) {
-                        this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                        this.actualizarEstadoEmit.emit(estado);
-                    } else {
-                        this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
-                        this.actualizarEstadoEmit.emit(estado);
+                if (resultado.mensaje === undefined) {
+                    agenda.estado = resultado.estado;
+                    if (alertCount === 0) {
+                        if (this.cantidadSeleccionadas === 1) {
+                            this.plex.toast('success', 'Información', 'La agenda cambió el estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
+                            this.actualizarEstadoEmit.emit(estado);
+                        } else {
+                            this.plex.toast('success', 'Información', 'Las agendas cambiaron de estado a ' + (estado !== 'prePausada' ? estado : agenda.prePausada));
+                            this.actualizarEstadoEmit.emit(estado);
+                        }
+                        alertCount++;
                     }
-                    alertCount++;
+                } else {
+                    this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', resultado.mensaje);
+                    this.actualizarEstadoEmit.emit(estado);
                 }
             });
         });

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
@@ -106,13 +106,19 @@ export class PanelAgendaComponent implements OnInit {
                     'otroEspacioFisico': otroEspacioFisico
                 };
 
-                this.serviceAgenda.patch(agenda.id, patch).subscribe(resultado => {
-                    this.agenda = resultado;
-                    this.plex.toast('success', 'Información', 'La agenda se guardó correctamente ');
-                    this.actualizarEstadoEmit.emit(true);
+                this.serviceAgenda.patch(agenda.id, patch).subscribe((resultado: any) => {
+                    if (resultado.mensaje === undefined) {
+                        this.agenda = resultado;
+                        this.plex.toast('success', 'Información', 'La agenda se guardó correctamente ');
+                        this.actualizarEstadoEmit.emit(true);
+                    } else {
+                        this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', resultado.mensaje);
+                        this.actualizarEstadoEmit.emit(true);
+                    }
                 });
             }
         }
+
     }
 
 

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
@@ -107,12 +107,12 @@ export class PanelAgendaComponent implements OnInit {
                 };
 
                 this.serviceAgenda.patch(agenda.id, patch).subscribe((resultado: any) => {
-                    if (resultado.mensaje === undefined) {
-                        this.agenda = resultado;
-                        this.plex.toast('success', 'Información', 'La agenda se guardó correctamente ');
-                        this.actualizarEstadoEmit.emit(true);
-                    } else {
-                        this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', resultado.mensaje);
+                    this.agenda = resultado;
+                    this.plex.toast('success', 'Información', 'La agenda se guardó correctamente ');
+                    this.actualizarEstadoEmit.emit(true);
+                }, err => {
+                    if (err) {
+                        this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', err);
                         this.actualizarEstadoEmit.emit(true);
                     }
                 });

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
@@ -83,13 +83,13 @@ export class SuspenderAgendaComponent implements OnInit {
 
         this.serviceAgenda.patch(this.agenda.id, patch).subscribe((resultado: any) => {
             // Si son múltiples, esperar a que todas se actualicen
-            if (resultado.mensaje !== undefined) {
-                this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', resultado.mensaje);
+            this.agenda.estado = resultado.estado;
+            this.plex.toast('success', 'Información', 'La agenda cambió el estado a Suspendida');
+            this.returnSuspenderAgenda.emit(this.agenda);
+        }, err => {
+            if (err) {
+                this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', err);
                 this.cancelar();
-            } else {
-                this.agenda.estado = resultado.estado;
-                this.plex.toast('success', 'Información', 'La agenda cambió el estado a Suspendida');
-                this.returnSuspenderAgenda.emit(this.agenda);
             }
         });
     }

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/suspender-agenda.component.ts
@@ -83,8 +83,8 @@ export class SuspenderAgendaComponent implements OnInit {
 
         this.serviceAgenda.patch(this.agenda.id, patch).subscribe((resultado: any) => {
             // Si son múltiples, esperar a que todas se actualicen
-            if (resultado.mensaje) {
-                this.plex.info('warning', resultado.mensaje);
+            if (resultado.mensaje !== undefined) {
+                this.plex.info('warning', 'Otro usuario ha modificado el estado de la agenda seleccionada, su gestor se ha actualizado', resultado.mensaje);
                 this.cancelar();
             } else {
                 this.agenda.estado = resultado.estado;


### PR DESCRIPTION
### Requerimiento
[https://proyectos.andes.gob.ar/browse/CIT-26](url)

### Funcionalidad desarrollada 
1.  Se agrega verificación al cambiar el estado de una agenda, en el caso en que la seleccionada haya cambiado de estado mostrara un "warning" y se actualizará el gestor de agendas.


### UserStory llegó a completarse

- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos

- [ ] Si
- [x] No

### Requiere actualizaciones en la API

- [x] Si https://github.com/andes/api/pull/899
- [ ] No

### Requiere actualizaciones en andes-test-integracion

- [ ] Si
- [x] No

