### PR TITLE
CITAS: Resetea los bloques de agenda dinámica

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
@@ -225,11 +225,13 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
             } else {
                 this.noNominalizada = false;
                 this.modelo.nominalizada = true;
+                this.modelo.bloques.length = 0;
+                this.resetBloques();
             }
             // Se activan las prestaciones para la agenda
-            this.modelo.bloques[0].tipoPrestaciones.forEach(unaPrestacion => {
-                unaPrestacion.activo = true;
-            });
+            this.modelo.bloques[0].tipoPrestaciones.forEach(unaPrestacion => unaPrestacion.activo = true);
+            this.modelo.bloques.cantidadTurnos = 0;
+            this.validarTodo();
         }
     }
 
@@ -348,10 +350,7 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
             }
         }
         if (this.modelo.bloques.length === 0) {
-            this.addBloque();
-            this.bloqueActivo = 0;
-            this.elementoActivo.horaInicio = this.modelo.horaInicio;
-            this.elementoActivo.horaFin = this.modelo.horaFin;
+            this.resetBloques();
         } else {
             this.modelo.bloques.forEach((bloque) => {
                 // Si se elimino una prestación, la saco de los bloques
@@ -388,6 +387,13 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
                 }
             });
         }
+    }
+
+    private resetBloques() {
+        this.addBloque();
+        this.bloqueActivo = 0;
+        this.elementoActivo.horaInicio = this.modelo.horaInicio;
+        this.elementoActivo.horaFin = this.modelo.horaFin;
     }
 
     cambioHoraBloques(texto: String) {
@@ -913,4 +919,3 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
         }
     }
 }
-


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
#1541 
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al marcar una agenda cómo dinámica, se resetean los bloques de agenda, dejando un único bloque con datos cargados por defecto.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
