### PR TITLE
fix(rup): corrige error profesional sin frecuentes

### DIFF
--- a/src/app/modules/rup/components/ejecucion/buscador.component.ts
+++ b/src/app/modules/rup/components/ejecucion/buscador.component.ts
@@ -178,6 +178,8 @@ export class BuscadorComponent implements OnInit, OnChanges {
                 this.results['misFrecuentes']['todos'] = frecuentesProfesional;
                 this.filtrarResultados('misFrecuentes');
                 this.resultsAux.misFrecuentes = Object.assign({}, this.results.misFrecuentes);
+            } else {
+                this.results['misFrecuentes']['todos'] = [];
             }
 
             let frecuentesTP = await this.inicializarFrecuentesTP();


### PR DESCRIPTION
 ### Requerimiento
Cuando el profesional no tenía frecuentes, devolvía este error en la consola:

```
core.js:6014 ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'length' of undefined
TypeError: Cannot read property 'length' of undefined
at BuscadorComponent.<anonymous> (buscador.component.ts:198)
at Generator.next (<anonymous>)
at fulfilled (rup.component.ts:36)
at ZoneDelegate.invoke (zone-evergreen.js:359)
at Object.onInvoke (core.js:39699)
at ZoneDelegate.invoke (zone-evergreen.js:358)
at Zone.run (zone-evergreen.js:124)
at zone-evergreen.js:855
at ZoneDelegate.invokeTask (zone-evergreen.js:391)
at Object.onInvokeTask (core.js:39680)
at resolvePromise (zone-evergreen.js:797)
at zone-evergreen.js:707
at fulfilled (rup.component.ts:36)
at ZoneDelegate.invoke (zone-evergreen.js:359)
at Object.onInvoke (core.js:39699)
at ZoneDelegate.invoke (zone-evergreen.js:358)
at Zone.run (zone-evergreen.js:124)
at zone-evergreen.js:855
at ZoneDelegate.invokeTask (zone-evergreen.js:391)
at Object.onInvokeTask (core.js:39680)
```

### Funcionalidad desarrollada 
1. Inicializa el array en vacío si no hay frecuentes. 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
