### PR TITLE
fix(rup): Agrega control para prestaciones no nominalizadas

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -716,18 +716,21 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
             if (!this.accesoHudsPaciente && !this.accesoHudsPrestacion && this.routeToParams && this.routeToParams[0] === 'huds') {
                 // Se esta accediendo a 'HUDS DE UN PACIENTE'
                 window.sessionStorage.setItem('motivoAccesoHuds', motivoAccesoHuds);
-                this.routeTo(this.routeToParams[0], (this.routeToParams[1]) ? this.routeToParams[1] : null);
             } else {
-                this.hudsService.generateHudsToken(this.auth.usuario, this.auth.organizacion, this.accesoHudsPaciente, motivoAccesoHuds, this.auth.profesional.id, this.accesoHudsTurno, this.accesoHudsPrestacion).subscribe(hudsToken => {
-                    // se obtiene token y loguea el acceso a la huds del paciente
-                    window.sessionStorage.setItem('huds-token', hudsToken.token);
-                    this.routeTo(this.routeToParams[0], (this.routeToParams[1]) ? this.routeToParams[1] : null);
-                    this.routeToParams = [];
-                    this.accesoHudsPaciente = null;
-                    this.accesoHudsTurno = null;
-                    this.accesoHudsPrestacion = null;
-                });
+                if (this.accesoHudsPaciente) {
+                    this.hudsService.generateHudsToken(this.auth.usuario, this.auth.organizacion, this.accesoHudsPaciente, motivoAccesoHuds, this.auth.profesional.id, this.accesoHudsTurno, this.accesoHudsPrestacion).subscribe(hudsToken => {
+                        // se obtiene token y loguea el acceso a la huds del paciente
+                        window.sessionStorage.setItem('huds-token', hudsToken.token);
+                        this.routeToParams = [];
+                        this.accesoHudsPaciente = null;
+                        this.accesoHudsTurno = null;
+                        this.accesoHudsPrestacion = null;
+                    });
+                }
+
             }
+            this.routeTo(this.routeToParams[0], (this.routeToParams[1]) ? this.routeToParams[1] : null);
+
         }
         this.showModalMotivo = false;
     }


### PR DESCRIPTION

### Requerimiento
Se agrega control de paciente en el punto de inicio de RUP, para evitar la generacion del token de acceso a la HUDS para prestaciones no nominalizadas

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Verificación en preAccesoHuds
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
