### PR TITLE
fix(buscador de prestaciones y turnos): Cambia la propiedad a mostrar

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -108,7 +108,7 @@
                         </ng-container>
                     </div>
                     <td>{{busqueda.estado}}</td>
-                    <td *ngIf="!sumarB">{{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}</td>
+                    <td *ngIf="!sumarB">{{busqueda.financiador ? busqueda.financiador.financiador : 'No posee'}}</td>
                     <td *ngIf="sumarB">
                         {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}</td>
                 </tr>


### PR DESCRIPTION

### Requerimiento
No se visualizaba SUMAR en el listado de prestaciones y turnos en el caso de los pacientes que tienen dicha cobertura

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Cambia la propiedad a mostrar de nombre a financiador 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
