### PR TITLE
fix(auth): agrega icon de contraseña en login

### DIFF
--- a/src/app/apps/auth/components/login/login.html
+++ b/src/app/apps/auth/components/login/login.html
@@ -14,8 +14,7 @@
                               [required]="true">
                     </plex-int>
                     <plex-text label="Ingrese su contraseña" [(ngModel)]="password" name="password" [password]="true"
-                               [required]="true">
-                        <plex-icon name="dialpad" prefix></plex-icon>
+                               [required]="true" prefix="<i class='mdi mdi-dialpad'></i>">
                     </plex-text>
                     <div class="row">&nbsp;</div>
                     <plex-button type="success" [validateForm]="true" [disabled]="loading" (click)="login($event)">


### PR DESCRIPTION
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Una funcionalida de plex-icon evitaba que se vea el icono de la contraseña. 

### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [x] No

 