### PR TITLE
HUDS: Se configura ruta propia para HUDS

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -73,7 +73,7 @@ export class AppComponent {
 
         let dato = this.auth.getPermissions('huds:?').length;
         if (this.auth.getPermissions('huds:?').length || this.auth.getPermissions('rup:?').length) {
-            accessList.push({ label: 'HUDS: Visualizar por paciente', icon: 'file-tree', route: '/rup/huds' });
+            accessList.push({ label: 'HUDS: Visualizar por paciente', icon: 'file-tree', route: '/huds' });
         }
 
         if (this.auth.getPermissions('reportes:?').length > 0) {

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -163,14 +163,17 @@ const appRoutes: Routes = [
   { path: 'rup/auditoriaRUP', component: AuditoriaPrestacionPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/llavesTipoPrestacion', component: LlavesTipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/vista/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
-  { path: 'rup/huds/paciente/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
-  { path: 'rup/huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/internacion/censo', component: CensoDiarioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/internacion/censo/mensual', component: CensoMensualComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/internacion/listado', component: ListadoInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/internacion/listaEspera', component: ListaEsperaInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/plantillas', component: PlantillasRUPComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
+  // HUDS
+  { path: 'huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'huds/paciente/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
+  // Alias desde RUP
+  { path: 'rup/huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
   // Configuraciones / ABM
   { path: 'configuracionPrestacion', component: ConfiguracionPrestacionVisualizarComponent, canActivate: [RoutingNavBar, RoutingGuard] },
@@ -207,20 +210,20 @@ const appRoutes: Routes = [
   // TODO: Verificar si estas rutas todavía son válidas, y ubicarlas en los módulos correspondientes
   /* VERIFICAR ==> */ { path: 'tipoprestaciones', component: TipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Principal
-    { path: 'inicio', component: InicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'auth', loadChildren: './apps/auth/auth.module#AuthAppModule' },
+  // Principal
+  { path: 'inicio', component: InicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'auth', loadChildren: './apps/auth/auth.module#AuthAppModule' },
 
-    { path: 'estadisticas', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'dashboard', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'gestor-usuarios', loadChildren: './apps/gestor-usuarios/gestor-usuarios.module#GestorUsuariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
-    // Campañas Salud
-    { path: 'campaniasSalud', component: CampaniaSaludComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    // Turnero
-    { path: 'pantallas', loadChildren: './apps/turnero/turnero.module#TurneroModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'estadisticas', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'dashboard', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'gestor-usuarios', loadChildren: './apps/gestor-usuarios/gestor-usuarios.module#GestorUsuariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  // Campañas Salud
+  { path: 'campaniasSalud', component: CampaniaSaludComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Turnero
+  { path: 'pantallas', loadChildren: './apps/turnero/turnero.module#TurneroModule', canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // dejar siempre al último porque no encuentra las url después de esta
-    { path: '**', redirectTo: 'inicio' }
+  // dejar siempre al último porque no encuentra las url después de esta
+  { path: '**', redirectTo: 'inicio' }
 ];
 
 export const appRoutingProviders: any[] = [];

--- a/src/app/modules/rup/components/ejecucion/hudsBusquedaPaciente.component.ts
+++ b/src/app/modules/rup/components/ejecucion/hudsBusquedaPaciente.component.ts
@@ -1,10 +1,11 @@
-import { Router } from '@angular/router';
+import { Router, NavigationEnd } from '@angular/router';
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Plex } from '@andes/plex';
 import { Auth } from '@andes/auth';
 import { IPaciente } from '../../../../core/mpi/interfaces/IPaciente';
 import { HUDSService } from '../../services/huds.service';
 import { ModalMotivoAccesoHudsComponent as modal } from '../huds/modal-motivo-acceso-huds.component';
+import { filter } from 'rxjs/operators';
 
 @Component({
     selector: 'rup-hudsBusquedaPaciente',
@@ -21,6 +22,7 @@ export class HudsBusquedaPacienteComponent implements OnInit {
     // public motivoAccesoHuds;
     showModalMotivo = false;
     pacienteSelected = null;
+    rutaVolver = null;
 
     constructor(
         public plex: Plex,
@@ -43,10 +45,15 @@ export class HudsBusquedaPacienteComponent implements OnInit {
         if (!this.auth.profesional && this.auth.getPermissions('huds:?').length <= 0) {
             this.router.navigate(['inicio']);
         }
+
+        if (window.location.href.indexOf('rup') > -1) {
+            this.rutaVolver = '/rup';
+        }
+
     }
 
     onCancel() {
-        this.router.navigate(['rup']);
+        this.router.navigate([this.rutaVolver]);
     }
 
     searchStart() {
@@ -79,7 +86,7 @@ export class HudsBusquedaPacienteComponent implements OnInit {
             this.hudsService.generateHudsToken(this.auth.usuario, this.auth.organizacion, this.pacienteSelected, motivoAccesoHuds, this.auth.profesional ? this.auth.profesional : null, null, null).subscribe(hudsToken => {
                 window.sessionStorage.setItem('huds-token', hudsToken.token);
                 window.sessionStorage.removeItem('motivoAccesoHuds');
-                this.router.navigate(['/rup/huds/paciente/' + this.pacienteSelected.id]);
+                this.router.navigate(['/huds/paciente/' + this.pacienteSelected.id]);
             });
         }
         this.showModalMotivo = false;

--- a/src/app/modules/rup/components/ejecucion/hudsBusquedaPaciente.html
+++ b/src/app/modules/rup/components/ejecucion/hudsBusquedaPaciente.html
@@ -8,7 +8,7 @@
             </div>
         </div>
         <plex-loader *ngIf="loading"></plex-loader>
-        <div class=" row">
+        <div class="row">
             <div class="col-12">
                 <paciente-listado *ngIf="resultadoBusqueda && resultadoBusqueda.length" [pacientes]="resultadoBusqueda"
                                   [autoselect]="false" (selected)="onSelect($event)">
@@ -24,6 +24,7 @@
         </modal-motivo-acceso-huds>
     </plex-layout-main>
     <plex-layout-footer>
-        <plex-button position="left" label="Cancelar" type="info" (click)='onCancel()'></plex-button>
+        <plex-button position="left" label="Volver" type="info" (click)="onCancel()" *ngIf="rutaVolver">
+        </plex-button>
     </plex-layout-footer>
 </plex-layout>

--- a/src/app/modules/rup/components/ejecucion/vistaHuds.component.ts
+++ b/src/app/modules/rup/components/ejecucion/vistaHuds.component.ts
@@ -30,7 +30,7 @@ export class VistaHudsComponent implements OnInit, OnDestroy {
     // boton de volver cuando la ejecucion tiene motivo de internacion.
     // Por defecto vuelve al mapa de camas
     public btnVolver = 'VOLVER';
-    public rutaVolver;
+    public rutaVolver = '';
 
     constructor(
         public elementosRUPService: ElementosRUPService,
@@ -77,12 +77,14 @@ export class VistaHudsComponent implements OnInit, OnDestroy {
         });
 
         // consultamos desde que pagina se ingreso para poder volver a la misma
-        this.servicioPrestacion.rutaVolver.subscribe((resp: any) => {
-            if (resp) {
-                this.btnVolver = resp.nombre;
-                this.rutaVolver = resp.ruta;
-            }
-        });
+        // this.servicioPrestacion.rutaVolver.subscribe((resp: any) => {
+        //     if (resp) {
+        //         this.btnVolver = resp.nombre;
+        //         this.rutaVolver = resp.ruta;
+        //     }
+        // });
+
+
         // Limpiar los valores observados al iniciar la ejecución
         // Evita que se autocompleten valores de una consulta anterior
         this.conceptObserverService.destroy();
@@ -133,7 +135,7 @@ export class VistaHudsComponent implements OnInit, OnDestroy {
     */
     volver() {
         // this.location.back();
-        this.router.navigate(['/rup']);
+        this.router.navigate([this.rutaVolver]);
     }
 
     evtCambiaPaciente() {

--- a/src/app/modules/rup/components/ejecucion/vistaHuds.html
+++ b/src/app/modules/rup/components/ejecucion/vistaHuds.html
@@ -53,7 +53,7 @@
                                          [prestacion]="registro.data" [soloValores]="true"></internacion-resumen>
                 </plex-tab>
                 <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term"
-                    [class]="registro.class" *ngIf="registro.tipo === 'solicitud'">
+                          [class]="registro.class" *ngIf="registro.tipo === 'solicitud'">
                     <vista-solicitud-top [registro]="registro.data"></vista-solicitud-top>
                 </plex-tab>
 


### PR DESCRIPTION
### Requerimiento
- Desacoplar la página principal de la HUDS de RUP
- Evitar que la ruta "se pinte" en el menú principal

### Funcionalidad desarrollada 
1. Se configuraron rutas para la HUDS (punto inicio) y la HUDS de un paciente por ID
2. Se implementó funcionalidad para "volver" si se accede desde RUP (botón "ver HUDS de un paciente")
3. Se corrigió el problema del menú principal (drop-down), ya que quedaban items seleccionados por duplicado ver screenshot: 
![image](https://user-images.githubusercontent.com/11394455/75377541-c886fe80-58b0-11ea-9d42-d6a9e6d3343b.png)



### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [X] No
