### PR TITLE
RUP: Fecha de ejecución en agendas anteriores

### DIFF
--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -617,7 +617,7 @@ export class PrestacionesService {
         return prestacion;
     }
 
-    crearPrestacion(paciente: any, snomedConcept: any, momento: String = 'solicitud', fecha: any = new Date(), turno: any = null): Observable<any> {
+    crearPrestacion(paciente: any, snomedConcept: any, momento: String = 'solicitud', fecha: any, turno: any = null): Observable<any> {
         let prestacion = this.inicializarPrestacion(paciente, snomedConcept, momento, 'ambulatorio', fecha, turno);
         return this.post(prestacion);
     }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-39

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se verifica al iniciar una prestación desde el punto de inicio si la agenda es de un dia anterior al actual, en caso de serlo, se verifica si tiene horario de asistencia registrado, si esto es verdadero se asigna para crear la prestacion, caso contrario se asigna el horario de inicio de la agenda.
2. Al crear una prestación de una agenda anterior al día actual se guarda como fecha de ejecución, la fecha de la agenda y no la actual.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/917
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

