### PR TITLE
HUDS: fix(modal motivo acceso): se corrige problema al cerrar con tecla ESC

### DIFF
--- a/src/app/modules/rup/components/ejecucion/hudsBusquedaPaciente.component.ts
+++ b/src/app/modules/rup/components/ejecucion/hudsBusquedaPaciente.component.ts
@@ -81,6 +81,8 @@ export class HudsBusquedaPacienteComponent implements OnInit {
                 window.sessionStorage.removeItem('motivoAccesoHuds');
                 this.router.navigate(['/rup/huds/paciente/' + this.pacienteSelected.id]);
             });
+        } else {
+            this.pacienteSelected = null;
         }
         this.showModalMotivo = false;
     }

--- a/src/app/modules/rup/components/huds/modal-motivo-acceso-huds.component.ts
+++ b/src/app/modules/rup/components/huds/modal-motivo-acceso-huds.component.ts
@@ -40,6 +40,7 @@ export class ModalMotivoAccesoHudsComponent {
         } else {
             this.motivoAccesoHuds.emit(null);
         }
-        this.modal.close();
+        // No se usa this.modal.close() porque interfiere con el cerrar con la tecla ESC
+        this.modal.showed = false;
     }
 }

--- a/src/app/modules/rup/components/huds/modal-motivo-acceso-huds.html
+++ b/src/app/modules/rup/components/huds/modal-motivo-acceso-huds.html
@@ -1,4 +1,4 @@
-<plex-modal #modal>
+<plex-modal #modal (closed)="notificarAccion(false)">
     <plex-icon name="alert-circle" type="danger"></plex-icon>
     <plex-modal-title type="danger">Historia Universal Digital de Salud</plex-modal-title>
     <plex-modal-subtitle type="">Por favor, indique el motivo de acceso:</plex-modal-subtitle>
@@ -23,6 +23,4 @@
     <plex-button modal left type="danger" (click)="notificarAccion(false)">
         CANCELAR
     </plex-button>
-
-
 </plex-modal>


### PR DESCRIPTION
### Requerimiento
Cuando se abre un plex-modal, es posible cerrarlo presionando la tecla ESC, actualmente se puede cerrar, pero si cierra de esta manera luego el modal no vuelve a abrirse. Nótese que si se usa el botón "Cerrar" nativo de plex-modal el problema no sucede.

### Funcionalidad desarrollada 
1. Se usó una manera diferente de registrar que el modal se cerró, antes hacía `this.modal.close()` ahora hace `this.modal.closed = true`, ya que la detección de eventos de teclado ya realiza un llamado al método `close()` y si se usa el mismo método desde el componente motivo-de-acceso genera un loop de llamados a `close()`, o algo.
2. Tener en cuenta que hay un problema con plex-modal en PLEX que no permite ingresar nada en el campo de búsqueda, ese bug se arregla en https://github.com/andes/plex/pull/128, mientras tanto se puede probar pegando un DNI o nombre en el campo de búsqueda.

### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [X] No

