### PR TITLE
RUP: se modifican llamados a la api en la recarga del punto de inicio

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -187,7 +187,7 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
                 this.cargarTurnos(this.agendas[0]);
             }
 
-           // recorremos agenda seleccionada para ver si tienen planes pendientes y mostrar en la vista..
+            // recorremos agenda seleccionada para ver si tienen planes pendientes y mostrar en la vista..
             if (this.agendaSeleccionada) {
                 this.agendaSeleccionada.bloques.forEach(element => {
                     element.turnos.forEach(turno => {
@@ -421,18 +421,11 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     reloadAgenda() {
         return this.agendaSeleccionada.id ? observableForkJoin(
             this.servicioAgenda.getById(this.agendaSeleccionada.id),
-            this.getPrestaciones(),
-            this.getPrestacionesPendientes()
         ).subscribe(data => {
-                let agenda = data[0];
-                this.prestaciones = data[1];
-                if (data[2]) {
-                    this.prestaciones = [...this.prestaciones, ...data[2]];
-                }
-
-                this.cargarPrestacionesTurnos(agenda);
-                this.agendas[this.agendas.indexOf(this.agendaSeleccionada)] = this.agendaSeleccionada = agenda;
-            }
+            let agenda = data[0];
+            this.cargarPrestacionesTurnos(agenda);
+            this.agendas[this.agendas.indexOf(this.agendaSeleccionada)] = this.agendaSeleccionada = agenda;
+        }
         ) : null;
     }
 
@@ -460,37 +453,38 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
 
     cargarPrestacionesTurnos(agenda) {
         // if (agenda) {
-            // loopeamos agendas y vinculamos el turno si existe con alguna de las prestaciones
-            agenda['cantidadTurnos'] = 0;
-            agenda.bloques.forEach(bloques => {
-                agenda['cantidadTurnos'] += bloques.turnos.length;
-                // loopeamos los turnos dentro de los bloques
-                bloques.turnos.forEach(turno => {
-                    let indexPrestacion = this.prestaciones.findIndex(prestacion => {
-                        return (prestacion.solicitud.turno && prestacion.solicitud.turno === turno.id);
-                    });
-                    // asignamos la prestacion al turno
-                    turno['prestacion'] = this.prestaciones[indexPrestacion];
-                    if (turno.paciente && turno.paciente.carpetaEfectores) {
-                        (turno.paciente.carpetaEfectores as any) = turno.paciente.carpetaEfectores.filter((ce: any) => ce.organizacion._id === this.auth.organizacion.id);
-                    }
+        // loopeamos agendas y vinculamos el turno si existe con alguna de las prestaciones
 
+        agenda['cantidadTurnos'] = 0;
+        agenda.bloques.forEach(bloques => {
+            agenda['cantidadTurnos'] += bloques.turnos.length;
+            // loopeamos los turnos dentro de los bloques
+            bloques.turnos.forEach(turno => {
+                let indexPrestacion = this.prestaciones.findIndex(prestacion => {
+                    return (prestacion.solicitud.turno && prestacion.solicitud.turno === turno.id);
                 });
+                // asignamos la prestacion al turno
+                turno['prestacion'] = this.prestaciones[indexPrestacion];
+                if (turno.paciente && turno.paciente.carpetaEfectores) {
+                    (turno.paciente.carpetaEfectores as any) = turno.paciente.carpetaEfectores.filter((ce: any) => ce.organizacion._id === this.auth.organizacion.id);
+                }
+
             });
+        });
 
-            // busquemos si hay sobreturnos para vincularlos con la prestacion correspondiente
-            if (agenda.sobreturnos) {
-                agenda.sobreturnos.forEach(sobreturno => {
-                    let indexPrestacion = this.prestaciones.findIndex(prestacion => {
-                        return (prestacion.solicitud.turno && prestacion.solicitud.turno === sobreturno.id);
-                    });
-                    // asignamos la prestacion al turno
-                    sobreturno['prestacion'] = this.prestaciones[indexPrestacion];
-                    if (sobreturno.paciente && sobreturno.paciente.carpetaEfectores) {
-                        (sobreturno.paciente.carpetaEfectores as any) = sobreturno.paciente.carpetaEfectores.filter((ce: any) => ce.organizacion._id === this.auth.organizacion.id);
-                    }
+        // busquemos si hay sobreturnos para vincularlos con la prestacion correspondiente
+        if (agenda.sobreturnos) {
+            agenda.sobreturnos.forEach(sobreturno => {
+                let indexPrestacion = this.prestaciones.findIndex(prestacion => {
+                    return (prestacion.solicitud.turno && prestacion.solicitud.turno === sobreturno.id);
                 });
-            }
+                // asignamos la prestacion al turno
+                sobreturno['prestacion'] = this.prestaciones[indexPrestacion];
+                if (sobreturno.paciente && sobreturno.paciente.carpetaEfectores) {
+                    (sobreturno.paciente.carpetaEfectores as any) = sobreturno.paciente.carpetaEfectores.filter((ce: any) => ce.organizacion._id === this.auth.organizacion.id);
+                }
+            });
+        }
         // }
     }
 

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -491,7 +491,7 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     intervalAgendaRefresh() {
         this.stopAgendaRefresh();
         if (this.agendaSeleccionada && this.agendaSeleccionada !== 'fueraAgenda' && moment(this.agendaSeleccionada.horaInicio).isSame(new Date(), 'day')) {
-            const timeOut = 30000; // Lapso de tiempo en que se recargara la agenda seleccionada
+            const timeOut = 300000; // Lapso de tiempo en que se recargara la agenda seleccionada
             this.interval = setInterval(this.reloadAgenda.bind(this), timeOut);
         }
     }


### PR DESCRIPTION
### Requerimiento
Se disparaba el uso de cpu en el servidor a partir del PR que recargaba el punto de inicio del profesional cada 30 segundos

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1.  Se quitan llamados a prestaciones en la recarga del punto de inicio. 
2. Se deja solo la recarga de la agenda actual cada 30 segundos.
3. Se eleva el intervalo de refresco de 30 segundos a 5 minutos


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
