### PR TITLE
CITAS: Visualizar detalle de agendas y prestaciones realizadas por el profesional

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -36,6 +36,8 @@ export class TurnosPrestacionesComponent implements OnInit {
     public prestaciones: any;
     public puedeEmitirComprobante: Boolean;
 
+    public selectProfesional: Boolean = false;
+    public profesional: any;
     public botonBuscarDisabled: Boolean = false;
 
     constructor(
@@ -88,7 +90,6 @@ export class TurnosPrestacionesComponent implements OnInit {
         }]);
     }
 
-
     initialize() {
         let fecha = moment().format();
 
@@ -109,11 +110,25 @@ export class TurnosPrestacionesComponent implements OnInit {
             estado: '',
             estadoFacturacion: '',
         };
+
+        if (this.auth.profesional) {
+            this.serviceProfesional.get({ id: this.auth.profesional }).subscribe(rta => {
+                this.profesional = rta[0];
+                params.idProfesional = this.profesional.id;
+                this.parametros['idProfesional'] = this.profesional.id;
+                this.selectProfesional = true;
+                this.busquedaPrestaciones(params);
+            });
+        } else {
+            this.busquedaPrestaciones(params);
+        }
+    }
+
+    private busquedaPrestaciones(params) {
         this.turnosPrestacionesService.get(params).subscribe((data) => {
             this.busquedas = this.ordenarPorFecha(data);
             this.loading = false;
         });
-
     }
 
     @Unsubscribe()
@@ -130,7 +145,6 @@ export class TurnosPrestacionesComponent implements OnInit {
     }
 
     refreshSelection(value, tipo) {
-
         let fechaDesde = this.fechaDesde ? moment(this.fechaDesde).startOf('day') : null;
         let fechaHasta = this.fechaHasta ? moment(this.fechaHasta).endOf('day') : null;
 

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -48,7 +48,7 @@
                     <plex-select [(ngModel)]="profesionales" (change)="refreshSelection($event, 'profesionales')"
                                  (getData)="loadEquipoSalud($event)" label="Equipo de salud"
                                  placeholder="Buscar por equipo de salud" labelField="apellido+' '+nombre"
-                                 ngModelOptions="{standalone: true}">
+                                 ngModelOptions="{standalone: true}" [readonly]="selectProfesional">
                     </plex-select>
                 </div>
                 <div class="col-3">
@@ -125,7 +125,7 @@
                 </div>
                 <div class="col d-flex justify-content-end">
                     <plex-button label="Cerrar" type="danger" (click)="onClose()"></plex-button>
-                    <plex-button *ngIf="puedeEmitirComprobante && (prestacion.financiador?.financiador === 'SUMAR' || prestacion.financiador === 'SUMAR') && ((!prestacion.estadoFacturacion) || prestacion.estadoFacturacion?.estado!=='Comprobante con prestacion')"
+                    <plex-button *ngIf="puedeEmitirComprobante && (!this.auth.profesional) && (prestacion.financiador?.financiador === 'SUMAR' || prestacion.financiador === 'SUMAR') && ((!prestacion.estadoFacturacion) || prestacion.estadoFacturacion?.estado!=='Comprobante con prestacion')"
                                  label="Comprobante" type="success" (click)="recupero()"></plex-button>
                 </div>
             </div>


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/plugins/servlet/mobile#issue/CIT-19

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al inicializar el componente turnos-prestaciones, se verifica si el usuario logueado es profesional, en caso de serlo se muestran solo los turnos asignados al mismo y se bloquea el filtro de profesionales( _[readonly]="selectProfesional"_ ).
2. Al seleccionar un turno se verifica si el usuario logueado es profesional, en caso de serlo se oculta el botón "Comprobante" 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/andes-test-integracion/pull/105
- [ ] No
