### PR TITLE
Punto de inicio RUP: Quita tooltip de cantidad de solicitudes asignadas

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -122,7 +122,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         this.servicioTurnero.get({ 'fields': 'espaciosFisicos.id' }).subscribe((pantallas) => {
             this.espaciosFisicosTurnero = pantallas.reduce((listado, p) => listado.concat(p.espaciosFisicos), []).map((espacio: any) => { return espacio.id; });
         });
-        this.cargarSolicitudes();
     }
 
     redirect(pagina: string) {

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.html
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.html
@@ -5,8 +5,7 @@
             <plex-help type="info" titulo="Reglas Solicitudes" tituloBoton="Reglas Solicitudes">
                 <visualizacion-reglas info [esParametrizado]="true"></visualizacion-reglas>
             </plex-help>
-            <plex-button type="warning" size="sm" title="Tiene {{solicitudes.length}} asignada/s"
-                         (click)="irASolicitudes()"> Mis
+            <plex-button type="warning" size="sm" (click)="irASolicitudes()"> Mis
                 solicitudes</plex-button>
         </plex-title>
 


### PR DESCRIPTION
### Requerimiento
Se quita tooltip que indicaba la cantidad de solicitudes asignadas para mejora de performance

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se quita llamada a solicitudes en carga de punto de inicio de rup
2. Se quita tooltip del botón


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->

