### PR TITLE
MISC: arreglo de error al cargar vista de pantallas

### DIFF
--- a/src/app/apps/turnero/views/pantalla-detalle.component.ts
+++ b/src/app/apps/turnero/views/pantalla-detalle.component.ts
@@ -36,7 +36,7 @@ export class PantallaDetalleComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.espacioFisicoService.get({ organizacion: this.auth.organizacion.id }).subscribe(data => this.espaciosFisicos = data);
+        this.espacioFisicoService.get({ organizacion: this.auth.organizacion }).subscribe(data => this.espaciosFisicos = data);
         this.listaTipos = [{ id: 'totem', nombre: 'Totem' }, { id: 'turnero', nombre: 'Turnero' }];
         this.esTurnero = this.pantalla.tipo === 'turnero';
     }

--- a/src/app/apps/turnero/views/pantallas.component.ts
+++ b/src/app/apps/turnero/views/pantallas.component.ts
@@ -37,7 +37,7 @@ export class PantallasComponent implements OnInit, OnDestroy {
         this.plex.updateTitle('Configuración de pantallas interactivas');
         let temp;
         this.ws.connect();
-        this.ws.join(`turnero-${this.auth.organizacion.id}`);
+        this.ws.join(`turnero-${this.auth.organizacion}`);
         this.sub = this.ws.events.subscribe(({ event, data }) => {
             let { pantalla } = data;
             switch (event) {
@@ -98,7 +98,7 @@ export class PantallasComponent implements OnInit, OnDestroy {
         this.pantalla = {
             nombre: '',
             espaciosFisicos: [],
-            organizacion: this.auth.organizacion.id
+            organizacion: this.auth.organizacion
         };
         this.mostrarDetalle = true;
         this.router.navigate(['/pantallas/create']);


### PR DESCRIPTION
### Requerimiento
Arreglar error en '/pantallas' al leer el id de la organización de auth 

### Funcionalidad desarrollada 
1. Se cambia this.auth.organizacion.id por this.auth.organizacion en los componentes pantallas y pantalla-detalle

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
