### PR TITLE
Se actualiza template de PRs, se agrega recordatorio para correr tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,8 @@ _____________________________________________
 
 2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
 3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
-4) Completar las siguientes secciones:
+4) NO olvidar correr los tests localmente antes de crear el PR.
+5) Completar las siguientes secciones:
 
 -->
 ### Requerimiento

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -172,7 +172,6 @@ const appRoutes: Routes = [
   { path: 'rup/internacion/listaEspera', component: ListaEsperaInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
   { path: 'rup/plantillas', component: PlantillasRUPComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-
   // Configuraciones / ABM
   { path: 'configuracionPrestacion', component: ConfiguracionPrestacionVisualizarComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 


### PR DESCRIPTION
### Requerimiento
Agregar un recordatorio para que no se olviden de correr los tests localmente antes de crear un PR

### Funcionalidad desarrollada 
1. Ninguna, se editó el template de este texto


### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [X] No
