### PR TITLE
RUP - Se elimina scroll horizontal en resultados

### DIFF
--- a/src/app/modules/rup/components/ejecucion/buscador.scss
+++ b/src/app/modules/rup/components/ejecucion/buscador.scss
@@ -19,15 +19,12 @@
     height: calc(100% - 220px);
     cdk-virtual-scroll-viewport {
         height: 100%;
+        overflow-x: hidden;
     }
 }
 
 .menu-buscador {
     .container-filtros {
-        // width: 103%;
-        // overflow: scroll;
-        // position: relative;
-        // height: auto;
         padding: 2px 0;
         margin: 5px 0;
     }


### PR DESCRIPTION
**Requerimiento**
https://proyectos.andes.gob.ar/browse/UIUX-95

**Funcionalidad desarrollada** 
Se agrega la propiedad <overflow-x: hidden> al tag <cdk-virtual-scroll-viewport>

**Cuál era el problema?**
Angular material incorpora la siguiente directiva: cdk-virtual-scroll-viewport *que a su vez, incluye la propiedad overflow con valor 'auto' haciendo override sobre la clase .plex-box-content*  del plex-box que está seteada inicialmente en hidden sobre el eje x (overflow-x: hidden); generando un scroll innecesario en el panel lateral.
 
### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No
