### PR TITLE
fix(rup-autocitación NUEVO): se agregan cambios para determinar autocitación

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionCrear.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionCrear.component.ts
@@ -110,6 +110,7 @@ export class PrestacionCrearComponent implements OnInit {
     }
 
     seleccionarTipoPrestacion() {
+        this.paciente = null;
         this.mostrarPaciente = this.tipoPrestacionSeleccionada && !this.tipoPrestacionSeleccionada.noNominalizada;
     }
 

--- a/src/app/modules/rup/components/ejecucion/prestacionCrear.html
+++ b/src/app/modules/rup/components/ejecucion/prestacionCrear.html
@@ -3,9 +3,8 @@
         <plex-title titulo="Crear Prestación">
             <plex-button type="danger" label="CANCELAR" (click)="cancelar()">
             </plex-button>
-            <plex-button label="INICIAR PRESTACIÓN" type="success" (click)="iniciarPrestacion()"
-                         [disabled]="opcion === 'fueraAgenda' && !paciente?.id && !tipoPrestacionSeleccionada?.noNominalizada"
-                         class="ml-1">
+            <plex-button [label]="btnLabel" type="success" (click)="btnClick()"
+                         [disabled]="!paciente?.id && !tipoPrestacionSeleccionada?.noNominalizada" class="ml-1">
             </plex-button>
         </plex-title>
         <div class="row">


### PR DESCRIPTION
### Requerimiento
Incorporar funcionalidad que permite dar una autocitación que se perdió en rebase, otra vez :joy_cat: 

### Funcionalidad desarrollada 
1. Se agregó funcionalidad de dar turno autocitado desde punto inicio de RUP

### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [X] Si
- [ ] No
**Habría que agregar test más completos para Autocitación, que contemplen el ciclo completo desde el punto de inicio de RUP, y navegación**
