### PR TITLE
fix(rup): remueve llamado incesario a crear prestacion

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionCrear.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionCrear.component.ts
@@ -230,7 +230,6 @@ export class PrestacionCrearComponent implements OnInit {
         this.servicioAgenda.get(params).subscribe(agendas => {
             this.agendasAutocitar = agendas;
             this.prestacionAutocitar = this.tipoPrestacionSeleccionada;
-            this.servicioPrestacion.crearPrestacion(this.paciente, this.tipoPrestacionSeleccionada.id, 'solicitud', (new Date()), null);
             this.showAutocitar = true;
         });
     }


### PR DESCRIPTION
 
### Requerimiento
El loader de plex quedaba corriendo todo el tiempo al dar una autocitación.

### Funcionalidad desarrollada 
1. Se elimina un POST sin subscribe que no es estaba ejecutando y no dabía estar ahí. 

### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
