### PR TITLE
RUP: agrega modal de motivo de consulta de HUDs en fuera de agenda

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.html
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.html
@@ -337,7 +337,7 @@
     <plex-layout-sidebar *ngIf="prestacion">
         <!-- Panel Buscador SNOMED + HUDS -->
         <div class="tabs-buscador-huds pr-0 h-100">
-            <plex-tabs [activeIndex]="panelIndex" *ngIf="!prestacion.solicitud.tipoPrestacion.noNominalizada"
+            <plex-tabs [activeIndex]="panelIndex" (change)="tabChange($event)" *ngIf="!prestacion.solicitud.tipoPrestacion.noNominalizada"
                        size="full">
                 <plex-tab label="Buscador" (click)="panelIndex = 0">
                     <rup-buscador [prestacion]="prestacion" [frecuentesTipoPrestacion]="masFrecuentes"
@@ -350,7 +350,7 @@
                     </rup-buscador>
                 </plex-tab>
                 <plex-tab *ngIf="tieneAccesoHUDS" label="Historia de Salud" (click)="panelIndex = 1">
-                    <rup-hudsBusqueda [paciente]="prestacion?.paciente" [_dragScope]="'registros-rup'"
+                    <rup-hudsBusqueda *ngIf="mostrarHUDS" [paciente]="prestacion?.paciente" [_dragScope]="'registros-rup'"
                                       (evtData)="ejecutarConceptoHuds($event)"
                                       (_onDragStart)="arrastrandoConcepto(true)"
                                       (_onDragEnd)="arrastrandoConcepto(false)"></rup-hudsBusqueda>
@@ -376,3 +376,6 @@
 
     </plex-layout-footer>
 </plex-layout>
+
+<modal-motivo-acceso-huds [show]="showModalMotivo" (motivoAccesoHuds)="preAccesoHuds($event)">
+</modal-motivo-acceso-huds>


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/PRIV-31
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Agrega modal de motivo de consulta de HUDs para prestaciones fuera de agenda

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si https://proyectos.andes.gob.ar/browse/PRIV-31
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
