### PR TITLE
CITAS: Resetea turnos virtuales a 0

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
@@ -918,4 +918,10 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
             return (arrayTP.length === 1);
         }
     }
+
+    onVentanillaVirtualChange($event) {
+        if (!$event.value) {
+            this.elementoActivo.cupoMobile = 0;
+        }
+    }
 }

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.html
@@ -265,7 +265,7 @@
                             <div class="col-4">
                                 <plex-bool *ngIf="elementoActivo.accesoDirectoProgramado > 0 && mobileEnabled"
                                            [(ngModel)]="elementoActivo.turnosMobile" label="Ventanilla virtual"
-                                           name="turnosMobile"></plex-bool>
+                                           name="turnosMobile" (change)="onVentanillaVirtualChange($event)"></plex-bool>
                             </div>
                             <div class="col-4"
                                  *ngIf="elementoActivo.turnosMobile && elementoActivo.accesoDirectoProgramado > 0 && mobileEnabled">


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
Arregla bug: En planificación de agenda, si se destilda el checkbox de ventanilla virtual y el bloque previamente tenía una cantidad de turnos virtuales mayor que 0, dicha cantidad permanece, a pesar que no debiera poseer ninguún turno virtual.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Cada vez que se destilda el checkbox de ventanilla virtual, se setea la cantidad de turnos virtuales a 0.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
