### PR TITLE
fix(mpi): Evita doble click en  "Ignorar y Guardar"

### DIFF
--- a/src/app/core/mpi/components/paciente-cru.component.ts
+++ b/src/app/core/mpi/components/paciente-cru.component.ts
@@ -560,6 +560,10 @@ export class PacienteCruComponent implements OnInit {
             this.plex.info('warning', 'Existen relaciones sin parentezco. Completelas antes de guardar', 'Atención');
         } else {
             this.disableGuardar = true;
+            if (ignoreCheck) {
+                this.enableIgnorarGuardar = false;
+            }
+
             let pacienteGuardar: any = Object.assign({}, this.pacienteModel);
             pacienteGuardar.ignoreCheck = ignoreCheck;
             pacienteGuardar.sexo = ((typeof this.pacienteModel.sexo === 'string')) ? this.pacienteModel.sexo : (Object(this.pacienteModel.sexo).id);

--- a/src/app/core/mpi/components/paciente-cru.html
+++ b/src/app/core/mpi/components/paciente-cru.html
@@ -319,8 +319,9 @@
                      (click)="deshacerValidacion()"></plex-button>
         <plex-button [disabled]="disableGuardar" class="pr-1" label="Guardar" type="success" position="right"
                      [validateForm]="formulario" (click)="save($event,false)"></plex-button>
-        <plex-button *ngIf="enableIgnorarGuardar" label="Ignorar y Guardar" type="warning" position="right"
-                     [validateForm]="formulario" (click)="save($event,true)"></plex-button>
+        <plex-button [disabled]="!enableIgnorarGuardar" *ngIf="enableIgnorarGuardar" label="Ignorar y Guardar"
+                     type="warning" position="right" [validateForm]="formulario" (click)="save($event,true)">
+        </plex-button>
 
     </plex-layout-footer>
 


### PR DESCRIPTION

### Requerimiento
Deshabilita el botón "Ignorar y Guardar" para evitar doble click al guardar un paciente, después de mostrarse el listado de pacientes similares

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Agrega propiedad disabled al botón "Ignorar y Guardar" en paciente-cru
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
