### PR TITLE
USUARIOS: Fix copiar/pegar permisos

### DIFF
--- a/src/app/apps/gestor-usuarios/views/usuarios-edit.view.html
+++ b/src/app/apps/gestor-usuarios/views/usuarios-edit.view.html
@@ -25,10 +25,10 @@
             <plex-button type="danger" size="sm" (click)="borrar()">
                 <plex-icon name="delete"></plex-icon>
             </plex-button>
-            <plex-button type="info" size="sm" (click)="copy()" title="Copiar permisos">
+            <plex-button type="info" size="sm" (click)="copy()" title="Copiar permisos" titlePosition="left">
                 <plex-icon name="content-copy"></plex-icon>
             </plex-button>
-            <plex-button type="info" size="sm" (click)="paste()" title="Pegar permisos"
+            <plex-button type="info" size="sm" (click)="paste()" title="Pegar permisos" titlePosition="left"
                          *ngIf="permisosService.hasCopy()">
                 <plex-icon name="content-paste"></plex-icon>
             </plex-button>


### PR DESCRIPTION
### Requerimiento
Problema con el tooltip de copiar/pegar permisos

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega _titlePosition="left"_ a _plex-button_ para solucionar problema con el _tooltip_ en botones de copiar y pegar permisos

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
