### PR TITLE
mapa-camas: pre visualización de los registros médicos

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -541,6 +541,7 @@ import { SelectBaseComponent } from './modules/rup/components/elementos/rupers/s
 import { DisclaimerService } from './services/disclaimer.service';
 import { SeccionComponent } from './modules/rup/components/elementos/rupers/seccionado/seccion.component';
 import { SeccionadoComponent } from './modules/rup/components/elementos/rupers/seccionado/seccionado.component';
+import { INTERNACION_COMPONENTS, INTERNACION_PROVIDERS } from './apps/rup/mapa-camas/mapa-camas.module';
 
 
 registerLocaleData(localeEs, 'es');
@@ -702,7 +703,9 @@ registerLocaleData(localeEs, 'es');
         SelectOrganizacionDirective,
         SelectProfesionalesDirective,
         SelectPrestacionesDirective,
-        SelectFinanciadorDirective
+        SelectFinanciadorDirective,
+
+        ...INTERNACION_COMPONENTS
     ],
     entryComponents: RUPComponentsArray,
     bootstrap: [AppComponent],
@@ -794,7 +797,8 @@ registerLocaleData(localeEs, 'es');
         WebSocketService,
         HotjarService,
         ConceptosTurneablesService,
-        DisclaimerService
+        DisclaimerService,
+        ...INTERNACION_PROVIDERS
     ]
 })
 

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -107,124 +107,132 @@ import { CampaniaSaludComponent } from './apps/campaniaSalud/components/campania
 // Buscador de turnos y prestaciones
 import { TurnosPrestacionesComponent } from './components/buscadorTurnosPrestaciones/turnos-prestaciones.component';
 import { NuevaSolicitudComponent } from './components/top/solicitudes/nuevaSolicitud.component';
+import { INTERNACION_ROUTES } from './apps/rup/mapa-camas/mapa-camas.routing';
 
 const appRoutes: Routes = [
-    // Tablas maestras
-    { path: 'tm/organizacion', component: OrganizacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/organizacion/:id/sectores', component: OrganizacionSectoresComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/organizacion/:id/ofertas_prestacionales', component: OrganizacionOfertaPrestacionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/organizacion/cama/:idCama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/organizacion/cama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/profesional', component: ProfesionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/profesional/create', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/profesional/create/:id', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/especialidad', component: EspecialidadComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/espacio_fisico', component: EspacioFisicoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'tm/mapa_espacio_fisico', component: MapaEspacioFisicoVistaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Tablas maestras
+  { path: 'tm/organizacion', component: OrganizacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/organizacion/:id/sectores', component: OrganizacionSectoresComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/organizacion/:id/ofertas_prestacionales', component: OrganizacionOfertaPrestacionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/organizacion/cama/:idCama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/organizacion/cama', component: CamaCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/profesional', component: ProfesionalComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/profesional/create', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/profesional/create/:id', component: ProfesionalCreateUpdateComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/especialidad', component: EspecialidadComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/espacio_fisico', component: EspacioFisicoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'tm/mapa_espacio_fisico', component: MapaEspacioFisicoVistaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // MPI
-    { path: 'apps/mpi/busqueda', component: BusquedaMpiComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/bebe', component: BebeCruComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/paciente', component: PacienteCruComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/extranjero', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/bebe/:origen', component: BebeCruComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/extranjero/:origen', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/paciente/:opcion/:origen', component: PacienteCruComponent, canActivate: [RoutingGuard] },
-    { path: 'apps/mpi/auditoria/vincular-pacientes', component: VincularPacientesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'apps/mpi/auditoria', component: AuditoriaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // MPI
+  { path: 'apps/mpi/busqueda', component: BusquedaMpiComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/bebe', component: BebeCruComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/paciente', component: PacienteCruComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/extranjero', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/bebe/:origen', component: BebeCruComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/extranjero/:origen', component: ExtranjeroNNCruComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/paciente/:opcion/:origen', component: PacienteCruComponent, canActivate: [RoutingGuard] },
+  { path: 'apps/mpi/auditoria/vincular-pacientes', component: VincularPacientesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'apps/mpi/auditoria', component: AuditoriaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Obras sociales
-    { path: 'puco', component: PucoComponent, canActivate: [RoutingNavBar] },
+  // Obras sociales
+  { path: 'puco', component: PucoComponent, canActivate: [RoutingNavBar] },
 
-    // Turnos
-    { path: 'citas', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/clonarAgenda', component: ClonarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/gestor_agendas', component: GestorAgendasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/panelEspacio', component: PanelEspacioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/agendas', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/agenda', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/turnos', component: DarTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/listaEspera', component: ListaEsperaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/punto-inicio', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/punto-inicio/:idPaciente', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Turnos
+  { path: 'citas', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/clonarAgenda', component: ClonarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/gestor_agendas', component: GestorAgendasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/panelEspacio', component: PanelEspacioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/agendas', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/agenda', component: PlanificarAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/turnos', component: DarTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/listaEspera', component: ListaEsperaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/punto-inicio', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/punto-inicio/:idPaciente', component: PuntoInicioTurnosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    { path: 'citas/revision_agenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/revision_agenda/:idAgenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    // { path: 'citas/sobreturnos', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/sobreturnos/:idAgenda', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'citas/paciente/:idAgenda', component: AgregarPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    // RUP
-    { path: 'rup', component: PuntoInicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/crear/:opcion', component: PrestacionCrearComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/crear', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/crear/:id', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/ocuparCama/:idCama/:idInternacion', component: OcuparCamaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/ejecucion/:id', component: PrestacionEjecucionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/validacion/:id', component: PrestacionValidacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/auditoriaRUP', component: AuditoriaPrestacionPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/llavesTipoPrestacion', component: LlavesTipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/vista/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
-    { path: 'rup/huds/paciente/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
-    { path: 'rup/huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/censo', component: CensoDiarioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/censo/mensual', component: CensoMensualComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/listado', component: ListadoInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/internacion/listaEspera', component: ListaEsperaInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'rup/plantillas', component: PlantillasRUPComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/revision_agenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/revision_agenda/:idAgenda', component: RevisionAgendaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // { path: 'citas/sobreturnos', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/sobreturnos/:idAgenda', component: AgregarSobreturnoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'citas/paciente/:idAgenda', component: AgregarPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // RUP
+  { path: 'rup', component: PuntoInicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/crear/:opcion', component: PrestacionCrearComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/crear', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/crear/:id', component: IniciarInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/ocuparCama/:idCama/:idInternacion', component: OcuparCamaComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/ejecucion/:id', component: PrestacionEjecucionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/validacion/:id', component: PrestacionValidacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/auditoriaRUP', component: AuditoriaPrestacionPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/llavesTipoPrestacion', component: LlavesTipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/vista/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
+  { path: 'rup/huds/paciente/:id', component: VistaHudsComponent, canActivate: [RoutingNavBar, RoutingGuard, RoutingHudsGuard] },
+  { path: 'rup/huds', component: HudsBusquedaPacienteComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/censo', component: CensoDiarioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/censo/mensual', component: CensoMensualComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/listado', component: ListadoInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/internacion/listaEspera', component: ListaEsperaInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'rup/plantillas', component: PlantillasRUPComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Configuraciones / ABM
-    { path: 'configuracionPrestacion', component: ConfiguracionPrestacionVisualizarComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Configuraciones / ABM
+  { path: 'configuracionPrestacion', component: ConfiguracionPrestacionVisualizarComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Mapa de camas
-    { path: 'internacion/camas', component: MapaDeCamasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'internacion/inicio', component: PuntoInicioInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Mapa de camas
+  { path: 'internacion/camas', component: MapaDeCamasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'internacion/inicio', component: PuntoInicioInternacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Préstamos HC
-    { path: 'prestamosHC', component: PrestamosHcComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Préstamos HC
+  { path: 'prestamosHC', component: PrestamosHcComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // formulario terapeutico
-    { path: 'formularioTerapeutico', component: FormTerapeuticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // formulario terapeutico
+  { path: 'formularioTerapeutico', component: FormTerapeuticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Reportes
-    { path: 'reportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'consultaDiagnostico', component: ConsultaDiagnosticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'encabezadoReportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'cantidadConsultaXPrestacion', component: CantidadConsultaXPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Reportes
+  { path: 'reportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'consultaDiagnostico', component: ConsultaDiagnosticoComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'encabezadoReportes', component: EncabezadoReportesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'cantidadConsultaXPrestacion', component: CantidadConsultaXPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // ReportesDiarios
-    { path: 'reportesDiarios', component: EncabezadoReportesDiariosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // ReportesDiarios
+  { path: 'reportesDiarios', component: EncabezadoReportesDiariosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Solicitudes
-    { path: 'solicitudes', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'solicitudes/:tipo', component: NuevaSolicitudComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'asignadas', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Solicitudes
+  { path: 'solicitudes', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'solicitudes/:tipo', component: NuevaSolicitudComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'asignadas', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Buscador de turnos y prestaciones
-    { path: 'buscador', component: TurnosPrestacionesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Buscador de turnos y prestaciones
+  { path: 'buscador', component: TurnosPrestacionesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // TOP
-    { path: 'top/reglas', component: ReglasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'top/reglasVisualizacion', component: VisualizacionReglasTopComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // TOP
+  { path: 'top/reglas', component: ReglasComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'top/reglasVisualizacion', component: VisualizacionReglasTopComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
   // TODO: Verificar si estas rutas todavía son válidas, y ubicarlas en los módulos correspondientes
   /* VERIFICAR ==> */ { path: 'tipoprestaciones', component: TipoPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // Principal
-    { path: 'auth', loadChildren: './apps/auth/auth.module#AuthAppModule' },
-    { path: 'inicio', component: InicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Principal
+  { path: 'auth', loadChildren: './apps/auth/auth.module#AuthAppModule' },
+  { path: 'inicio', component: InicioComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
-    { path: 'estadisticas', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'dashboard', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'gestor-usuarios', loadChildren: './apps/gestor-usuarios/gestor-usuarios.module#GestorUsuariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
-    // Campañas Salud
-    { path: 'campaniasSalud', component: CampaniaSaludComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    // Turnero
-    { path: 'pantallas', loadChildren: './apps/turnero/turnero.module#TurneroModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'estadisticas', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'dashboard', loadChildren: './modules/estadisticas/estadistica.module#EstadisticaModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'gestor-usuarios', loadChildren: './apps/gestor-usuarios/gestor-usuarios.module#GestorUsuariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  // Campañas Salud
+  { path: 'campaniasSalud', component: CampaniaSaludComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // Turnero
+  { path: 'pantallas', loadChildren: './apps/turnero/turnero.module#TurneroModule', canActivate: [RoutingNavBar, RoutingGuard] },
 
-    { path: 'internacion', loadChildren: './apps/rup/mapa-camas/mapa-camas.module#MapaCamasModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  // LAMENTABLEMENTE TENGO QUE SACAR EL MODULO DE INTERNACION HASTA PROXIMO AVISO
+  // { path: 'internacion', loadChildren: './apps/rup/mapa-camas/mapa-camas.module#MapaCamasModule', canActivate: [RoutingNavBar, RoutingGuard] },
+  {
+    path: 'internacion', children: [
+      ...INTERNACION_ROUTES
+    ], canActivate: [RoutingNavBar, RoutingGuard]
+  },
 
-    // dejar siempre al último porque no encuentra las url después de esta
-    { path: '**', redirectTo: 'inicio' }
+
+  // dejar siempre al último porque no encuentra las url después de esta
+  { path: '**', redirectTo: 'inicio' }
 ];
 
 export const appRoutingProviders: any[] = [];

--- a/src/app/apps/rup/mapa-camas/mapa-camas.module.ts
+++ b/src/app/apps/rup/mapa-camas/mapa-camas.module.ts
@@ -43,56 +43,63 @@ import { MaquinaEstadosHTTP } from './services/maquina-estados.http';
 import { ListadoInternacionService } from './views/listado-internacion/listado-internacion.service';
 import { RegistrosHudsDetalleComponent } from './sidebar/registros-huds-detalle/registros-huds-detalle.component';
 
+export const INTERNACION_COMPONENTS = [
+    MapaCamasMainComponent,
+    MapaCamasCapaComponent,
+    CensosDiariosComponent,
+    CensosMensualesComponent,
+    FiltrosCamasComponent,
+    CamaMainComponent,
+    EstadoServicioComponent,
+    ItemCamaComponent,
+    IngresarPacienteComponent,
+    IconoCamitaComponent,
+    CamaDestinoGenericoComponent,
+    CamaDesocuparComponent,
+    EgresarPacienteComponent,
+    CamaDetalleComponent,
+    InternacionDetalleComponent,
+    InformeIngresoComponent,
+    InformeEgresoComponent,
+    HistorialDetalleComponent,
+    MovimientosInternacionComponent,
+    CambiarCamaComponent,
+    InternacionListadoComponent,
+    InternacionListaEsperaComponent,
+    ElegirPacienteComponent,
+    FiltrosInternacionComponent,
+    NuevoRegistroSaludComponent,
+    RegistrosHudsDetalleComponent
+];
 
-@NgModule({
-    imports: [
-        CommonModule,
-        PlexModule,
-        FormsModule,
-        RouterModule,
-        HttpClientModule,
-        MapaCamasRouting,
-        SharedModule,
-        MPILibModule,
-        MitosModule,
-        OrganizacionLibModule
-    ],
-    declarations: [
-        MapaCamasMainComponent,
-        MapaCamasCapaComponent,
-        CensosDiariosComponent,
-        CensosMensualesComponent,
-        FiltrosCamasComponent,
-        CamaMainComponent,
-        EstadoServicioComponent,
-        ItemCamaComponent,
-        IngresarPacienteComponent,
-        IconoCamitaComponent,
-        CamaDestinoGenericoComponent,
-        CamaDesocuparComponent,
-        EgresarPacienteComponent,
-        CamaDetalleComponent,
-        InternacionDetalleComponent,
-        InformeIngresoComponent,
-        InformeEgresoComponent,
-        HistorialDetalleComponent,
-        MovimientosInternacionComponent,
-        CambiarCamaComponent,
-        InternacionListadoComponent,
-        InternacionListaEsperaComponent,
-        ElegirPacienteComponent,
-        FiltrosInternacionComponent,
-        NuevoRegistroSaludComponent,
-        RegistrosHudsDetalleComponent
-    ],
-    providers: [
-        MapaCamasService,
-        MapaCamasHTTP,
-        MaquinaEstadosHTTP,
-        ListadoInternacionService
-    ],
-    exports: [],
-})
-export class MapaCamasModule {
+export const INTERNACION_PROVIDERS = [
+    MapaCamasService,
+    MapaCamasHTTP,
+    MaquinaEstadosHTTP,
+    ListadoInternacionService
+];
 
-}
+// @NgModule({
+//     imports: [
+//         CommonModule,
+//         PlexModule,
+//         FormsModule,
+//         RouterModule,
+//         HttpClientModule,
+//         MapaCamasRouting,
+//         SharedModule,
+//         MPILibModule,
+//         MitosModule,
+//         OrganizacionLibModule
+//     ],
+//     declarations: [
+//         ...INTERNACION_COMPONENTS
+//     ],
+//     providers: [
+//         ...INTERNACION_PROVIDERS
+//     ],
+//     exports: [],
+// })
+// export class MapaCamasModule {
+
+// }

--- a/src/app/apps/rup/mapa-camas/mapa-camas.routing.ts
+++ b/src/app/apps/rup/mapa-camas/mapa-camas.routing.ts
@@ -8,7 +8,7 @@ import { CensosMensualesComponent } from './views/censos/censo-mensual/censo-men
 import { InternacionListadoComponent } from './views/listado-internacion/listado-internacion.component';
 import { InternacionListaEsperaComponent } from './views/lista-espera/lista-espera.component';
 
-const routes = [
+export const INTERNACION_ROUTES = [
     { path: 'mapa-camas', component: MapaCamasMainComponent },
 
     { path: 'mapa-camas/:capa', component: MapaCamasCapaComponent },
@@ -30,7 +30,7 @@ const routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forChild(routes)],
+    imports: [RouterModule.forChild(INTERNACION_ROUTES)],
     providers: []
 })
 export class MapaCamasRouting { }

--- a/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
+++ b/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
@@ -62,6 +62,8 @@ export class MapaCamasService {
     // public listaInternacionFiltrada$: Observable<IPrestacion[]>;
     public fechaActual$: Observable<Date>;
 
+    public mainView = new BehaviorSubject<any>('mapa-camas');
+
     public ambito = 'internacion';
     public capa;
     public fecha: Date;
@@ -163,6 +165,10 @@ export class MapaCamasService {
             map(() => moment().toDate()),
             startWith(new Date())
         );
+    }
+
+    resetView() {
+        this.mainView.next('mapa-camas');
     }
 
     getEstadoCama(cama: ISnapshot) {

--- a/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/cama-detalle.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/cama-detalle.component.ts
@@ -98,6 +98,7 @@ export class CamaDetalleComponent implements OnInit, OnDestroy {
     }
 
     cambiarTab(index) {
+        this.mapaCamasService.resetView();
         this.tabIndex = index;
     }
 

--- a/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/historial-detalle/historial-detalle.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/historial-detalle/historial-detalle.component.html
@@ -32,7 +32,7 @@
             </td>
             <td *ngIf="item.paciente; else sinPaciente">
                 <small>
-                    {{ item.paciente | nombre }}
+                    {{ item.paciente | paciente }}
                 </small>
             </td>
             <ng-template #sinPaciente>

--- a/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/internacion-detalle/internacion-detalle.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/internacion-detalle/internacion-detalle.component.ts
@@ -83,6 +83,7 @@ export class InternacionDetalleComponent implements OnInit, OnDestroy {
     }
 
     onActiveOption(opcion) {
+        this.mapaCamasService.resetView();
         this.mostrar = opcion;
     }
 

--- a/src/app/apps/rup/mapa-camas/sidebar/ingreso/informe-ingreso.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/ingreso/informe-ingreso.component.html
@@ -43,7 +43,8 @@
             </div>
             <div class="row mt-4">
                 <div class="col-6">
-                    <plex-label titulo="Profesional responsable" subtitulo="{{ informeIngreso.profesional | nombre }}">
+                    <plex-label titulo="Profesional responsable"
+                                subtitulo="{{ informeIngreso.profesional | profesional }}">
                     </plex-label>
                 </div>
                 <div class="col-6">

--- a/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.html
@@ -42,7 +42,7 @@
         </tr>
     </thead>
     <tbody>
-        <tr *ngFor="let prestacion of historialFiltrado$ | async; trackBy: trackById">
+        <tr *ngFor="let prestacion of historialFiltrado$ | async">
             <td>
                 <small>
                     {{ prestacion.solicitud.fecha | fecha }}

--- a/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.html
@@ -1,10 +1,12 @@
 <plex-title titulo="Registros">
-    <plex-button type="info" size="sm" (click)="verHuds()">
-        HUDS
-    </plex-button>
-    <plex-button size="sm" type="info" (click)="onNuevoRegistrio()">
-        NUEVO
-    </plex-button>
+    <ng-container *ngIf="esProfesional">
+        <plex-button type="info" size="sm" (click)="verHuds()">
+            HUDS
+        </plex-button>
+        <plex-button size="sm" type="info" (click)="onNuevoRegistrio()" class="ml-1">
+            NUEVO
+        </plex-button>
+    </ng-container>
     <ng-content></ng-content>
 </plex-title>
 <div class="row mb-1">
@@ -36,10 +38,11 @@
                     PROFESIONAL
                 </small>
             </th>
+            <th></th>
         </tr>
     </thead>
     <tbody>
-        <tr *ngFor="let prestacion of historialFiltrado$ | async">
+        <tr *ngFor="let prestacion of historialFiltrado$ | async; trackBy: trackById">
             <td>
                 <small>
                     {{ prestacion.solicitud.fecha | fecha }}
@@ -53,8 +56,15 @@
             </td>
             <td>
                 <small>
-                    {{ prestacion.solicitud.profesional | nombre }}
+                    {{ prestacion.solicitud.profesional | profesional }}
                 </small>
+            </td>
+            <td>
+                <plex-button size="sm" icon="eye" type="info" (click)="onViewRegistro(prestacion)" title="Ver"
+                             titlePosition="left" *ngIf="!esEjecucion(prestacion)"></plex-button>
+                <plex-button size="sm" label="Continuar" (click)="ejecutar(prestacion)" type="info" title="Continuar"
+                             titlePosition="left" *ngIf="esEjecucion(prestacion)">
+                </plex-button>
             </td>
         </tr>
     </tbody>

--- a/src/app/apps/rup/mapa-camas/views/lista-espera/lista-espera.component.html
+++ b/src/app/apps/rup/mapa-camas/views/lista-espera/lista-espera.component.html
@@ -12,7 +12,7 @@
                     <b button></b>
                 </plex-heading>
                 <plex-item *ngFor="let item of listaEspera">
-                    <plex-label [tituloBold]="false" titulo="{{ item.paciente | nombre  }}"></plex-label>
+                    <plex-label [tituloBold]="false" titulo="{{ item.paciente | paciente  }}"></plex-label>
                     <plex-label [tituloBold]="false" titulo="{{ item.paciente.documento }}"></plex-label>
                     <plex-label [tituloBold]="false" titulo="{{ item.paciente | sexo }}"></plex-label>
                     <plex-label [tituloBold]="false" titulo="{{ item.paciente.fechaNacimiento | fecha }}"></plex-label>

--- a/src/app/apps/rup/mapa-camas/views/listado-internacion/listado-internacion.component.html
+++ b/src/app/apps/rup/mapa-camas/views/listado-internacion/listado-internacion.component.html
@@ -28,7 +28,7 @@
                                     [class.text-white]="selectedPrestacion._id === internacion._id"
                                     (click)="seleccionarPrestacion(internacion, selectedPrestacion)">
                                     <td>
-                                        {{internacion.paciente | nombre }}
+                                        {{internacion.paciente | paciente }}
                                     </td>
                                     <td>
                                         {{internacion.paciente.documento}}

--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/filtros-cama/filtros-camas.component.ts
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/filtros-cama/filtros-camas.component.ts
@@ -61,7 +61,7 @@ export class FiltrosCamasComponent implements OnInit {
         );
 
         this.equipamientoList$ = this.mapaCamasService.snapshot$.pipe(
-            map((camas) => arrayToSet(camas, 'conceptId', (item) => item.equipamiento)),
+            map((camas) => arrayToSet(camas, 'conceptId', ((item) => item.equipamiento ? item.equipamiento : []))),
         );
 
         this.estadoList$ = this.mapaCamasService.snapshot$.pipe(

--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.html
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.html
@@ -32,7 +32,7 @@
                     <th>ACCIONES</th>
                 </tr>
                 <ng-container *ngIf="(selectedCama$ | async) as selectedCama">
-                    <tr app-item-cama *ngFor="let cama of camas | async; trackBy: trackByFn" [cama]="cama" [capa]="capa"
+                    <tr app-item-cama *ngFor="let cama of camas | async" [cama]="cama" [capa]="capa"
                         [permisoIngreso]="permisoIngreso" (accionCama)="selectCama(cama, $event)"
                         (click)="verDetalle(cama, selectedCama)" [class.invert]="cama._id === selectedCama._id">
                     </tr>

--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.html
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.html
@@ -1,6 +1,6 @@
 <plex-layout main="8">
     <plex-layout-main>
-        <header>
+        <header [hidden]="mainView !== 'mapa-camas'">
             <plex-title titulo="Mapa de Camas">
                 <plex-button *ngIf="capa === 'estadistica'" class="mr-1" size="sm" label="LISTA DE ESPERA"
                              type="primary" (click)="gotoListaEspera()">
@@ -22,7 +22,7 @@
             </plex-title>
 
         </header>
-        <fieldset>
+        <fieldset [hidden]="mainView !== 'mapa-camas'">
             <table class="table table-striped table-hover">
                 <tr>
                     <th>CAMA</th>
@@ -32,13 +32,18 @@
                     <th>ACCIONES</th>
                 </tr>
                 <ng-container *ngIf="(selectedCama$ | async) as selectedCama">
-                    <tr app-item-cama *ngFor="let cama of camas | async" [cama]="cama" [capa]="capa"
+                    <tr app-item-cama *ngFor="let cama of camas | async; trackBy: trackByFn" [cama]="cama" [capa]="capa"
                         [permisoIngreso]="permisoIngreso" (accionCama)="selectCama(cama, $event)"
                         (click)="verDetalle(cama, selectedCama)" [class.invert]="cama._id === selectedCama._id">
                     </tr>
                 </ng-container>
             </table>
         </fieldset>
+        <ng-container *ngIf="mainView !== 'mapa-camas'">
+            <vista-prestacion [idPrestacion]="mainView.id">
+                <plex-button type="danger" size="sm" icon="close" (click)="mapaCamasService.resetView()"></plex-button>
+            </vista-prestacion>
+        </ng-container>
     </plex-layout-main>
     <plex-layout-sidebar type="invert">
         <app-estado-servicio *ngIf="!accion"></app-estado-servicio>

--- a/src/app/modules/rup/components/huds/vistaPrestacion.html
+++ b/src/app/modules/rup/components/huds/vistaPrestacion.html
@@ -1,6 +1,9 @@
-<div class="prestaciones mt-3 ml-3">
+<div class="prestaciones mt-3 ml-3" *ngIf="ready$ | async">
     <ng-container *ngIf="prestacion">
-        <h4 class="text-capitalize">{{ prestacion.solicitud.tipoPrestacion.term }}</h4>
+        <h4 class="text-capitalize" justify>
+            {{ prestacion.solicitud.tipoPrestacion.term }}
+            <ng-content></ng-content>
+        </h4>
         <div class="row">
             <div class="col-6">
                 <b> Fecha: </b>
@@ -65,12 +68,12 @@
                                 </span>
                             </div>
                             <div class="content">
-                                <div class="row" *ngIf="paciente">
+                                <div class="row" *ngIf="prestacion.paciente">
                                     <div class="col-12">
                                         <rup [elementoRUP]="elementosRUPService.elementoRegistro(elemento)"
                                              [params]="elementosRUPService.getParams(elemento)"
-                                             [prestacion]="prestacion" [registro]="elemento" [paciente]="paciente"
-                                             [soloValores]="true" [vistaHUDS]="false">
+                                             [prestacion]="prestacion" [registro]="elemento"
+                                             [paciente]="prestacion.paciente" [soloValores]="true" [vistaHUDS]="false">
                                         </rup>
                                     </div>
                                 </div>

--- a/src/app/modules/rup/components/huds/vistaPrestacion.ts
+++ b/src/app/modules/rup/components/huds/vistaPrestacion.ts
@@ -10,6 +10,7 @@ import { PacienteService } from '../../../../core/mpi/services/paciente.service'
 @Component({
     selector: 'vista-prestacion',
     templateUrl: 'vistaPrestacion.html',
+    styleUrls: ['../core/_rup.scss'],
     encapsulation: ViewEncapsulation.None,
 })
 
@@ -21,6 +22,8 @@ export class VistaPrestacionComponent {
     @Input() evolucionActual: any;
     @Input() indice = 0;
 
+    public ready$ = this.elementosRUPService.ready;
+
     constructor(
         public servicioPrestacion: PrestacionesService,
         private servicioPaciente: PacienteService,
@@ -31,16 +34,13 @@ export class VistaPrestacionComponent {
     @Input()
     set idPrestacion(value: any) {
         this.paciente = null;
+        this.prestacion = null;
         this._idPrestacion = value;
-        this.elementosRUPService.ready.subscribe((resultado) => {
-            if (resultado) {
-                this.servicioPrestacion.getById(this.idPrestacion).subscribe(prestacion => {
-                    this.prestacion = prestacion;
-                    this.servicioPaciente.getById(this.prestacion.paciente.id).subscribe(paciente => {
-                        this.paciente = paciente;
-                    });
-                });
-            }
+        this.servicioPrestacion.getById(this.idPrestacion).subscribe(prestacion => {
+            this.servicioPaciente.getById(prestacion.paciente.id).subscribe(paciente => {
+                this.prestacion = prestacion;
+                this.paciente = paciente;
+            });
         });
     }
     get idPrestacion(): any {


### PR DESCRIPTION
### Requerimiento
Pre-visualización de prestaciones de internación desde el mapa de cama. 

### Funcionalidad desarrollada 
1.  Agrega botón "ojo" en cada registros de internación.
2. Se pre-visualizan en el layout pricipal.
3. Se elimina modulo internación hasta que exista el modulo de RUP. 


### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API 
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [X] No

 