### PR TITLE
feat(mapa-camas): agrega sectores en seleccionar cama

### DIFF
--- a/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
+++ b/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
@@ -98,6 +98,12 @@ export class MapaCamasService {
                 return this.camasHTTP.snapshot(ambito, capa, fecha);
             }),
             map((snapshot: ISnapshot[]) => {
+                snapshot.forEach((snap) => {
+                    const sectores = snap.sectores || [];
+                    const sectorName = [...sectores].reverse().map(s => s.nombre).join(', ');
+                    (snap as any).sectorName = sectorName;
+                });
+
                 return snapshot.sort((a, b) => (a.unidadOrganizativa.term.localeCompare(b.unidadOrganizativa.term)) ||
                     (a.sectores[a.sectores.length - 1].nombre.localeCompare(b.sectores[b.sectores.length - 1].nombre + '')) ||
                     (a.nombre.localeCompare('' + b.nombre)));

--- a/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/cambiar-cama.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/cambiar-cama.component.html
@@ -9,7 +9,8 @@
         <ng-container *ngIf="camasDisponibles$ | async as camasDisponibles">
             <plex-select [required]="true" [(ngModel)]="nuevaCama" name="cama"
                          [data]="(cambiarUO) ? camasDisponibles.camasDistintaUO : camasDisponibles.camasMismaUO"
-                         placeholder="Elija cama" label="Cama" idField="idCama" labelField="nombre">
+                         placeholder="Elija cama" label="Cama" idField="idCama"
+                         labelField="nombre + '(' + sectorName + ')'">
             </plex-select>
         </ng-container>
     </fieldset>

--- a/src/app/apps/rup/mapa-camas/sidebar/ingreso/ingresar-paciente.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/ingreso/ingresar-paciente.component.html
@@ -35,8 +35,9 @@
                             <div class="col-md">
                                 <ng-container *ngIf="camas$ | async as camas">
                                     <plex-select *ngIf="!prestacion" [required]="true" [(ngModel)]="cama" name="cama"
-                                                 [data]="camas" placeholder="Elija cama" label="Cama" idField="nombre"
-                                                 labelField="nombre" (change)="selectCama(cama)">
+                                                 [data]="camas" placeholder="Elija cama" label="Cama" idField="idCama"
+                                                 labelField="nombre + '(' + sectorName + ')'"
+                                                 (change)="selectCama(cama)">
                                     </plex-select>
                                 </ng-container>
                                 <plex-text *ngIf="prestacion && cama" [required]="true" [disabled]="true" label="Cama"

--- a/src/app/apps/rup/mapa-camas/sidebar/ingreso/ingresar-paciente.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/ingreso/ingresar-paciente.component.ts
@@ -315,6 +315,7 @@ export class IngresarPacienteComponent implements OnInit, OnDestroy {
                 this.onSave.emit();
             }
         } else {
+            delete this.cama['sectorName'];
             this.cama.extras = { ingreso: true };
             this.mapaCamasService.save(this.cama, this.informeIngreso.fechaIngreso).subscribe(camaActualizada => {
                 this.plex.info('success', 'Paciente internado');


### PR DESCRIPTION
### Requerimiento
Mostrar nombre del sector para identificar la cama ya que hay muchas camas con el mismo nombre: "CAMA 01", "CAMA 02".

### Funcionalidad desarrollada  
1.  Agrega nombre del sector para identificar rapidamente la cama.


### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [x] No
 