### PR TITLE
tipo-prestaciones: cache de prestaciones según permisos

### DIFF
--- a/src/app/apps/gestor-usuarios/views/usuarios-list.view.ts
+++ b/src/app/apps/gestor-usuarios/views/usuarios-list.view.ts
@@ -86,7 +86,7 @@ export class UsuariosListComponent implements OnInit {
                 if (query.search) {
                     query.search = '^' + query.search;
                 }
-                return this.usuariosHttp.find({ ...query, fields: '-password -permisosGlobales' });
+                return this.usuariosHttp.find({ ...query, fields: '-password -permisosGlobales', limit: 50 });
             }),
             tap(() => this.userSelected = null),
             cache()

--- a/src/app/components/top/solicitudes/solicitudes.html
+++ b/src/app/components/top/solicitudes/solicitudes.html
@@ -43,9 +43,10 @@
                         </plex-select>
                     </div>
                     <div class="col-3">
-                        <plex-select [(ngModel)]="prestacionDestino" [required]="true" name="nombrePrestacion" label="Prestación destino"
-                            name="prestacionDestino" tmPrestaciones="solicitudes:tipoPrestacion:?" (change)="cargarSolicitudes()"
-                            [preload]="true">
+                        <plex-select [(ngModel)]="prestacionDestino" [required]="true" name="nombrePrestacion"
+                                     label="Prestación destino" name="prestacionDestino"
+                                     tmPrestaciones="solicitudes:tipoPrestacion:?" (change)="cargarSolicitudes()"
+                                     [preload]="true">
                         </plex-select>
                     </div>
                     <div class="col-3">

--- a/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
+++ b/src/app/components/turnos/gestor-agendas/gestor-agendas.component.ts
@@ -479,7 +479,7 @@ export class GestorAgendasComponent implements OnInit, OnDestroy {
                 event.callback(listaEspaciosFisicos);
             });
             // Para que el filtro muestre las instituciones
-            this.serviceInstitucion.get(query.nombre).subscribe(resultado => {
+            this.serviceInstitucion.get({ search: '^' + query.nombre }).subscribe(resultado => {
                 if (this.modelo.espacioFisico) {
                     listaEspaciosFisicos = resultado ? this.modelo.espacioFisico.concat(resultado) : this.modelo.espacioFisico;
                 } else {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/panel-agenda.component.ts
@@ -153,7 +153,7 @@ export class PanelAgendaComponent implements OnInit {
                     event.callback(listaEspaciosFisicos);
                 });
             } else {
-                this.serviceInstitucion.get(query['nombre']).subscribe(resultado => {
+                this.serviceInstitucion.get({ search: '^' + query['nombre'] }).subscribe(resultado => {
                     listaEspaciosFisicos = resultado;
                     event.callback(listaEspaciosFisicos);
                 });

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/planificar-agenda.component.ts
@@ -174,7 +174,7 @@ export class PlanificarAgendaComponent implements OnInit, AfterViewInit {
             };
             let listaEspaciosFisicos = [];
             if (!this.espacioFisicoPropios) {
-                this.servicioInstitucion.get(event.query).subscribe(resultado => {
+                this.servicioInstitucion.get({ search: '^' + event.query }).subscribe(resultado => {
                     listaEspaciosFisicos = resultado;
                     event.callback(listaEspaciosFisicos);
                 });

--- a/src/app/directives/prestaciones-select.directive.ts
+++ b/src/app/directives/prestaciones-select.directive.ts
@@ -33,7 +33,7 @@ export class SelectPrestacionesDirective implements OnInit, OnDestroy {
         if (this.preload) {
             plexSelect.data = [];
             const permisos = this.tmPrestaciones;
-            this.conceptosTurneables.search({ permisos }).subscribe(result => {
+            this.conceptosTurneables.getByPermisos(permisos).subscribe(result => {
                 plexSelect.data = result;
             });
         } else {

--- a/src/app/services/conceptos-turneables.service.ts
+++ b/src/app/services/conceptos-turneables.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ResourceBaseHttp, Server } from '@andes/shared';
+import { ResourceBaseHttp, Server, Cache } from '@andes/shared';
 import { ITipoPrestacion } from '../interfaces/ITipoPrestacion';
 
 @Injectable()
@@ -8,5 +8,12 @@ export class ConceptosTurneablesService extends ResourceBaseHttp<ITipoPrestacion
 
     constructor(protected server: Server) {
         super(server);
+    }
+
+    @Cache({ key: true })
+    getByPermisos(permisos?: string) {
+        // para evitar que se envie por la red si es null
+        permisos = permisos || undefined;
+        return this.search({ permisos });
     }
 }


### PR DESCRIPTION
### Requerimiento
Cache de prestaciones según permisos y replicada en la directiva de prestaciones.
Ajusta la busqueda de instituciones y limit=50 en el gestor de usuarios para mantener compatibilidad.

### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API  
- [x] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [x] No

https://github.com/andes/api/pull/970