### PR TITLE
fix(prestamo-carpeta): stopPropagation change event

### DIFF
--- a/src/app/shared/components/upload-file.component.ts
+++ b/src/app/shared/components/upload-file.component.ts
@@ -40,7 +40,7 @@ export class UploadFileComponent {
 
     }
 
-    public get btnLabel () {
+    public get btnLabel() {
         if (this.disabled) {
             return this.progress + '%';
         } else {
@@ -56,7 +56,8 @@ export class UploadFileComponent {
         }
     }
 
-    public onChange ($event) {
+    public onChange($event) {
+        $event.stopPropagation();
         this.disabled = true;
         const selectedFile = $event.target.files;
         this.currentFileUpload = selectedFile.item(0);


### PR DESCRIPTION
### Requerimiento

El evento change del input de <upload-file> se propagaba hasta plex-tab que emitia un (chage), provocando que se actualicen toda la vista y queden las componentes desacopladas.


### Funcionalidad desarrollada 
1. Agrego stopPropagation
2. 
3. 


### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
