### PR TITLE
INTERNACION - Arregla mapa de cama al volver de la edición con cama seleccionada

### DIFF
--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.ts
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.ts
@@ -107,7 +107,7 @@ export class MapaCamasCapaComponent implements OnInit, OnDestroy {
         this.ambito = this.mapaCamasService.ambito;
 
         this.selectedCama$ = this.mapaCamasService.selectedCama.map((cama) => {
-            if (cama.idCama) {
+            if (cama.idCama && !this.accion) {
                 this.accion = 'verDetalle';
             }
             return cama;

--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.ts
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.ts
@@ -106,7 +106,12 @@ export class MapaCamasCapaComponent implements OnInit, OnDestroy {
 
         this.ambito = this.mapaCamasService.ambito;
 
-        this.selectedCama$ = this.mapaCamasService.selectedCama;
+        this.selectedCama$ = this.mapaCamasService.selectedCama.map((cama) => {
+            if (cama.idCama) {
+                this.accion = 'verDetalle';
+            }
+            return cama;
+        });
 
         this.selectedPaciente$ = this.mapaCamasService.selectedPaciente;
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
Al editar una cama y volver al mapa de camas la cama queda seleccionada pero en el sidebar se ve el estado de servicio. Debería mostrarse la cama seleccionada.
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1.  Si hay una cama seleccionada al entrar al mapa de camas, muestra el detalle de la misma.
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
