### PR TITLE
RUP: habilita registrar turneables como procedimientos

### DIFF
--- a/src/app/modules/rup/components/ejecucion/buscador.component.ts
+++ b/src/app/modules/rup/components/ejecucion/buscador.component.ts
@@ -423,9 +423,9 @@ export class BuscadorComponent implements OnInit, OnChanges {
         if (this.results && this.results[busquedaActual]) {
 
             // quitamos de this.filtroActual aquellos que son turneables, no es correcto que aparezcan
-            this.results[busquedaActual]['todos'] = this.results[busquedaActual]['todos'].filter(x => !this.esTurneable(x));
+            this.results[busquedaActual]['todos'] = this.results[busquedaActual]['todos'];
             // quitamos de los 'procedimientos' aquellos que son turneables, no es correcto que aparezcan
-            this.results[busquedaActual]['procedimientos'] = this.results[busquedaActual]['procedimientos'] ? this.results[busquedaActual]['procedimientos'].filter(x => !this.esTurneable(x)) : [];
+            this.results[busquedaActual]['procedimientos'] = this.results[busquedaActual]['procedimientos'] ? this.results[busquedaActual]['procedimientos'] : [];
             if (busquedaActual !== 'buscadorBasico') {
                 // quitamos de los 'planes' aquellos que son no son solicitudes, no es correcto que aparezcan
                 this.results[busquedaActual]['planes'] = this.results[busquedaActual]['planes'] ? this.results[busquedaActual]['planes'].filter(x => this.esSolicitud(x)) : [];
@@ -532,7 +532,7 @@ export class BuscadorComponent implements OnInit, OnChanges {
         if (concepto.plan) {
             filtro = ['planes'];
         } else {
-            filtro = this.esTurneable(concepto) ? ['planes'] : this.getFiltroSeleccionado();
+            filtro = this.getFiltroSeleccionado();
         }
 
         if (!this.secciones) {
@@ -555,23 +555,6 @@ export class BuscadorComponent implements OnInit, OnChanges {
             this.servicioPrestacion.setEsSolicitud(true);
         }
         return filtro;
-    }
-
-    /**
-     * Devuelve si un concepto es turneable o no.
-     * Se fija en la variable conceptosTurneables inicializada en OnInit
-     *
-     * @param {any} concepto Concepto SNOMED a verificar si esta en el array de conceptosTurneables
-     * @returns  boolean TRUE/FALSE si es turneable o no
-     * @memberof BuscadorComponent
-     */
-    public esTurneable(concepto: any) {
-        if (!this.conceptosTurneables) {
-            return false;
-        }
-        return this.conceptosTurneables.find(x => {
-            return x.conceptId === concepto.conceptId;
-        });
     }
 
     public esSolicitud(concepto: any) {

--- a/src/app/modules/rup/components/ejecucion/buscador.html
+++ b/src/app/modules/rup/components/ejecucion/buscador.html
@@ -214,7 +214,7 @@
                             <div class="d-flex justify-content-end">
                                 <plex-badge size="sm"
                                             type="{{ servicioPrestacion.getCssClass(item, filtroActual === 'planes') }}">
-                                    {{ (item.plan || filtroActual === 'planes' || esTurneable(item)) ? 'solicitud' :
+                                    {{ (item.plan || filtroActual === 'planes') ? 'solicitud' :
                                     item.semanticTag }}
                                 </plex-badge>
                                 <plex-button type="info" size="sm" icon="plus" (click)="seleccionarConcepto(item, i)">

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -764,24 +764,6 @@ export class PrestacionesService {
     }
 
     /**
-     * Devuelve si un concepto es turneable o no.
-     * Se fija en la variable conceptosTurneables inicializada en OnInit
-     *
-     * @param {any} concepto Concepto SNOMED a verificar si esta en el array de conceptosTurneables
-     * @returns  boolean TRUE/FALSE si es turneable o no
-     * @memberof BuscadorComponent
-     */
-    public esTurneable(concepto) {
-        if (!this.conceptosTurneables) {
-            return false;
-        }
-
-        return this.conceptosTurneables.find(x => {
-            return x.conceptId === concepto.conceptId;
-        });
-    }
-
-    /**
      * Devuelve true si se cargo en la prestación algun concepto que representa la ausencia del paciente
      *
      * @param {any} prestacion prestación en ejecución
@@ -804,7 +786,7 @@ export class PrestacionesService {
     public getCssClass(conceptoSNOMED, esSolicitud) {
         let clase = conceptoSNOMED.semanticTag;
 
-        if (conceptoSNOMED.plan || this.esTurneable(conceptoSNOMED) || (typeof esSolicitud !== 'undefined' && esSolicitud)) {
+        if (conceptoSNOMED.plan || (typeof esSolicitud !== 'undefined' && esSolicitud)) {
             clase = 'solicitud';
         } else if (conceptoSNOMED.semanticTag === 'régimen/tratamiento') {
             clase = 'regimen';
@@ -832,7 +814,7 @@ export class PrestacionesService {
     public getIcon(conceptoSNOMED, esSolicitud) {
         let icon = conceptoSNOMED.semanticTag;
 
-        if (conceptoSNOMED.plan || this.esTurneable(conceptoSNOMED) || (typeof esSolicitud !== 'undefined' && esSolicitud)) {
+        if (conceptoSNOMED.plan || (typeof esSolicitud !== 'undefined' && esSolicitud)) {
             icon = 'plan';
         } else {
             switch (conceptoSNOMED.semanticTag) {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/RUP-83
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Remueve control que filtra los conceptos turneables de la lista de procedimientos.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si https://proyectos.andes.gob.ar/browse/RUP-83
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si **NOTA:** Para probar es necesario poseer un registro de elementoTurneable cuyo semanticTag sea `procedimiento` y que esté registrado en la colección de conceptos elementoRup `ObservacionesComponent` (elemento rup por defecto para procedimientos)
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
