### PR TITLE
refactor(reportes-diarios): crea modulo lazy load

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -243,12 +243,6 @@ import { EncabezadoReportesComponent } from './components/reportes/encabezadoRep
 import { TurnosPrestacionesComponent } from './components/buscadorTurnosPrestaciones/turnos-prestaciones.component';
 import { TurnosPrestacionesService } from './components/buscadorTurnosPrestaciones/services/turnos-prestaciones.service';
 
-
-// REPORTES SJ
-import { EncabezadoReportesDiariosComponent } from './components/reportesDiarios/encabezadoReportesDiarios.component';
-import { ResumenDiarioMensualComponent } from './components/reportesDiarios/resumenDiarioMensual.component';
-import { PlanillaC1Component } from './components/reportesDiarios/planillaC1.component';
-
 // Locales
 import { AppComponent } from './app.component';
 import { routing, appRoutingProviders } from './app.routing';
@@ -415,7 +409,6 @@ registerLocaleData(localeEs, 'es');
         ConsultaDiagnosticoComponent,
         CantidadConsultaXPrestacionComponent,
         EncabezadoReportesComponent,
-        ResumenDiarioMensualComponent, PlanillaC1Component, EncabezadoReportesDiariosComponent,
         ListarTurnosComponent, ListarCarpetasComponent,
         MapaEspacioFisicoComponent, SuspenderAgendaComponent,
         MapaEspacioFisicoVistaComponent,
@@ -523,7 +516,6 @@ registerLocaleData(localeEs, 'es');
         HttpClient,
         Plex,
         Server,
-        ExcelService,
         NovedadesService,
         ModulosService,
         RoutingGuard,

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -173,7 +173,7 @@ const appRoutes: Routes = [
   { path: 'cantidadConsultaXPrestacion', component: CantidadConsultaXPrestacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 
   // ReportesDiarios
-  { path: 'reportesDiarios', component: EncabezadoReportesDiariosComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'reportesDiarios', loadChildren: './components/reportesDiarios/reportes-diarios.module#ReportesDiariosModule', canActivate: [RoutingNavBar, RoutingGuard] },
 
   // Solicitudes
   { path: 'solicitudes', component: SolicitudesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
@@ -204,13 +204,13 @@ const appRoutes: Routes = [
 
   { path: 'internacion', loadChildren: './apps/rup/mapa-camas/mapa-camas.module#MapaCamasModule', canActivate: [RoutingNavBar, RoutingGuard] },
 
-    // dejar siempre al último porque no encuentra las url después de esta
-    { path: 'novedades/ver/:novedad', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'novedades/:modulo', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'novedades/:modulo/ver/:novedad', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    { path: 'novedades', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
-    // dejar siempre al último porque no encuentra las url después de esta
-    { path: '**', redirectTo: 'inicio' }
+  // dejar siempre al último porque no encuentra las url después de esta
+  { path: 'novedades/ver/:novedad', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'novedades/:modulo', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'novedades/:modulo/ver/:novedad', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  { path: 'novedades', component: NovedadesComponent, canActivate: [RoutingNavBar, RoutingGuard] },
+  // dejar siempre al último porque no encuentra las url después de esta
+  { path: '**', redirectTo: 'inicio' }
 ];
 
 export const appRoutingProviders: any[] = [];

--- a/src/app/components/reportesDiarios/reportes-diarios.module.ts
+++ b/src/app/components/reportesDiarios/reportes-diarios.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { PlexModule } from '@andes/plex';
+import { SharedModule } from '@andes/shared';
+import { ExcelService } from '../../services/xlsx.service';
+import { EncabezadoReportesDiariosComponent } from './encabezadoReportesDiarios.component';
+import { PlanillaC1Component } from './planillaC1.component';
+import { ResumenDiarioMensualComponent } from './resumenDiarioMensual.component';
+import { ReportesDiariosRouting } from './reportes-diarios.routing';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        PlexModule,
+        FormsModule,
+        RouterModule,
+        HttpClientModule,
+        SharedModule,
+        ReportesDiariosRouting
+    ],
+    declarations: [
+        EncabezadoReportesDiariosComponent,
+        PlanillaC1Component,
+        ResumenDiarioMensualComponent
+    ],
+    providers: [
+        ExcelService
+    ],
+    exports: [],
+})
+export class ReportesDiariosModule {
+
+}

--- a/src/app/components/reportesDiarios/reportes-diarios.routing.ts
+++ b/src/app/components/reportesDiarios/reportes-diarios.routing.ts
@@ -1,0 +1,13 @@
+import { RouterModule } from '@angular/router';
+import { NgModule } from '@angular/core';
+import { EncabezadoReportesDiariosComponent } from './encabezadoReportesDiarios.component';
+
+export const REPORTES_ROUTES = [
+    { path: '', component: EncabezadoReportesDiariosComponent, pathMatch: 'full' }
+];
+
+@NgModule({
+    imports: [RouterModule.forChild(REPORTES_ROUTES)],
+    providers: []
+})
+export class ReportesDiariosRouting { }


### PR DESCRIPTION
### Requerimiento
Genera un modulo que se carga perezosamente para evitar cargar la librería de excel que es muy pesada en el archivo raíz de la aplicación. 

Antes:
chunk {1} main.cd02d39e63755c8321b1.js (main) 7.94 MB [initial] [rendered] 

Después:
chunk {1} main-es2015.e351e019ff503b36bc74.js (main) 6.57 MB [initial] [rendered]


### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
