### PR TITLE
fix(rup): permisos solo internacion

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
@@ -125,7 +125,9 @@ export class PrestacionValidacionComponent implements OnInit {
             }
         });
         // Verificamos permisos globales para rup, si no posee realiza redirect al home
-        if (this.auth.getPermissions('rup:?').length <= 0) {
+        const permisosAmbulatorio = this.auth.getPermissions('rup:?').length > 0;
+        const permisosInternacion = this.auth.getPermissions('internacion:rol:?').length > 0;
+        if (!(permisosAmbulatorio || permisosInternacion)) {
             this.redirect('inicio');
         }
         if (!this.auth.profesional) {


### PR DESCRIPTION
### Requerimiento
Existen usuarios con solo permisos a internación y no pueden validar actualemente. 

### Funcionalidad desarrollada 
1. Control de permisos para internacion 


### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [x] No
