### PR TITLE
RUP: Pto Inicio, carga de prestaciones lazy y limpieza de código

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.html
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.html
@@ -26,14 +26,6 @@
                              [preload]="true">
                 </plex-select>
             </div>
-            <!-- <div class="pr-0 col-4">
-                <label class="form-control-label">Agendas</label>
-                <div class="d-flex align-items-end h-50">
-                    <plex-radio class="form-check form-check-inline" [(ngModel)]="filtroAgendas.radio" [data]="opciones"
-                                name="agendas" type="vertical" (change)="filtrar();">
-                    </plex-radio>
-                </div>
-            </div> -->
         </div>
         <br>
 
@@ -280,12 +272,6 @@
                                             </div>
                                         </td>
                                         <td>
-                                            <plex-badge *ngIf="turno.prestacion?.turnosPedientes"
-                                                        title="Turno autocitado sin asignar" type="warning">
-                                                <plex-icon name="message-alert"></plex-icon>
-                                            </plex-badge>
-                                        </td>
-                                        <td>
                                             <ng-container *ngIf="turno.tipoPrestacion && turno.paciente?.id">
                                                 <plex-button size="block"
                                                              (click)="setRouteToParams(['vista', turno.paciente.id]); setAccesoHudsParams(turno.paciente, turno.id, turno.tipoPrestacion.id)"
@@ -295,7 +281,7 @@
                                                 <plex-button size="block"
                                                              *ngIf="!esFutura(agendaSeleccionada) && turno.paciente && turno.estado !== 'suspendido'  && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente' && tienePermisos(turno) && verificarAsistencia(turno)"
                                                              label="INICIAR PRESTACIÓN" type="success btn-sm"
-                                                             (click)="ejecutarPrestacionPendiente(turno.prestacion, turno.paciente, turno.tipoPrestacion, turno)">
+                                                             (click)="ejecutarPrestacionPendiente(turno)">
                                                 </plex-button>
 
                                                 <!--Una agenda futura muestra en boton deshabilitado -->
@@ -309,7 +295,7 @@
                                                 <plex-button size="block"
                                                              *ngIf="!esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && turno.estado !== 'suspendido' && turno.paciente && !turno.prestacion && tienePermisos(turno) && verificarAsistencia(turno)"
                                                              label="INICIAR PRESTACIÓN" type="success btn-sm"
-                                                             (click)="iniciarPrestacion(turno.paciente, turno.tipoPrestacion, turno.id)">
+                                                             (click)="iniciarPrestacion(turno)">
                                                 </plex-button>
 
                                                 <plex-button size="block"
@@ -471,13 +457,6 @@
                                                 </div>
                                             </td>
                                             <td>
-                                                <plex-badge *ngIf="sobreturno.prestacion?.turnosPedientes"
-                                                            title="Turno autocitado sin asignar" type="warning">
-                                                    <plex-icon name="message-alert"></plex-icon>
-                                                </plex-badge>
-                                            </td>
-
-                                            <td>
                                                 <ng-container
                                                               *ngIf="sobreturno.tipoPrestacion && sobreturno.paciente?.id">
                                                     <plex-button size="block"
@@ -487,7 +466,7 @@
                                                     <plex-button size="block"
                                                                  *ngIf="!esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && sobreturno.estado !== 'suspendido' && sobreturno.paciente && !sobreturno.prestacion && tienePermisos(sobreturno) && verificarAsistencia(sobreturno)"
                                                                  label="INICIAR PRESTACIÓN" type="success btn-sm"
-                                                                 (click)="iniciarPrestacion(sobreturno.paciente, sobreturno.tipoPrestacion, sobreturno.id)">
+                                                                 (click)="iniciarPrestacion(sobreturno)">
                                                     </plex-button>
 
                                                     <plex-button size="block"
@@ -566,15 +545,6 @@
                                         </ng-container>
                                     </td>
                                     <td>
-
-                                    </td>
-                                    <td>
-                                        <plex-badge *ngIf="prestacion.turnosPedientes"
-                                                    title="Turno autocitado sin asignar" type="warning">
-                                            <plex-icon name="message-alert"></plex-icon>
-                                        </plex-badge>
-                                    </td>
-                                    <td>
                                         <plex-button size="block"
                                                      *ngIf="!prestacion.solicitud.tipoPrestacion.noNominalizada"
                                                      (click)="setRouteToParams(['vista', prestacion.paciente.id]); setAccesoHudsParams(prestacion.paciente, null, prestacion.solicitud.tipoPrestacion.id)"
@@ -606,7 +576,6 @@
         </div>
     </plex-layout-sidebar>
     <plex-layout-footer *ngIf="!buscandoPaciente">
-        <!-- <plex-dropdown type="primary" label="Paciente" [items]="dropdownPaciente"></plex-dropdown> -->
         <plex-button position="right" label="HUDS DE UN PACIENTE" type="primary" (click)="verHuds()" class="mr-1">
         </plex-button>
         <plex-button position="right" label="PACIENTE FUERA DE AGENDA" type="primary"


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/RUP-93
https://proyectos.andes.gob.ar/browse/RUP-39
https://proyectos.andes.gob.ar/browse/RUP-119
https://proyectos.andes.gob.ar/browse/RUP-121

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. RUP-93: Se quitó la carga del total de prestaciones de agendas encontradas en la carga de búsqueda de agendas (método `actualizar` ), se cambió, en el mismo método, la carga de `fueraDeAgendas` reemplazando el GET de prestaciones por un GET de prestaciones fuera de agenda, y se modificó el método `cargarPrestacionesTurnos`, para que realice la carga de prestaciones asincrónicamente por ids de turnos y sobreturnos de la agenda, de manera que inicialmente solo realiza la carga de agendas y fuera de agendas, y realiza la carga de prestaciones de los turnos en la medida que una agenda es seleccionada.
2. RUP-39: Se arregló la manera en que recibe el parámetro turno (actualmente se recibe un id pero se maneja cómo un turno) https://github.com/andes/app/compare/RUP93?expand=1#diff-3dc3c7f9707aa4f51a1efb4900c826a9R296sf
3. RUP-119: Al crear una nueva prestación, se cambio el parámetro de fecha `new Date()` x `horaInicio` https://github.com/andes/app/compare/RUP93?expand=1#diff-3dc3c7f9707aa4f51a1efb4900c826a9R302
4. RUP-121: Bloques de código en desuso removidos:
https://github.com/andes/app/compare/RUP93?expand=1#diff-3dc3c7f9707aa4f51a1efb4900c826a9L185-L200
https://github.com/andes/app/compare/RUP93?expand=1#diff-3dc3c7f9707aa4f51a1efb4900c826a9L317-L330
https://github.com/andes/app/compare/RUP93?expand=1#diff-3dc3c7f9707aa4f51a1efb4900c826a9L538-L581
https://github.com/andes/app/compare/RUP93?expand=1#diff-3dc3c7f9707aa4f51a1efb4900c826a9L657-L714
Baged de autocitado en https://github.com/andes/app/compare/RUP93?expand=1#diff-70d78e4fed791649e852653ce9a014e0




### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
https://proyectos.andes.gob.ar/browse/RUP-93
https://proyectos.andes.gob.ar/browse/RUP-39
https://proyectos.andes.gob.ar/browse/RUP-119
https://proyectos.andes.gob.ar/browse/RUP-121
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
