### PR TITLE
INTERNACION - Arregla navegacion defectuosa entre mapa-camas y huds de paciente

### DIFF
--- a/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.ts
@@ -131,6 +131,7 @@ export class RegistrosHudsDetalleComponent implements OnInit {
 
     verHuds() {
         this.cama$.pipe(take(1)).subscribe((cama) => {
+            this.prestacionService.notificaRuta({ nombre: 'Mapa de Camas', ruta: '/internacion/mapa-camas' });
             this.router.navigate(['/rup/huds/paciente/' + cama.paciente.id]);
         });
     }

--- a/src/app/modules/rup/components/ejecucion/vistaHuds.component.ts
+++ b/src/app/modules/rup/components/ejecucion/vistaHuds.component.ts
@@ -10,7 +10,6 @@ import { PrestacionesService } from '../../services/prestaciones.service';
 import { ConceptObserverService } from './../../services/conceptObserver.service';
 import { HeaderPacienteComponent } from '../../../../components/paciente/headerPaciente.component';
 import { HUDSService } from '../../services/huds.service';
-import { Location } from '@angular/common';
 
 import { SeguimientoPacienteService } from '../../services/seguimientoPaciente.service';
 
@@ -43,7 +42,6 @@ export class VistaHudsComponent implements OnInit, OnDestroy {
         public auth: Auth,
         private router: Router,
         private route: ActivatedRoute,
-        private location: Location,
         private servicioPaciente: PacienteService,
         private logService: LogService,
         private servicioPrestacion: PrestacionesService,
@@ -141,7 +139,11 @@ export class VistaHudsComponent implements OnInit, OnDestroy {
     */
     volver() {
         // this.location.back();
-        this.router.navigate(['/rup']);
+        if (this.rutaVolver) {
+            this.router.navigate([this.rutaVolver]);
+        } else {
+            this.router.navigate(['/rup']);
+        }
     }
 
     evtCambiaPaciente() {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
Al querer volver al mapa de camas, el botón 'volver' direcciona al usuario hacia el punto de inicio de RUP. En camino feliz sería que regrese al mapa de camas.
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1.  El mapa de camas declara la ruta a volver para que en huds de paciente pueda volver al mapa de camas. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
