### PR TITLE
RUP: pto inicio lazy load pendientes

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -331,7 +331,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
                         organizacion: this.auth.organizacion.id,
                         turnos: [turno.id],
                         estado: 'pendiente',
-                        // tieneTurno: true,
                         ambitoOrigen: 'ambulatorio'
                     }).subscribe((pendientes) => {
                         if (pendientes.length) {

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -153,15 +153,9 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
             }),
             // Prestaciones
             this.getPrestaciones(),
-            // buscamos las prestaciones pendientes que este asociadas a un turno para ejecutarlas
-            this.getPrestacionesPendientes()
         ).subscribe(data => {
             this.agendas = data[0];
             this.prestaciones = data[1];
-            if (data[2]) {
-                this.prestaciones = [...this.prestaciones, ...data[2]];
-            }
-
             if (this.agendas.length) {
 
                 // loopeamos agendas y vinculamos el turno si existe con alguna de las prestaciones
@@ -180,25 +174,12 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
             // agregamos el original de las prestaciones que estan fuera
             // de agenda para poder reestablecer los filtros
             this.prestacionesOriginales = JSON.parse(JSON.stringify(this.fueraDeAgenda));
-            this.mostrarTurnoPendiente(this.fueraDeAgenda);
             // filtramos los resultados
             this.filtrar();
 
             if (this.agendas.length) {
                 this.cargarTurnos(this.agendas[0]);
             }
-
-            // recorremos agenda seleccionada para ver si tienen planes pendientes y mostrar en la vista..
-            if (this.agendaSeleccionada) {
-                this.agendaSeleccionada.bloques.forEach(element => {
-                    element.turnos.forEach(turno => {
-                        if (turno.prestacion) {
-                            turno.prestacion = this.mostrarTurnoPendiente(turno.prestacion);
-                        }
-                    });
-                });
-            }
-            this.fueraDeAgenda = this.mostrarTurnoPendiente(this.fueraDeAgenda);
         });
     }
 
@@ -340,33 +321,51 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         this.router.navigate(['/asignadas']);
     }
 
-    iniciarPrestacion(paciente, snomedConcept, turno) {
-        this.plex.confirm('Paciente: <b>' + paciente.apellido + ', ' + paciente.nombre + '.</b><br>Prestación: <b>' + snomedConcept.term + '</b>', '¿Crear Prestación?').then(confirmacion => {
+    iniciarPrestacion(turno) {
+        const paciente = turno.paciente;
+        const snomedConcept = turno.tipoPrestacion;
+        this.plex.confirm('Paciente: <b>' + paciente.apellido + ', ' + paciente.nombre + '.</b><br>Prestación: <b>' + snomedConcept.term + '</b>', '¿Iniciar Prestación?').then(confirmacion => {
             if (confirmacion) {
-                let res = this.servicioPrestacion.crearPrestacion(paciente, snomedConcept, 'ejecucion', new Date(), turno);
+                const ejecutarPrestacion = () => {
+                    this.servicioPrestacion.get({
+                        organizacion: this.auth.organizacion.id,
+                        turnos: [turno.id],
+                        estado: 'pendiente',
+                        // tieneTurno: true,
+                        ambitoOrigen: 'ambulatorio'
+                    }).subscribe((pendientes) => {
+                        if (pendientes.length) {
+                            this.ejecutarPrestacionPendiente(pendientes[0], turno).subscribe(() => {
+                                this.routeTo('ejecucion', pendientes[0].id); // prestacion pendiente
+                            });
+                        } else {
+                            this.servicioPrestacion.crearPrestacion(paciente, snomedConcept, 'ejecucion', turno.horaInicio, turno.id).subscribe(nuevaPrestacion => {
+                                if (nuevaPrestacion.error) {
+                                    this.plex.info('info', nuevaPrestacion.error, 'Aviso');
+                                }
+                                this.routeTo('ejecucion', nuevaPrestacion.id); // prestacion
+                            }, (err) => {
+                                if (err === 'ya_iniciada') {
+                                    this.plex.info('info', 'La prestación ya fue iniciada por otro profesional', 'Aviso');
+                                } else {
+                                    this.plex.info('warning', err, 'Error');
+                                }
+                            });
+                        }
+                    });
+                };
+
                 if (this.tieneAccesoHUDS) {
-                    const token = this.hudsService.generateHudsToken(this.auth.usuario, this.auth.organizacion, paciente, snomedConcept.term, this.auth.profesional, turno.id, snomedConcept._id);
-                    res = concat(token, res);
+                    this.hudsService.generateHudsToken(this.auth.usuario, this.auth.organizacion, paciente, snomedConcept.term, this.auth.profesional, turno.id, snomedConcept._id).subscribe((husdTokenRes) => {
+                        if (husdTokenRes.token) {
+                            window.sessionStorage.setItem('huds-token', husdTokenRes.token);
+                            ejecutarPrestacion();
+                        }
+                    });
+                } else {
+                    ejecutarPrestacion();
                 }
 
-                res.subscribe(input => {
-                    if (input.token) {
-                        // se obtuvo token y loguea el acceso a la huds del paciente
-                        window.sessionStorage.setItem('huds-token', input.token);
-                    } else {
-                        if (input.error) {
-                            this.plex.info('info', input.error, 'Aviso');
-                        } else {
-                            this.routeTo('ejecucion', input.id); // prestacion
-                        }
-                    }
-                }, (err) => {
-                    if (err === 'ya_iniciada') {
-                        this.plex.info('info', 'La prestación ya fue iniciada por otro profesional', 'Aviso');
-                    } else {
-                        this.plex.info('warning', err, 'Error');
-                    }
-                });
             } else {
                 return false;
             }
@@ -469,17 +468,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         });
     }
 
-    getPrestacionesPendientes() {
-        return this.servicioPrestacion.get({
-            solicitudHasta: moment(this.fecha).isValid() ? moment(this.fecha).endOf('day').toDate() : new Date(),
-            organizacion: this.auth.organizacion.id,
-            estado: 'pendiente',
-            tieneTurno: true,
-            ambitoOrigen: 'ambulatorio',
-            tipoPrestaciones: this.tiposPrestacion.map(t => t.conceptId)
-        });
-    }
-
     cargarPrestacionesTurnos(agenda) {
         // if (agenda) {
         // loopeamos agendas y vinculamos el turno si existe con alguna de las prestaciones
@@ -535,58 +523,11 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     }
 
     routeTo(action, id) {
-        if (this.agendaSeleccionada && this.agendaSeleccionada !== 'fueraAgenda') {
-            let agenda = this.agendaSeleccionada ? this.agendaSeleccionada : null;
-        }
         if (id) {
             this.router.navigate(['rup/' + action + '/', id]);
         } else {
             this.router.navigate(['rup/' + action]);
         }
-    }
-
-    // dada una prestación busca las prestaciones generadas (por planes) que esten pendientes y sin turno asignado.
-    comprobarPrestacionesPendientes(unaPrestacion) {
-        if (unaPrestacion.id && unaPrestacion.estados[unaPrestacion.estados.length - 1].tipo === 'validada') {
-            let registropendiente = unaPrestacion.ejecucion.registros.filter(registro => registro.esSolicitud && registro.valor && registro.valor.autocitado);
-            if (registropendiente && registropendiente.length > 0) {
-                this.servicioPrestacion.get({ idPrestacionOrigen: unaPrestacion.id }).subscribe(prestacionesPaciente => {
-                    prestacionesPaciente.forEach(elemento => {
-                        if (elemento.estados[elemento.estados.length - 1].tipo === 'pendiente'
-                            && !elemento.solicitud.turno) {
-                            unaPrestacion.turnosPedientes = true;
-                        }
-                    });
-                });
-            }
-        }
-    }
-
-
-    // Recibe un array o un objeto lo recorre y busca los planes que estan pendientes..
-    mostrarTurnoPendiente(prestaciones) {
-        if (prestaciones) {
-            if (Array.isArray(prestaciones)) {
-                let _prestaciones = prestaciones.filter(p => {
-                    // filtramos todas las prestaciones que:
-                    // 1) esten validadas
-                    // 2) que sean planes y sean autocitados
-                    let registropendiente = p.ejecucion.registros.filter(registro => registro.esSolicitud && registro.valor &&
-                        registro.valor.autocitado
-                    );
-                    if (p.id && p.estados[p.estados.length - 1].tipo === 'validada' && registropendiente.length > 0
-                    ) {
-                        return p;
-                    }
-                });
-                _prestaciones.forEach(unaPrestacion => {
-                    this.comprobarPrestacionesPendientes(unaPrestacion);
-                });
-            } else { // ingresa cuando lo llamo con una prestacion
-                this.comprobarPrestacionesPendientes(prestaciones);
-            }
-        }
-        return prestaciones;
     }
 
     llamarTurnero(turno) {
@@ -623,39 +564,18 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     /**
        * Ejecutar una prestacion que esta en estado pendiente
     */
-    ejecutarPrestacionPendiente(prestacion, paciente, snomedConcept, turno) {
+    ejecutarPrestacionPendiente(prestacion, turno) {
         let params: any = {
             op: 'estadoPush',
             ejecucion: {
                 fecha: turno.horaInicio,
                 registros: [],
-                // organizacion desde la que se solicita la prestacion
                 organizacion: { id: this.auth.organizacion.id, nombre: this.auth.organizacion.nombre }
             },
             estado: { tipo: 'ejecucion' }
         };
 
-        this.plex.confirm('Paciente: <b>' + paciente.apellido + ', ' + paciente.nombre + '.</b><br>Prestación: <b>' + snomedConcept.term + '</b>', '¿Iniciar Prestación?').then(confirmacion => {
-            if (confirmacion) {
-                let res = this.servicioPrestacion.patch(prestacion.id, params);
-                if (this.tieneAccesoHUDS) {
-                    const token = this.hudsService.generateHudsToken(this.auth.usuario, this.auth.organizacion, paciente, snomedConcept.term, this.auth.profesional, turno, prestacion.id);
-                    concat(token, res).subscribe(input => {
-                        if (input.token) {
-                            // se obtuvo token y loguea el acceso a la huds del paciente
-                            window.sessionStorage.setItem('huds-token', input.token);
-                        } else {
-                            // prestacion
-                            this.router.navigate(['/rup/ejecucion', prestacion.id]);
-                        }
-                    });
-                } else {
-                    res.subscribe(() => {
-                        this.router.navigate(['/rup/ejecucion', prestacion.id]);
-                    });
-                }
-            }
-        });
+        return this.servicioPrestacion.patch(prestacion.id, params);
     }
 
     verificarAsistencia(turno) {
@@ -669,63 +589,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         return false;
     }
 
-    verIniciarPrestacionPendiente(turno, agenda) {
-        let condAsistencia = false;
-        if (turno.asistencia && turno.asistencia === 'asistio') {
-            if (turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente') {
-                condAsistencia = true;
-            }
-        } else {
-            if (turno.asistencia && turno.asistencia !== 'asistio') {
-                condAsistencia = true;
-            } else {
-                if (!turno.asistencia) {
-                    condAsistencia = true;
-                }
-            }
-        }
-
-        return (this.esFutura(agenda) && turno.paciente && turno.estado !== 'suspendido' && turno.prestacion &&
-            turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente' &&
-            this.tienePermisos(turno) && condAsistencia);
-    }
-
-
-    verIniciarPrestacion(turno, agenda) {
-        let condAsistencia = false;
-        if (turno.asistencia && turno.asistencia === 'asistio') {
-            if (!turno.prestacion) {
-                condAsistencia = true;
-            }
-        } else {
-            if (turno.asistencia && turno.asistencia !== 'asistio') {
-                condAsistencia = true;
-            } else {
-                if (!turno.asistencia) {
-                    condAsistencia = true;
-                }
-            }
-        }
-
-        return (!this.esFutura(agenda) && turno.paciente && turno.estado !== 'suspendido' &&
-            this.tienePermisos(turno) && condAsistencia);
-    }
-
-    /**
-     * Se puede registrar inasistencia de un turno cuando se cumplen todas las validaciones:
-     * la agenda: no es futura, no está auditada
-     * turno: no está suspendido, ya pasó la hora de inicio, profesional no cargó prestación todavía y tiene paciente asignado
-     * @param {*} turno
-     * @returns {Boolean} si debe mostrarse o no el botón para registrar inasistencia
-     * @memberof PuntoInicioComponent
-     */
-    esHabilitadoRegistrarInasistencia(turno): Boolean {
-        let horaActual = moment(new Date()).format('LT');
-        let horaTurno = moment(turno.horaInicio).format('LT');
-        return !this.esFutura(this.agendaSeleccionada) && this.agendaSeleccionada.estado !== 'auditada' &&
-            turno.estado !== 'suspendido' && (!turno.asistencia || (turno.asistencia && turno.asistencia === 'asistio')) &&
-            turno.paciente && turno.diagnostico.codificaciones.length === 0;
-    }
 
     setRouteToParams(params) {
         this.routeToParams = params;

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.html
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.html
@@ -26,14 +26,6 @@
                              [preload]="true">
                 </plex-select>
             </div>
-            <!-- <div class="pr-0 col-4">
-                <label class="form-control-label">Agendas</label>
-                <div class="d-flex align-items-end h-50">
-                    <plex-radio class="form-check form-check-inline" [(ngModel)]="filtroAgendas.radio" [data]="opciones"
-                                name="agendas" type="vertical" (change)="filtrar();">
-                    </plex-radio>
-                </div>
-            </div> -->
         </div>
         <br>
 
@@ -280,36 +272,16 @@
                                             </div>
                                         </td>
                                         <td>
-                                            <plex-badge *ngIf="turno.prestacion?.turnosPedientes"
-                                                        title="Turno autocitado sin asignar" type="warning">
-                                                <plex-icon name="message-alert"></plex-icon>
-                                            </plex-badge>
-                                        </td>
-                                        <td>
                                             <ng-container *ngIf="turno.tipoPrestacion && turno.paciente?.id">
                                                 <plex-button size="block" *ngIf='tieneAccesoHUDS'
                                                              (click)="setRouteToParams(['vista', turno.paciente.id]); setAccesoHudsParams(turno.paciente, turno.id, turno.tipoPrestacion.id)"
                                                              label="VER HUDS" type="primary btn-sm">
                                                 </plex-button>
-                                                <!--Iniciar una prestacion a partir de una solicitud pendiente (es decir una prestacion en estado pendiente) -->
-                                                <plex-button size="block"
-                                                             *ngIf="!esFutura(agendaSeleccionada) && turno.paciente && turno.estado !== 'suspendido'  && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente' && tienePermisos(turno) && verificarAsistencia(turno)"
-                                                             label="INICIAR PRESTACIÓN" type="success btn-sm"
-                                                             (click)="ejecutarPrestacionPendiente(turno.prestacion, turno.paciente, turno.tipoPrestacion, turno)">
-                                                </plex-button>
-
-                                                <!--Una agenda futura muestra en boton deshabilitado -->
-                                                <plex-button size="block"
-                                                             *ngIf="esFutura(agendaSeleccionada) && turno.paciente && turno.estado !== 'suspendido'  && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente' && tienePermisos(turno) && verificarAsistencia(turno)"
-                                                             label="INICIAR PRESTACIÓN" type="disabled btn-sm"
-                                                             title="Disponible {{diaAgenda(agendaSeleccionada)}}"
-                                                             titlePosition="top"></plex-button>
-
 
                                                 <plex-button size="block"
                                                              *ngIf="!esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && turno.estado !== 'suspendido' && turno.paciente && !turno.prestacion && tienePermisos(turno) && verificarAsistencia(turno)"
                                                              label="INICIAR PRESTACIÓN" type="success btn-sm"
-                                                             (click)="iniciarPrestacion(turno.paciente, turno.tipoPrestacion, turno.id)">
+                                                             (click)="iniciarPrestacion(turno)">
                                                 </plex-button>
 
                                                 <plex-button size="block"
@@ -331,7 +303,7 @@
                                                 </plex-button>
 
                                                 <plex-button size="block"
-                                                             *ngIf="!turno.asistencia && !esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && turno.estado !== 'suspendido' && turno.paciente && (!turno.prestacion || (turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'pendiente') || turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'ejecucion')"
+                                                             *ngIf="!turno.asistencia && !esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && turno.estado !== 'suspendido' && turno.paciente && (!turno.prestacion || turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'ejecucion')"
                                                              type="warning btn-sm" label="REGISTRAR INASISTENCIA"
                                                              (click)="registrarInasistencia(turno.paciente,agendaSeleccionada, turno.id, 'noAsistio')">
                                                 </plex-button>
@@ -471,12 +443,6 @@
                                                 </div>
                                             </td>
                                             <td>
-                                                <plex-badge *ngIf="sobreturno.prestacion?.turnosPedientes"
-                                                            title="Turno autocitado sin asignar" type="warning">
-                                                    <plex-icon name="message-alert"></plex-icon>
-                                                </plex-badge>
-                                            </td>
-
                                             <td>
                                                 <ng-container
                                                               *ngIf="sobreturno.tipoPrestacion && sobreturno.paciente?.id">
@@ -487,7 +453,7 @@
                                                     <plex-button size="block"
                                                                  *ngIf="!esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && sobreturno.estado !== 'suspendido' && sobreturno.paciente && !sobreturno.prestacion && tienePermisos(sobreturno) && verificarAsistencia(sobreturno)"
                                                                  label="INICIAR PRESTACIÓN" type="success btn-sm"
-                                                                 (click)="iniciarPrestacion(sobreturno.paciente, sobreturno.tipoPrestacion, sobreturno.id)">
+                                                                 (click)="iniciarPrestacion(sobreturno)">
                                                     </plex-button>
 
                                                     <plex-button size="block"
@@ -508,7 +474,7 @@
                                                                  (click)="setRouteToParams(['validacion', sobreturno.prestacion.id]); accesoHudsPaciente = sobreturno.paciente; accesoHudsTurno = sobreturno.id; accesoHudsPrestacion = sobreturno.tipoPrestacion.id; preAccesoHuds(motivoVerContinuarPrestacion)">
                                                     </plex-button>
                                                     <plex-button size="block"
-                                                                 *ngIf="!sobreturno.asistencia &&!esFutura(agendaSeleccionada)&& agendaSeleccionada.estado !== 'auditada' && sobreturno.estado !== 'suspendido' && sobreturno.paciente && (!sobreturno.prestacion || (sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'pendiente')|| sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'ejecucion')"
+                                                                 *ngIf="!sobreturno.asistencia &&!esFutura(agendaSeleccionada)&& agendaSeleccionada.estado !== 'auditada' && sobreturno.estado !== 'suspendido' && sobreturno.paciente && (!sobreturno.prestacion || sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'ejecucion')"
                                                                  type="warning btn-sm" label="REGISTRAR INASISTENCIA"
                                                                  (click)=" registrarInasistencia(sobreturno.paciente,agendaSeleccionada, sobreturno.id, 'noAsistio')">
                                                     </plex-button>
@@ -566,15 +532,6 @@
                                         </ng-container>
                                     </td>
                                     <td>
-
-                                    </td>
-                                    <td>
-                                        <plex-badge *ngIf="prestacion.turnosPedientes"
-                                                    title="Turno autocitado sin asignar" type="warning">
-                                            <plex-icon name="message-alert"></plex-icon>
-                                        </plex-badge>
-                                    </td>
-                                    <td>
                                         <plex-button size="block"
                                                      *ngIf="!prestacion.solicitud.tipoPrestacion.noNominalizada && tieneAccesoHUDS"
                                                      (click)="setRouteToParams(['vista', prestacion.paciente.id]); setAccesoHudsParams(prestacion.paciente, null, prestacion.solicitud.tipoPrestacion.id)"
@@ -605,9 +562,7 @@
         </div>
     </plex-layout-sidebar>
     <plex-layout-footer *ngIf="!buscandoPaciente">
-        <!-- <plex-dropdown type="primary" label="Paciente" [items]="dropdownPaciente"></plex-dropdown> -->
-        <plex-button *ngIf='tieneAccesoHUDS' position="right" label="HUDS DE UN PACIENTE" type="primary"
-                     (click)="verHuds()" class="mr-1">
+        <plex-button *ngIf='tieneAccesoHUDS' position="right" label="HUDS DE UN PACIENTE" type="primary" (click)="verHuds()" class="mr-1">
         </plex-button>
         <plex-button position="right" label="PACIENTE FUERA DE AGENDA" type="primary"
                      (click)="crearPrestacion('fueraAgenda')" class="mr-1">


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/RUP-93
Adicionales
https://proyectos.andes.gob.ar/browse/RUP-119
https://proyectos.andes.gob.ar/browse/RUP-121

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se removió la carga de prestaciones pendientes del método `actualizar`.
2. En el método `iniciarPrestación`:

-  Se cambió la entrada de parámetros por el turno
-  Se luego de obtener el token de acceso a HUDS y antes de crear la prestación nuevo, consulta a la API si existe una solicitud pendiente para ese turno; si la encuentra, ejecuta esa prestación.
- Se arregló el id de turno que se envía por parámetro a `generateHudsToken`
- Al crearPrestacion, se cambió la fecha que se envía, el `new Date()` x `turno.horaInicio`, para que la ejecución quede registrada con la fecha del turno que la inició.
3. Se remueve código en desuso relacionado a autocitados pendientes y métodos en desuso `getPrestacionesPendientes`, `verIniciarPrestacionPendiente`, `verIniciarPrestacion` y `esHabilitadoRegistrarInasistencia`.



### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
https://proyectos.andes.gob.ar/browse/RUP-93
https://proyectos.andes.gob.ar/browse/RUP-119
https://proyectos.andes.gob.ar/browse/RUP-121
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/andes-test-integracion/pull/171
- [ ] No


