### PR TITLE
Gestor de usuarios: Visualizar todas organizaciones en las que el usuario tiene permiso

### DIFF
--- a/src/app/apps/gestor-usuarios/views/usuarios-list.view.html
+++ b/src/app/apps/gestor-usuarios/views/usuarios-list.view.html
@@ -80,7 +80,7 @@
                 <div class="list-group mt-2" *ngIf="!showNewOrgView">
                     <div justify class="list-group-item" *ngFor="let org of data.orgList">
                         {{ org.nombre }}
-                        <span>
+                        <span *ngIf="organizacionesConPermisos.includes(org)">
                             <ng-container *ngIf="org.activo && !readOnly">
                                 <plex-button type="danger" size="sm" title="Desactivar" titlePosition="left"
                                              (click)="toogleActivo(org)">

--- a/src/app/apps/gestor-usuarios/views/usuarios-list.view.ts
+++ b/src/app/apps/gestor-usuarios/views/usuarios-list.view.ts
@@ -39,7 +39,7 @@ export class UsuariosListComponent implements OnInit {
 
     public organizaciones = [];
     public usuarios$;
-
+    public organizacionesConPermisos = [];
 
     ngOnInit() {
         this.plex.updateTitle([{
@@ -109,9 +109,10 @@ export class UsuariosListComponent implements OnInit {
         this.orgList$ = this.userSelected$.pipe(
             map((user: any) => {
                 if (user) {
-                    return user.organizaciones.filter(org => {
+                    this.organizacionesConPermisos = user.organizaciones.filter(org => {
                         return this.organizaciones.find(o => o.id === org.id);
                     });
+                    return user.organizaciones;
                 } else {
                     return of([]);
                 }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/GDU-14

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se visualizan en el gestor de usuarios todas las organizaciones en las que el usuario seleccionado tiene permisos.
2. Se verifican los permisos para las organizaciones del usuario logueado para mostrar o no los botones de editar y activar o desactivar las distintas organizaciones.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
![Captura de pantalla -2020-06-24 12-29-41](https://user-images.githubusercontent.com/56874534/85600870-39061800-b624-11ea-948c-19dc2cc3ebb0.png)
![Captura de pantalla -2020-06-24 12-25-59](https://user-images.githubusercontent.com/56874534/85600876-3acfdb80-b624-11ea-8b7e-9258a009121b.png)

