### PR TITLE
CITAS: quitar botón de dar turno desde solicitudes en punto de inicio

### DIFF
--- a/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.component.ts
+++ b/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.component.ts
@@ -58,17 +58,15 @@ export class ListaSolicitudTurnoVentanillaComponent implements OnInit {
             estados: [
                 'auditoria', // solicitudes a ser auditadas, pueden pasar a rechazadas o a pendientes
                 'pendiente', // solicitudes pendientes pueden tener o no turno asociado, están pendientes de ejecución
-                'rechazada', // solicitudes rechazadas en el proceso de auditoría
-                'validada'   // solicitudes validadas, si tienen turno asociado veremos la información
             ]
         };
 
         this.servicioPrestacion.getSolicitudes(params).subscribe(resultado => {
-            this.solicitudesPrestaciones = this.sortSolicitudees(resultado);
+            this.solicitudesPrestaciones = this.sortSolicitudes(resultado);
         });
     }
 
-    private sortSolicitudees(solicitudes) {
+    private sortSolicitudes(solicitudes) {
         return solicitudes.sort((a, b) => {
             let inia = a.solicitud.fecha ? new Date(a.solicitud.fecha) : null;
             let inib = b.solicitud.fecha ? new Date(b.solicitud.fecha) : null;
@@ -79,11 +77,6 @@ export class ListaSolicitudTurnoVentanillaComponent implements OnInit {
 
     }
 
-    // Emite a <solicitud-turno-ventanilla> la solicitud/prestación completa para usar en darTurno
-    solicitudPrestacionDarTurno(prestacionSolicitud) {
-        this.solicitudPrestacionEmit.emit(prestacionSolicitud);
-    }
-
     formularioSolicitud() {
         this.showCargarSolicitud = true;
     }
@@ -92,6 +85,7 @@ export class ListaSolicitudTurnoVentanillaComponent implements OnInit {
         this.cargarSolicitudes();
         this.showCargarSolicitud = false;
     }
+
     redirect(pagina: string) {
         this.router.navigate(['./' + pagina]);
         return false;

--- a/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.html
+++ b/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.html
@@ -38,7 +38,7 @@
                             <td class="text-center">
                                 <plex-badge *ngIf="prestacion.solicitud?.turno" type="success">Turno Dado</plex-badge>
                                 <span
-                                      *ngIf="!prestacion.solicitud?.turno && (auth.organizacion.id !== prestacion?.solicitud?.organizacion?.id)">
+                                      *ngIf="!prestacion.solicitud?.turno && (auth.organizacion !== prestacion?.solicitud?.organizacion?.id)">
                                     <plex-badge type="info">
                                         {{prestacion.estados[prestacion.estados.length-1]?.tipo}}
                                     </plex-badge>

--- a/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.html
+++ b/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.html
@@ -36,9 +36,6 @@
                                       *ngIf="prestacion.solicitud?.registros[0]?.valor?.solicitudPrestacion?.autocitado === true">(autocitado)</span>
                             </td>
                             <td class="text-center">
-                                <plex-button *ngIf="!prestacion.solicitud?.turno && (auth.organizacion.id === prestacion?.solicitud?.organizacion?.id)"
-                                             type="success" (click)="solicitudPrestacionDarTurno(prestacion)"
-                                             title="Dar Turno" icon="calendar-plus"></plex-button>
                                 <plex-badge *ngIf="prestacion.solicitud?.turno" type="success">Turno Dado</plex-badge>
                                 <span
                                       *ngIf="!prestacion.solicitud?.turno && (auth.organizacion.id !== prestacion?.solicitud?.organizacion?.id)">


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/TOP-48

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se elimina el botón de sacar turno del listado de solicitudes en punto de inicio de CITAS
2. Muestra solo solicitudes pendientes o en auditoría en el listado

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No
