### PR TITLE
RUP: Marcar asistencia del turno en background

### DIFF
--- a/src/app/modules/rup/components/ejecucion/prestacionCrear.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionCrear.component.ts
@@ -13,7 +13,6 @@ import { ObraSocialCacheService } from '../../../../services/obraSocialCache.ser
 import { IPaciente } from '../../../../core/mpi/interfaces/IPaciente';
 import { HUDSService } from '../../services/huds.service';
 import { concat } from 'rxjs';
-import { tap } from 'rxjs/operators';
 
 @Component({
     templateUrl: 'prestacionCrear.html'
@@ -199,7 +198,6 @@ export class PrestacionCrearComponent implements OnInit {
                         // se obtuvo token y loguea el acceso a la huds del paciente
                         window.sessionStorage.setItem('huds-token', input.token);
                     } else {
-                        localStorage.removeItem('idAgenda');
                         this.router.navigate(['/rup/ejecucion', input.id]); // prestacion
                     }
                 }, (err) => {
@@ -207,7 +205,6 @@ export class PrestacionCrearComponent implements OnInit {
                 });
             } else {
                 this.servicioPrestacion.post(nuevaPrestacion).subscribe(prestacion => {
-                    localStorage.removeItem('idAgenda');
                     this.router.navigate(['/rup/ejecucion', prestacion.id]);
                 }, (err) => {
                     this.disableGuardar = false;
@@ -246,7 +243,6 @@ export class PrestacionCrearComponent implements OnInit {
      */
     elegirPrestacion(unPacientePresente) {
         if (unPacientePresente.idPrestacion) {
-
             if (unPacientePresente.estado === 'Programado') {
                 let cambioEstado: any = {
                     op: 'estadoPush',

--- a/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionValidacion.component.ts
@@ -79,10 +79,14 @@ export class PrestacionValidacionComponent implements OnInit, OnDestroy {
     conceptosTurneables: ITipoPrestacion[] = [];
     public title;
 
-    constructor(public servicioPrestacion: PrestacionesService,
+    constructor(
+        public servicioPrestacion: PrestacionesService,
         public elementosRUPService: ElementosRUPService,
-        private servicioPaciente: PacienteService, private SNOMED: SnomedService,
-        public plex: Plex, public auth: Auth, private router: Router,
+        private servicioPaciente: PacienteService,
+        private SNOMED: SnomedService,
+        public plex: Plex,
+        public auth: Auth,
+        private router: Router,
         public servicioAgenda: AgendaService,
         private route: ActivatedRoute,
         private codificacionService: CodificacionService,

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -115,7 +115,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
                     this.redirect('inicio');
                 }
                 this.tiposPrestacion = data;
-                localStorage.removeItem('idAgenda');
                 this.actualizar();
             });
         }
@@ -538,7 +537,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     routeTo(action, id) {
         if (this.agendaSeleccionada && this.agendaSeleccionada !== 'fueraAgenda') {
             let agenda = this.agendaSeleccionada ? this.agendaSeleccionada : null;
-            localStorage.setItem('idAgenda', agenda.id);
         }
         if (id) {
             this.router.navigate(['rup/' + action + '/', id]);


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-135
https://proyectos.andes.gob.ar/browse/RUP-137

### Funcionalidad desarrollada 
1. Se elimina de la app la lógica de marcar la asistencia a un turno cuando se crea la prestación
2. Se elimina el uso de localStorage para guardar el idAgenda en RUP

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si https://github.com/andes/api/pull/1035
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Observación
Se debe mergear https://github.com/andes/app/pull/1783 antes porque se trabajó sobre la rama de ese PR

