### PR TITLE
RUP: arreglo de acceso a HUDS sin elegir motivo

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -727,7 +727,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
 
     preAccesoHuds(motivoAccesoHuds) {
         const doRoute = () => this.routeTo(this.routeToParams[0], (this.routeToParams[1]) ? this.routeToParams[1] : null);
-
         if (this.tieneAccesoHUDS && motivoAccesoHuds) {
             if (!this.accesoHudsPaciente && !this.accesoHudsPrestacion && this.routeToParams && this.routeToParams[0] === 'huds') {
                 // Se esta accediendo a 'HUDS DE UN PACIENTE'
@@ -744,8 +743,6 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
                     this.accesoHudsPrestacion = null;
                 });
             }
-        } else {
-            doRoute();
         }
         this.showModalMotivo = false;
     }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/HUDS-22

### Funcionalidad desarrollada 
1. Al hacer click en  cancelar cuando te pide seleccionar el motivo de acceso, continúa a la HUDS sin guardar el registro

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

