### PR TITLE
feat(mapa-camas): registros filtros por unidad organizativa

### DIFF
--- a/src/app/apps/rup/mapa-camas/interfaces/IMaquinaEstados.ts
+++ b/src/app/apps/rup/mapa-camas/interfaces/IMaquinaEstados.ts
@@ -18,7 +18,8 @@ export interface IMAQEstado {
         label: string,
         tipo: string,
         parametros: {
-            concepto?: ISnomedConcept
+            concepto?: ISnomedConcept,
+            unidadOrganizativa?: string[],
         }
     }[];
 }

--- a/src/app/apps/rup/mapa-camas/sidebar/nuevo-registro-salud/nuevo-registro-salud.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/nuevo-registro-salud/nuevo-registro-salud.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { MapaCamasService } from '../../services/mapa-camas.service';
-import { Observable } from 'rxjs';
+import { Observable, combineLatest } from 'rxjs';
 import { switchMap, pluck, map, tap, take } from 'rxjs/operators';
 import { Auth } from '@andes/auth';
 import { HUDSService } from '../../../../../modules/rup/services/huds.service';
 import { PrestacionesService } from '../../../../../modules/rup/services/prestaciones.service';
 import { Router } from '@angular/router';
+import { ISnomedConcept } from '../../../../../modules/rup/interfaces/snomed-concept.interface';
 
 @Component({
     selector: 'app-nuevo-registro-salud',
@@ -20,6 +21,7 @@ export class NuevoRegistroSaludComponent implements OnInit {
     public hora: Date;
     public registro: any;
 
+
     constructor(
         private mapaCamasService: MapaCamasService,
         private auth: Auth,
@@ -29,12 +31,7 @@ export class NuevoRegistroSaludComponent implements OnInit {
     ) { }
 
     ngOnInit() {
-        this.accionesEstado$ = this.mapaCamasService.selectedCama.pipe(
-            switchMap(cama => this.mapaCamasService.getEstadoCama(cama)),
-            pluck('acciones'),
-            map(acciones => acciones.filter(acc => acc.tipo === 'nuevo-registro'))
-        );
-
+        this.accionesEstado$ = this.mapaCamasService.prestacionesPermitidas(this.mapaCamasService.selectedCama);
         this.paciente$ = this.mapaCamasService.selectedCama.pipe(
             pluck('paciente')
         );


### PR DESCRIPTION
 
### Requerimiento
La prestación de atención domiciliaria COVID, solo debe aparecer en la unidad organizativa de COVID. 

### Funcionalidad desarrollada  
1. Se crea un filtro de registro por unidad organizativa.
2. Se puede configurar inclusivo o exclusivo (usando el caracter !).


### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [x] Si https://github.com/andes/api/pull/1054
- [ ] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [x] No
 

## EJEMPLO
```
{
     "tipo" : "nuevo-registro",
     "label" : "Epicrisis",
     "parametros" : {
         "unidadOrganizativa" : [ 
             "!309901009"
          ],
       "concepto" : {
            "conceptId" : "2341000013106",
            "term" : "epicrisis médica",
            "fsn" : "epicrisis médica (elemento de registro)",
            "semanticTag" : "elemento de registro"
        }
    }
}
```