### PR TITLE
feat(mapa-camas): quita filtro por ambito en registros medicos

### DIFF
--- a/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/registros-huds-detalle/registros-huds-detalle.component.html
@@ -14,18 +14,18 @@
 
 <div class="row">
     <div class="col-6">
-        <plex-datetime label="Desde" name="desde" type="date" [(ngModel)]="desde" [max]="hasta" [debounce]="600">
+        <plex-datetime label="Desde" name="desde" type="date" [(ngModel)]="desde" [min]="min$ | async" [debounce]="600">
         </plex-datetime>
     </div>
     <div class="col-6">
-        <plex-datetime label="Hasta" name="haste" type="date" [(ngModel)]="hasta" [min]="desde" [debounce]="600">
+        <plex-datetime label="Hasta" name="haste" type="date" [(ngModel)]="hasta" [max]="max$ | async" [debounce]="600">
         </plex-datetime>
     </div>
 </div>
 <div class="row">
     <div class="col-12">
-        <plex-select label="Prestacion" name="tipoPrestacion" [(ngModel)]="tipoPrestacion" idField="conceptId" labelField="term"
-                     [data]="prestacionesList$ | async">
+        <plex-select label="Prestacion" name="tipoPrestacion" [(ngModel)]="tipoPrestacion" idField="conceptId"
+                     labelField="term" [data]="prestacionesList$ | async">
         </plex-select>
     </div>
 </div>

--- a/src/app/modules/rup/components/huds/vistaPrestacion.html
+++ b/src/app/modules/rup/components/huds/vistaPrestacion.html
@@ -2,9 +2,10 @@
     <ng-container *ngIf="prestacion">
 
         <plex-title main titulo="{{ prestacion.solicitud.tipoPrestacion.term }}">
-            <plex-button *ngIf='puedeDescargarInforme' type="info" size="sm" icon="download" title="Descargar PDF" [disabled]="requestInProgress"
-                (click)="descargarInforme()" titlePosition="left">
+            <plex-button *ngIf='puedeDescargarInforme' type="info" size="sm" icon="download" title="Descargar PDF"
+                         [disabled]="requestInProgress" (click)="descargarInforme()" titlePosition="left">
             </plex-button>
+            <ng-content></ng-content>
         </plex-title>
         <div class="row">
             <div class="col-6">


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/IN-177

Quitar filtro por ambito internación, pero agregar fecha mínima. Si se hacen estudios fuera del ambito internación (desde fuera de agenda o programado) se deben ver los registros. 

### Funcionalidad desarrollada 
1. Quita filtro por ambito
2. Busca el historial de la internación y usa esas fechas para calcular.


### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [x] No
