### PR TITLE
fix(TOP): control en visualización de reglas

### DIFF
--- a/src/app/components/top/reglas/visualizacionReglas.html
+++ b/src/app/components/top/reglas/visualizacionReglas.html
@@ -29,7 +29,7 @@
                     <div class="elementos-graficos w-100" *ngIf="!esParametrizado">
                         <plex-icon name="hospital-building" type="info"></plex-icon>
                         <plex-label [tituloBold]="true" titulo="{{ fila.organizacionOrigen.nombre }}"
-                                    subtitulo="Ciudad de {{ fila.organizacionOrigen.direccion.ubicacion.localidad.nombre }}">
+                                    subtitulo="Ciudad de {{ fila.organizacionOrigen.direccion?.ubicacion?.localidad?.nombre }}">
                         </plex-label>
                     </div>
                     <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.prestacionOrigen.prestacion.term }}">
@@ -37,7 +37,7 @@
                     <div class="elementos-graficos w-100">
                         <plex-icon *ngIf="!esParametrizado" name="hospital-building" type="success"></plex-icon>
                         <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.organizacionDestino.nombre }}"
-                                    subtitulo="Ciudad de {{ fila.organizacionDestino.direccion.ubicacion.localidad.nombre }}">
+                                    subtitulo="Ciudad de {{ fila.organizacionDestino.direccion?.ubicacion?.localidad?.nombre }}">
                         </plex-label>
                     </div>
                     <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.prestacionDestino.term }}"></plex-label>


### PR DESCRIPTION
### Requerimiento
Corrige BUG que ocurría en el listado de reglas que ahora muestra la localidad del efector y hay organizaciones en la BD que no tienen nombre en la localidad. 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
