### PR TITLE
fix(reportes): Agrega control para microservicio inactivo

### DIFF
--- a/src/app/components/reportes/encabezadoReportes.component.ts
+++ b/src/app/components/reportes/encabezadoReportes.component.ts
@@ -8,6 +8,8 @@ import { OrganizacionService } from '../../services/organizacion.service';
 import { AgendaService } from '../../services/turnos/agenda.service';
 import { QueriesService } from '../../services/query.service';
 import { Slug } from 'ng2-slugify';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 
 @Component({
@@ -78,7 +80,9 @@ export class EncabezadoReportesComponent implements OnInit {
             organizacion: this.auth.organizacion.id
         };
         this.organizacion = this.auth.organizacion.nombre;
-        this.queryService.getAllQueries({ desdeAndes: true }).subscribe((query) => {
+        this.queryService.getAllQueries({ desdeAndes: true }).pipe(
+            catchError((err => of([])))
+         ).subscribe(query => {
             this.opciones = [{
                 id: 1,
                 nombre: 'Reporte C2'
@@ -92,13 +96,15 @@ export class EncabezadoReportesComponent implements OnInit {
                 nombre: 'Consultas por prestación'
             },
             ];
-            this.queries = query;
-            let i = 4;
-            this.queries.forEach(element => {
-                this.opciones.push({ id: i, nombre: element.nombre });
-                i++;
+             if (query) {
+                 this.queries = query;
+                 let i = 4;
+                 this.queries.forEach(element => {
+                     this.opciones.push({ id: i, nombre: element.nombre });
+                     i++;
+                    });
+             }
             });
-        });
     }
 
     loadOrganizacion(event) {

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -12,8 +12,7 @@ export class QueriesService {
 
     // Retorna todas las queries guardadas en la base de datos
     getAllQueries(params): Observable<any> {
-        const res = this.server.get(`${this.biUrl}/queries`, { params, showError: true });
-        return res;
+        return this.server.get(`${this.biUrl}/queries`, { params, showError: false });
     }
 
     // Devuelve el resultado de ejecutar la query enviada por parametro


### PR DESCRIPTION
### Requerimiento
 Corregir bug que ocurre al iniciar el módulo de reportes y el microservicio de bi-queries está inactivo

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


Nota: queda pendiente una mejora para agregar una ruta en la API que devuelva si está vivo.
