### PR TITLE
RUP - Visualiza "term" o "title" en SoloValores

### DIFF
--- a/src/app/modules/rup/components/elementos/SelectPorRefset.html
+++ b/src/app/modules/rup/components/elementos/SelectPorRefset.html
@@ -26,12 +26,9 @@
     </ng-container>
 
     <p *ngIf="soloValores" class="readonly">
-        <div *ngIf="params?.titulo; else showTerm">
-            <label class="text-capitalize">{{ params.titutlo }}</label>
-        </div>
-        <ng-template #showTerm>
-            <label class="text-capitalize">{{ registro.concepto.term }}</label>
-        </ng-template>
+
+        <label class="text-capitalize">{{ registro.concepto.term }}</label>
+
         <ng-container *ngIf="registro?.valor?.concepto || registro.valor.length === 1">
             <p class="list-item-group text-capitalize">{{ registro.valor?.concepto ? registro.valor.concepto.term :
                 registro.valor[0].concepto.term }}</p>

--- a/src/app/modules/rup/components/elementos/SelectPorRefset.html
+++ b/src/app/modules/rup/components/elementos/SelectPorRefset.html
@@ -26,6 +26,12 @@
     </ng-container>
 
     <p *ngIf="soloValores" class="readonly">
+        <div *ngIf="params?.titulo; else showTerm">
+            <label class="text-capitalize">{{ params.titutlo }}</label>
+        </div>
+        <ng-template #showTerm>
+            <label class="text-capitalize">{{ registro.concepto.term }}</label>
+        </ng-template>
         <ng-container *ngIf="registro?.valor?.concepto || registro.valor.length === 1">
             <p class="list-item-group text-capitalize">{{ registro.valor?.concepto ? registro.valor.concepto.term :
                 registro.valor[0].concepto.term }}</p>

--- a/src/app/modules/rup/components/elementos/valorFecha.html
+++ b/src/app/modules/rup/components/elementos/valorFecha.html
@@ -6,6 +6,12 @@
                 </plex-datetime>
             </ng-container>
             <ng-template #showSoloValores>
+                <div *ngIf="params?.title; else showTerm">
+                    <label class="text-capitalize">{{ params.title }}</label>
+                </div>
+                <ng-template #showTerm>
+                    <label class="text-capitalize">{{ registro.concepto.term }}</label>
+                </ng-template>
                 {{DateFormat}}
             </ng-template>
         </div>


### PR DESCRIPTION
 
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
Poder visualizar el term, sobre el valor en SoloValores, para saber al referencia a ese valor dentro de una molécula.
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Solo se agrega que en los componente de SelectPorRefset y valorFecha se visualice el term en el huds.
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
