### PR TITLE
INTERNACION - Separar los pases de cama del egreso de paciente

### DIFF
--- a/src/app/apps/rup/mapa-camas/mapa-camas.module.ts
+++ b/src/app/apps/rup/mapa-camas/mapa-camas.module.ts
@@ -20,7 +20,7 @@ import { ItemCamaComponent } from './views/mapa-camas-capa/item-cama/item-cama.c
 import { IngresarPacienteComponent } from './sidebar/ingreso/ingresar-paciente.component';
 import { IconoCamitaComponent } from './sidebar/estado-servicio/iconito-cama/icono-camita.component';
 import { CamaDestinoGenericoComponent } from './sidebar/cama-destino-generico/cama-destino-generico.component';
-import { CamaDesocuparComponent } from './sidebar/desocupar-cama/desocupar-cama.component';
+import { PaseCamaComponent } from './sidebar/desocupar-cama/pase-cama.component';
 import { EgresarPacienteComponent } from './sidebar/egreso/egresar-paciente.component';
 import { CamaDetalleComponent } from './sidebar/cama-detalle/cama-detalle.component';
 import { InternacionDetalleComponent } from './sidebar/cama-detalle/internacion-detalle/internacion-detalle.component';
@@ -57,7 +57,7 @@ export const INTERNACION_COMPONENTS = [
     IngresarPacienteComponent,
     IconoCamitaComponent,
     CamaDestinoGenericoComponent,
-    CamaDesocuparComponent,
+    PaseCamaComponent,
     EgresarPacienteComponent,
     CamaDetalleComponent,
     InternacionDetalleComponent,

--- a/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/pase-cama.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/pase-cama.component.html
@@ -1,5 +1,5 @@
 <div>
-    <plex-title justify titulo="Desocupar cama">
+    <plex-title justify titulo="Realizar Pase">
         <ng-content></ng-content>
     </plex-title>
     <ng-container *ngIf="movimientoEgreso$ | async as movimientoEgreso; else puedeEgresar">
@@ -31,20 +31,13 @@
                         <ng-container *ngIf="!(camasDisponibles.camasMismaUO.length > 0)">
                             <strong>No hay camas disponibles en la unidad organizativa actual.</strong>
                         </ng-container>
-                        <plex-button label="Cambiar de unidad organizativa" type="secondary" size="block"
-                                     title="{{ (!permisoMovimiento) ? 'No tiene permisos suficientes' : null }}"
-                                     [disabled]="!permisoMovimiento || !(camasDisponibles.camasDistintaUO.length > 0)"
-                                     (click)="cambiarCama(true)" [validateForm]="formReparada" class="mb-2">
+                        <plex-button label="Cambiar de unidad organizativa" type="warning" size="block"
+                                        title="{{ (!permisoMovimiento) ? 'No tiene permisos suficientes' : null }}"
+                                        [disabled]="!permisoMovimiento || !(camasDisponibles.camasDistintaUO.length > 0)"
+                                        (click)="cambiarCama(true)" [validateForm]="formReparada" class="mb-2">
                         </plex-button>
                         <ng-container *ngIf="!(camasDisponibles.camasDistintaUO.length > 0)">
                             <strong> No hay camas disponibles en otra unidad organizativa.</strong>
-                        </ng-container>
-                        <ng-container *ngIf="(view$ | async) === 'mapa-camas'">
-                            <plex-button label="Egresar paciente" type="warning" size="block"
-                                         title="{{ (!permisoEgreso) ? 'No tiene permisos para egresar pacientes' : null }}"
-                                         [disabled]="!permisoEgreso" (click)="egresarPaciente()"
-                                         [validateForm]="formReparada">
-                            </plex-button>
                         </ng-container>
                     </ng-template>
                 </ng-container>

--- a/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/pase-cama.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/pase-cama.component.ts
@@ -1,17 +1,17 @@
 import { Component, OnInit, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
 import { MapaCamasService } from '../../services/mapa-camas.service';
 import { ISnapshot } from '../../interfaces/ISnapshot';
-import { Subscription, combineLatest, Observable, of } from 'rxjs';
-import { switchMap, map, switchMapTo } from 'rxjs/operators';
+import { combineLatest, Observable, of } from 'rxjs';
+import { switchMap, map } from 'rxjs/operators';
 import { cache } from '@andes/shared';
 import { Auth } from '@andes/auth';
 
 
 @Component({
-    selector: 'app-desocupar-cama',
-    templateUrl: 'desocupar-cama.component.html'
+    selector: 'app-pase-cama',
+    templateUrl: 'pase-cama.component.html'
 })
-export class CamaDesocuparComponent implements OnInit, OnDestroy {
+export class PaseCamaComponent implements OnInit, OnDestroy {
     camasDisponibles$: Observable<any>;
 
     // EVENTOS

--- a/src/app/apps/rup/mapa-camas/views/listado-internacion/listado-internacion.component.html
+++ b/src/app/apps/rup/mapa-camas/views/listado-internacion/listado-internacion.component.html
@@ -64,11 +64,11 @@
                     </plex-title>
                     <app-internacion-detalle *ngIf="mostrar === 'datosInternacion'" (cambiarCama)="cambiarCama()">
                     </app-internacion-detalle>
-                    <app-desocupar-cama *ngIf="mostrar === 'desocuparCama'" (cancel)="volverADetalle()"
+                    <app-pase-cama *ngIf="mostrar === 'desocuparCama'" (cancel)="volverADetalle()"
                                         (accionDesocupar)="accionDesocupar($event)">
                         <plex-button title="volver" icon="arrow-left" type="danger" size="sm" (click)="volverADetalle()">
                         </plex-button>
-                    </app-desocupar-cama>
+                    </app-pase-cama>
                     <app-cambiar-cama *ngIf="mostrar === 'cambiarCama'" cambiarUO="{{ cambiarUO }}"
                                       (cancel)="volverADetalle()">
                     </app-cambiar-cama>

--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/item-cama/item-cama.component.html
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/item-cama/item-cama.component.html
@@ -46,6 +46,11 @@
             <ng-container *ngFor="let relacion of relacionesPosibles$ | async">
                 <ng-container
                               *ngIf="(relacion.accion !== 'internarPaciente') || (relacion.accion === 'internarPaciente' && permisoIngreso)">
+                    <ng-container *ngIf="relacion.accion === 'egresarPaciente'">
+                        <plex-button title="Realizar pase" icon="swap-horizontal-bold" type="warning" size="sm"
+                                (click)="accion({accion: 'realizarPase'}, $event)">
+                    </plex-button>
+                    </ng-container>
                     <plex-button title="{{ relacion.nombre }}" [icon]="relacion.icon" [type]="relacion.color" size="sm"
                                  (click)="accion(relacion, $event)">
                     </plex-button>

--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.html
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/mapa-camas-capa.component.html
@@ -59,17 +59,17 @@
                 </plex-button>
             </app-ingresar-paciente>
         </ng-container>
-        <app-desocupar-cama *ngIf="accion === 'desocuparCama'" (accionDesocupar)="accionDesocupar($event)">
+        <app-pase-cama *ngIf="accion === 'realizarPase'" (accionDesocupar)="accionDesocupar($event)">
             <plex-button title="Volver" icon="arrow-left" type="danger" size="sm" (click)="volverADetalle()">
             </plex-button>
-        </app-desocupar-cama>
+        </app-pase-cama>
         <app-cambiar-cama *ngIf="accion === 'cambiarCama'" cambiarUO="{{ cambiarUO }}" (onSave)="volverAResumen()">
             <plex-button title="Volver" icon="arrow-left" type="danger" size="sm" (click)="volverADetalle()">
             </plex-button>
         </app-cambiar-cama>
         <app-egresar-paciente *ngIf="accion === 'egresarPaciente'" (onSave)="volverAResumen()"
                               (cancel)="volverAResumen()">
-            <plex-button title="Volver" icon="arrow-left" type="danger" size="sm" (click)="volverADesocupar()">
+            <plex-button title="Volver" icon="arrow-left" type="danger" size="sm" (click)="volverADetalle()">
             </plex-button>
         </app-egresar-paciente>
         <app-cama-destino-generico *ngIf="accion === 'accionGenerica'" [relacion]="estadoRelacion"


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
Se necesita separar las opciones de pase de camas con egresar paciente, así el mapa de camas queda orientado al paciente y no tanto a las camas. 
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Separa los componentes desocupar cama y egresar paciente.
2. El componente de desocupar cama pasa a ser el que se encarga de los pases de cama.
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [X] Si --> Script: https://gist.github.com/GaboCancellieri/2298de5650f88a2cdaaf42c77228079e#file-update-desocupar-egresar
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
