### PR TITLE
TOP: arreglo en visualización de reglas globales

### DIFF
--- a/src/app/components/top/reglas/visualizacionReglas.component.ts
+++ b/src/app/components/top/reglas/visualizacionReglas.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ReglaService } from '../../../services/top/reglas.service';
-import { OrganizacionService } from '../../../services/organizacion.service';
 import { TipoPrestacionService } from './../../../services/tipoPrestacion.service';
 import { IRegla } from '../../../interfaces/IRegla';
 import { IOrganizacion } from '../../../interfaces/IOrganizacion';
@@ -46,7 +45,7 @@ export class VisualizacionReglasComponent implements OnInit {
      */
     filas: any[];
 
-    constructor(private servicioReglas: ReglaService, private servicioOrganizacion: OrganizacionService, public servicioPrestacion: TipoPrestacionService, private auth: Auth, private serviceTipoPrestacion: TipoPrestacionService) { }
+    constructor(private servicioReglas: ReglaService, public servicioPrestacion: TipoPrestacionService, private auth: Auth, private serviceTipoPrestacion: TipoPrestacionService) { }
 
     ngOnInit() {
         if (this.esParametrizado) {
@@ -112,41 +111,33 @@ export class VisualizacionReglasComponent implements OnInit {
      */
     obtenerFilasTabla(reglas: [IRegla]) {
         this.filas = [];
-        let ids = reglas.map(regla => regla.origen.organizacion.id).concat(reglas.map(regla => regla.destino.organizacion.id));
-        let parametros = {
-            ids: ids
-        };
-        this.servicioOrganizacion.get(parametros)
-            .subscribe(
-                organizaciones => {
-                    for (let regla of reglas) {
-                        regla.origen.prestaciones.forEach((prestacionAux: any) => { // prestacionAux es cada celda del arreglo de origen.prestaciones. Tiene la prestación y si es auditable
-                            if (!this.prestacionOrigen || this.prestacionOrigen.conceptId === prestacionAux.prestacion.conceptId) {
-                                /* Es necesaria esta validación porque una regla tiene un origen y un destino. El origen se compone de
-                                 * una organización y una lista de prestaciones. Entonces si filtra por prestación origen, que muestre
-                                 * solo aquellas partes de la regla que cumpla con los filtros ingresados. El destino es una organización
-                                 * y una sola prestación por lo que no es necesario más validaciones. */
-                                this.filas.push({
-                                    organizacionOrigen: organizaciones.find(org => org.id === regla.origen.organizacion.id),
-                                    prestacionOrigen: prestacionAux,
-                                    organizacionDestino: organizaciones.find(org => org.id === regla.destino.organizacion.id),
-                                    prestacionDestino: regla.destino.prestacion
-                                });
-                            }
-                        });
-                    }
-                    if (this.esParametrizado) {
-                        this.filas.sort((fila1, fila2) => {
-                            if (fila2.prestacionDestino.term < fila1.prestacionDestino.term) {
-                                return 1;
-                            }
-                            if (fila2.prestacionDestino.term > fila1.prestacionDestino.term) {
-                                return -1;
-                            }
-                            return 0;
-                        });
-                    }
-                });
+        for (let regla of reglas) {
+            regla.origen.prestaciones.forEach((prestacionAux: any) => { // prestacionAux es cada celda del arreglo de origen.prestaciones. Tiene la prestación y si es auditable
+                if (!this.prestacionOrigen || this.prestacionOrigen.conceptId === prestacionAux.prestacion.conceptId) {
+                    /* Es necesaria esta validación porque una regla tiene un origen y un destino. El origen se compone de
+                     * una organización y una lista de prestaciones. Entonces si filtra por prestación origen, que muestre
+                     * solo aquellas partes de la regla que cumpla con los filtros ingresados. El destino es una organización
+                     * y una sola prestación por lo que no es necesario más validaciones. */
+                    this.filas.push({
+                        organizacionOrigen: regla.origen.organizacion,
+                        prestacionOrigen: prestacionAux,
+                        organizacionDestino: regla.destino.organizacion,
+                        prestacionDestino: regla.destino.prestacion
+                    });
+                }
+            });
+        }
+        if (this.esParametrizado) {
+            this.filas.sort((fila1, fila2) => {
+                if (fila2.prestacionDestino.term < fila1.prestacionDestino.term) {
+                    return 1;
+                }
+                if (fila2.prestacionDestino.term > fila1.prestacionDestino.term) {
+                    return -1;
+                }
+                return 0;
+            });
+        }
     }
 }
 

--- a/src/app/components/top/reglas/visualizacionReglas.html
+++ b/src/app/components/top/reglas/visualizacionReglas.html
@@ -1,16 +1,16 @@
 <plex-wrapper *ngIf="!esParametrizado">
-        <plex-select [(ngModel)]="organizacionOrigen" name="orgOrigen" tmOrganizaciones label="Organización origen"
-                     placeholder="Seleccione la organización" (change)="actualizarTabla()">
-        </plex-select>
-        <plex-select [(ngModel)]="prestacionOrigen" (getData)="loadPrestaciones($event)" name="prestOrigen"
-                     label="Prestación origen" placeholder="Seleccione la prestación" (change)="actualizarTabla()">
-        </plex-select>
-        <plex-select [(ngModel)]="organizacionDestino" name="orgDestino" tmOrganizaciones label="Organización destino"
-                     placeholder="Seleccione la organización" (change)="actualizarTabla()">
-        </plex-select>
-        <plex-select [(ngModel)]="prestacionDestino" name="prestDestino" (getData)="loadPrestaciones($event)"
-                     label="Prestación destino" placeholder="Seleccione la prestación" (change)="actualizarTabla()">
-        </plex-select>
+    <plex-select [(ngModel)]="organizacionOrigen" name="orgOrigen" tmOrganizaciones label="Organización origen"
+                 placeholder="Seleccione la organización" (change)="actualizarTabla()">
+    </plex-select>
+    <plex-select [(ngModel)]="prestacionOrigen" (getData)="loadPrestaciones($event)" name="prestOrigen"
+                 label="Prestación origen" placeholder="Seleccione la prestación" (change)="actualizarTabla()">
+    </plex-select>
+    <plex-select [(ngModel)]="organizacionDestino" name="orgDestino" tmOrganizaciones label="Organización destino"
+                 placeholder="Seleccione la organización" (change)="actualizarTabla()">
+    </plex-select>
+    <plex-select [(ngModel)]="prestacionDestino" name="prestDestino" (getData)="loadPrestaciones($event)"
+                 label="Prestación destino" placeholder="Seleccione la prestación" (change)="actualizarTabla()">
+    </plex-select>
 </plex-wrapper>
 <div *ngIf="!filtroIngresado() || !filas?.length" class="alert alert-default">
     No hay resultados que coincidan con los filtros de búsqueda
@@ -28,16 +28,14 @@
                 <plex-item *ngFor="let fila of filas">
                     <div class="elementos-graficos w-100" *ngIf="!esParametrizado">
                         <plex-icon name="hospital-building" type="info"></plex-icon>
-                        <plex-label [tituloBold]="true" titulo="{{ fila.organizacionOrigen.nombre }}"
-                                    subtitulo="Ciudad de {{ fila.organizacionOrigen.direccion?.ubicacion?.localidad?.nombre }}">
+                        <plex-label [tituloBold]="true" titulo="{{ fila.organizacionOrigen.nombre }}">
                         </plex-label>
                     </div>
                     <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.prestacionOrigen.prestacion.term }}">
                     </plex-label>
                     <div class="elementos-graficos w-100">
                         <plex-icon *ngIf="!esParametrizado" name="hospital-building" type="success"></plex-icon>
-                        <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.organizacionDestino.nombre }}"
-                                    subtitulo="Ciudad de {{ fila.organizacionDestino.direccion?.ubicacion?.localidad?.nombre }}">
+                        <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.organizacionDestino.nombre }}">
                         </plex-label>
                     </div>
                     <plex-label [tituloBold]="!esParametrizado" titulo="{{ fila.prestacionDestino.term }}"></plex-label>


### PR DESCRIPTION
### Requerimiento
En la visualización de reglas globales, el llamado a la api para traer las organizaciones colapsaba en producción, por lo que se decide eliminar el dato de localidad.

### Funcionalidad desarrollada 
1. En el listado de reglas globales se quita la localidad de las organizaciones

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


