### PR TITLE
GDU: permitir copy/paste entre prestaciones

### DIFF
--- a/src/app/apps/gestor-usuarios/components/arbol-permisos/arbol-permisos-item.component.html
+++ b/src/app/apps/gestor-usuarios/components/arbol-permisos/arbol-permisos-item.component.html
@@ -35,8 +35,14 @@
             {{item.title}}
             <plex-bool *ngIf="!item.avoidAll" [(ngModel)]="all" label="Seleccionar todos" type="slide"> </plex-bool>
         </h5>
-        <plex-select [multiple]="true" [readonly]="all" [(ngModel)]="seleccionados" *ngIf="!loading"
-            (getData)="loadData(item.type, $event)" placeholder="Seleccione los elementos con permisos" name="plexSelect"
-            idField="id"></plex-select>
+        <plex-wrapper>
+            <plex-select [multiple]="true" [readonly]="all" [(ngModel)]="seleccionados" *ngIf="!loading"
+                         (getData)="loadData(item.type, $event)" placeholder="Seleccione los elementos con permisos"
+                         name="plexSelect" idField="id" (change)="parseSelecionados()"
+                         (paste)="$event.preventDefault();onPaste($event);">
+            </plex-select>
+            <plex-copy *ngIf="!loading && item.type === 'prestacion'" [value]="seleccionadosJson">
+            </plex-copy>
+        </plex-wrapper>
     </div>
 </div>


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/GDU-5

### Funcionalidad desarrollada 
1. Se suma plex-copy a los select de prestaciones para poder copiar entra items

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

![image](https://user-images.githubusercontent.com/7090371/91329402-7f9bfe00-e79e-11ea-940a-94ea6db8173b.png)
