### PR TITLE
RUP: posibilidad de registrar conceptos repetidos en una prestación

### DIFF
--- a/src/app/modules/rup/interfaces/elementoRUP.interface.ts
+++ b/src/app/modules/rup/interfaces/elementoRUP.interface.ts
@@ -44,6 +44,11 @@ export interface IElementoRUP {
     frecuentes: ISnomedConcept[];
 
     inactiveAt?: Date;
+
+    /**
+     * Puede repetirse el concepto mas de una vez en la prestación.
+     */
+    permiteRepetidos?: boolean;
 }
 
 export interface IElementoRUPRequeridos {

--- a/src/app/modules/rup/services/ejecucion.service.ts
+++ b/src/app/modules/rup/services/ejecucion.service.ts
@@ -8,6 +8,7 @@ import { PrestacionesService } from './prestaciones.service';
 import { switchMap, map, filter } from 'rxjs/operators';
 import { IPrestacion } from '../interfaces/prestacion.interface';
 import { cache } from '@andes/shared';
+import { ElementosRUPService } from './elementosRUP.service';
 
 
 @Injectable()
@@ -35,7 +36,8 @@ export class RupEjecucionService {
 
     constructor(
         private plex: Plex,
-        private prestacionService: PrestacionesService
+        private prestacionService: PrestacionesService,
+        private elementosRUPService: ElementosRUPService
     ) {
 
     }
@@ -75,7 +77,13 @@ export class RupEjecucionService {
     }
 
     chequearRepetido(data: EmitConcepto) {
-        const { concepto } = data;
+        const { concepto, esSolicitud } = data;
+
+        const elementoRUP = this.elementosRUPService.buscarElemento(concepto, esSolicitud);
+        if (elementoRUP.permiteRepetidos) {
+            return true;
+        }
+
         const registros = this.getPrestacionRegistro();
         const registoExiste = registros.find(registro => registro.concepto.conceptId === concepto.conceptId);
         if (registoExiste) {


### PR DESCRIPTION
### Requerimiento 
https://proyectos.andes.gob.ar/browse/RUP-179

### Funcionalidad desarrollada 
1. En la ejecución de una prestación, si el concepto a registrar está repetido se chequea si el elementoRUP asociado permite repetidos.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si https://github.com/andes/api/pull/1092
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No
