### PR TITLE
fix(rup): odontrograma no se podia usar como segungo registro

### DIFF
--- a/src/app/apps/auth/components/accept-disclaimer/modal-disclaimer.component.ts
+++ b/src/app/apps/auth/components/accept-disclaimer/modal-disclaimer.component.ts
@@ -36,7 +36,7 @@ export class ModalDisclaimerComponent implements OnInit {
 
     ngOnInit() {
         this.disclaimerService.get({ activo: true }).subscribe(data => {
-            if (data) {
+            if (data && data.length) {
                 this.disclaimer = data[0];
                 this.version = this.disclaimer.version;
                 this.texto = this.disclaimer.texto;

--- a/src/app/modules/rup/components/elementos/OdontogramaRefset.component.ts
+++ b/src/app/modules/rup/components/elementos/OdontogramaRefset.component.ts
@@ -432,7 +432,7 @@ export class OdontogramaRefsetComponent extends RUPComponent implements OnInit {
             // No es pieza completa (ver seleccionarPieza())
             dienteSel.piezaCompleta = false;
 
-            this.prestacion.ejecucion.registros[0].valor = {
+            this.registro.valor = {
                 odontograma: this.odontograma
             };
 


### PR DESCRIPTION
### Requerimiento
Bug de odontograma cuando se usaba como segundo registro. El valor no estaba definido. 

### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
