### PR TITLE
fix(TOP): no se visualizaban  indicaciones de RUP

### DIFF
--- a/src/app/components/top/solicitudes/detalleSolicitud.html
+++ b/src/app/components/top/solicitudes/detalleSolicitud.html
@@ -126,7 +126,7 @@
                 <ng-container
                               *ngIf='prestacionSeleccionada.solicitud.registros[0].valor.solicitudPrestacion.indicaciones'>
                     <plex-help type="help" titulo="Indicaciones" tituloBoton="Ver Indicaciones">
-                        <p class="m-2"
+                        <p class="m-2 text-muted"
                            [innerHTML]="prestacionSeleccionada.solicitud.registros[0].valor.solicitudPrestacion.indicaciones">
                         </p>
                     </plex-help>


### PR DESCRIPTION
### Requerimiento
En el detalle de una solicitud con indicaciones, a partir del cambio en el sidebar que pasa a ser invert no se visualizan las indicaciones cargadas desde RUP en el plex-help. 

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se modifica el class del parrafo donde se visualizan las indicaciones para resolver el bug provisoriamente hasta que suban cambios a plex. 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
