### PR TITLE
RUP - Invalidar inicio de prestación

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -374,26 +374,13 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
     invalidarPrestacion(prestacion, idTurno) {
         this.plex.confirm('¿Está seguro que desea invalidar esta prestación?').then(confirmacion => {
             if (confirmacion) {
-                if (this.agendaSeleccionada && this.agendaSeleccionada.dinamica) {
-                    // Si es agenda dinámica, se elimina el turno y en caso de tener cupo maximo éste aumenta en uno
-                    let index = this.agendaSeleccionada.bloques[0].turnos.findIndex(t => t.id === idTurno);
-                    if (index >= 0) {
-                        this.agendaSeleccionada.bloques[0].turnos.splice(index, 1);
-                        if (this.agendaSeleccionada.cupo > -1) {
-                            this.agendaSeleccionada.cupo++;
-                        }
-                        this.servicioAgenda.save(this.agendaSeleccionada).subscribe();
-                    }
-                }
                 let data;
                 if (prestacion.solicitud.turno) {
-                    // Se desasocia el turno, de manera que puedan iniciar nuevamente la prestación
                     data = { op: 'desasociarTurno' };
                 } else {
-                    // Es prestación fuera de agenda
                     data = { op: 'estadoPush', estado: { tipo: 'anulada' } };
                 }
-                this.servicioPrestacion.patch(prestacion.id, data).subscribe(this.actualizar.bind(this));
+                this.servicioPrestacion.patch(prestacion.id, data).subscribe(() => this.actualizar());
             }
         });
     }

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -487,7 +487,7 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
             fechaDesde: this.fecha ? this.fecha : new Date(),
             fechaHasta: new Date(),
             organizacion: this.auth.organizacion.id,
-            sinEstado: 'modificada',
+            sinEstado: ['modificada', 'anulada'],
             ambitoOrigen: 'ambulatorio',
             tipoPrestaciones: this.tiposPrestacion.map(t => t.conceptId)
         });

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -371,6 +371,32 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         });
     }
 
+    invalidarPrestacion(prestacion, idTurno) {
+        this.plex.confirm('¿Está seguro que desea invalidar esta prestación?').then(confirmacion => {
+            if (confirmacion) {
+                if (this.agendaSeleccionada && this.agendaSeleccionada.dinamica) {
+                    // Si es agenda dinámica, se elimina el turno y en caso de tener cupo maximo éste aumenta en uno
+                    let index = this.agendaSeleccionada.bloques[0].turnos.findIndex(t => t.id === idTurno);
+                    if (index >= 0) {
+                        this.agendaSeleccionada.bloques[0].turnos.splice(index, 1);
+                        if (this.agendaSeleccionada.cupo > -1) {
+                            this.agendaSeleccionada.cupo++;
+                        }
+                        this.servicioAgenda.save(this.agendaSeleccionada).subscribe();
+                    }
+                }
+                let data;
+                if (prestacion.solicitud.turno) {
+                    // Se desasocia el turno, de manera que puedan iniciar nuevamente la prestación
+                    data = { op: 'desasociarTurno' };
+                } else {
+                    // Es prestación fuera de agenda
+                    data = { op: 'estadoPush', estado: { tipo: 'anulada' } };
+                }
+                this.servicioPrestacion.patch(prestacion.id, data).subscribe(this.actualizar.bind(this));
+            }
+        });
+    }
 
     registrarInasistencia(paciente, agenda: IAgenda = null, turno, operacion) {
         const msg = operacion === 'noAsistio' ?

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.html
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.html
@@ -258,14 +258,12 @@
                                     <plex-badge type="danger" *ngIf="turno && turno.estado === 'suspendido'">
                                         Suspendido</plex-badge>
                                     <span *ngIf="turno && turno.nota">
-                                        <i title="{{turno.nota}}"
-                                           class="text-warning warning mdi mdi-message"></i>
+                                        <i title="{{turno.nota}}" class="text-warning warning mdi mdi-message"></i>
                                     </span>
 
                                     <div *ngIf="turno && turno.confirmatedAt">
                                         <br />
-                                        <plex-badge type="default"
-                                                    title="{{turno.confirmatedAt | date: 'medium'}}">                                            
+                                        <plex-badge type="default" title="{{turno.confirmatedAt | date: 'medium'}}">
                                             Confirmado
                                         </plex-badge>
                                     </div>
@@ -305,6 +303,12 @@
                                                      *ngIf="!turno.asistencia && !esFutura(agendaSeleccionada) && agendaSeleccionada.estado !== 'auditada' && turno.estado !== 'suspendido' && turno.paciente && (!turno.prestacion || turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'ejecucion')"
                                                      type="warning btn-sm" label="REGISTRAR INASISTENCIA"
                                                      (click)="registrarInasistencia(turno.paciente,agendaSeleccionada, turno.id, 'noAsistio')">
+                                        </plex-button>
+
+                                        <plex-button size="block"
+                                                     *ngIf="turno.paciente && turno.estado !== 'suspendido' && turno.prestacion && turno.prestacion.estados[turno.prestacion.estados.length - 1].tipo === 'ejecucion' && tienePermisos(turno) && verificarAsistencia(turno)"
+                                                     label="ANULAR INICIO DE PRESTACIÓN" type="danger btn-sm"
+                                                     (click)="invalidarPrestacion(turno.prestacion, agendaSeleccionada.dinamica ? turno.id : false)">
                                         </plex-button>
 
                                     </ng-container>
@@ -358,8 +362,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <ng-container
-                                          *ngFor="let sobreturno of agendaSeleccionada.sobreturnos; let j=index">
+                            <ng-container *ngFor="let sobreturno of agendaSeleccionada.sobreturnos; let j=index">
                                 <tr *ngIf="sobreturno" class="hover">
                                     <td>
                                         <strong>{{ sobreturno.horaInicio | date: 'HH:mm' }}</strong>
@@ -443,8 +446,7 @@
                                     </td>
                                     <td>
                                     <td>
-                                        <ng-container 
-                                                      *ngIf="sobreturno.tipoPrestacion && sobreturno.paciente?.id">
+                                        <ng-container *ngIf="sobreturno.tipoPrestacion && sobreturno.paciente?.id">
                                             <plex-button size="block" *ngIf='tieneAccesoHUDS'
                                                          (click)="setRouteToParams(['paciente', sobreturno.paciente.id]); setAccesoHudsParams(sobreturno.paciente, sobreturno.id, sobreturno.tipoPrestacion.id)"
                                                          label="VER HUDS" type="primary btn-sm">
@@ -477,6 +479,11 @@
                                                          type="warning btn-sm" label="REGISTRAR INASISTENCIA"
                                                          (click)=" registrarInasistencia(sobreturno.paciente,agendaSeleccionada, sobreturno.id, 'noAsistio')">
                                             </plex-button>
+                                            <plex-button size="block"
+                                                         *ngIf="sobreturno.paciente && sobreturno.estado !== 'suspendido' && sobreturno.prestacion && sobreturno.prestacion.estados[sobreturno.prestacion.estados.length - 1].tipo === 'ejecucion' && tienePermisos(sobreturno)"
+                                                         label="ANULAR INICIO DE PRESTACIÓN" type="danger btn-sm"
+                                                         (click)="invalidarPrestacion(sobreturno.prestacion)">
+                                            </plex-button>
 
                                         </ng-container>
                                     </td>
@@ -495,8 +502,7 @@
                     <tbody>
                         <tr *ngFor="let prestacion of fueraDeAgenda" class="hover">
                             <td>
-                                <strong 
-                                        *ngIf="prestacion">{{ prestacion.solicitud.fecha | date: 'HH:mm' }}</strong>
+                                <strong *ngIf="prestacion">{{ prestacion.solicitud.fecha | date: 'HH:mm' }}</strong>
                                 <br>
                                 <plex-badge
                                             type="{{ prestacion.estados[prestacion.estados.length - 1].tipo === 'validada' ? 'success' : (
@@ -545,9 +551,16 @@
 
                                 <plex-button size="block"
                                              *ngIf="prestacion.estados[prestacion.estados.length - 1].tipo === 'validada'"
-                                             (click)="onVerResumenClick('validacion', prestacion)" 
-                                             label="VER RESUMEN" type="success btn-sm">
+                                             (click)="onVerResumenClick('validacion', prestacion)" label="VER RESUMEN"
+                                             type="success btn-sm">
                                 </plex-button>
+
+                                <plex-button size="block"
+                                             *ngIf="prestacion.estados[prestacion.estados.length - 1].tipo === 'ejecucion'"
+                                             label="ANULAR INICIO DE PRESTACIÓN" type="danger btn-sm"
+                                             (click)="invalidarPrestacion(prestacion)">
+                                </plex-button>
+
                             </td>
                         </tr>
                     </tbody>

--- a/src/app/modules/rup/interfaces/prestacionGetParams.interface.ts
+++ b/src/app/modules/rup/interfaces/prestacionGetParams.interface.ts
@@ -1,7 +1,7 @@
 export class IPrestacionGetParams {
     id?: string;
     estado?: any;
-    sinEstado?: string;
+    sinEstado?: string | string[];
     fechaDesde?: Date;
     fechaHasta?: Date;
     idProfesional?: string;

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -142,7 +142,7 @@ export class PrestacionesService {
             const opt = {
                 params: {
                     idPaciente: idPaciente,
-                    sinEstado: 'modificada',
+                    sinEstado: ['modificada', 'anulada'],
                     hudsToken: this.hudsService.getHudsToken()
                 },
                 options: {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-124

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Nueva funcion ' anular inicio de prestacion' que, dada una prestación en ejecución, desasocia el turno/sobreturno de la agenda correspondiente (En caso de no ser prestación fuera de agenda) y pone en estado anulada dicha prestación. De esta manera la prestación puede volver a iniciarse.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si  https://github.com/andes/api/pull/1128
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si  https://github.com/andes/andes-test-integracion/pull/247
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
