### PR TITLE
fix(huds): cache es un observable ahora

### DIFF
--- a/src/app/modules/rup/components/elementos/evolucionProblemaDefault.html
+++ b/src/app/modules/rup/components/elementos/evolucionProblemaDefault.html
@@ -128,7 +128,7 @@
                         <div class="row ml-1">
                             <div class="col">
                                 <span
-                                      [innerHTML]="prestacionesService.mostrarInformeRelacionado(paciente,evolucion,registro.concepto)"></span>
+                                      [innerHTML]="prestacionesService.mostrarInformeRelacionado(paciente,evolucion,registro.concepto) | async"></span>
                             </div>
                         </div>
                         <div class="row ml-1">

--- a/src/app/modules/rup/components/huds/vistaProcedimiento.html
+++ b/src/app/modules/rup/components/huds/vistaProcedimiento.html
@@ -44,7 +44,7 @@
                              [params]="elementosRUPService.elementoRegistro(registro).params" [soloValores]="true">
                         </rup>
                         <span
-                              [innerHTML]="prestacionesService.mostrarInformeRelacionado(paciente, registro, registro.concepto)"></span>
+                              [innerHTML]="prestacionesService.mostrarInformeRelacionado(paciente, registro, registro.concepto) | async"></span>
                     </div>
 
 

--- a/src/app/modules/rup/components/huds/vistaRegistro.html
+++ b/src/app/modules/rup/components/huds/vistaRegistro.html
@@ -49,7 +49,7 @@
                             <span [innerHTML]="registro.evoluciones[indice].evolucion"></span><br>
                         </ng-container>
                         <span
-                              [innerHTML]="prestacionesService.mostrarInformeRelacionado(paciente, registro, registro.concepto)"></span>
+                              [innerHTML]="prestacionesService.mostrarInformeRelacionado(paciente, registro, registro.concepto) | async"></span>
                     </div>
                     <div class="columna-completa align">
                         <b>Estado:</b>

--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -1,7 +1,7 @@
 
 import { map, switchMap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
-import { Observable, BehaviorSubject, forkJoin } from 'rxjs';
+import { Observable, BehaviorSubject, forkJoin, of } from 'rxjs';
 import { Auth } from '@andes/auth';
 import { cache, Server } from '@andes/shared';
 import { IPrestacion } from '../interfaces/prestacion.interface';
@@ -720,28 +720,30 @@ export class PrestacionesService {
 
 
     /**
-        * Devuelve el texto del informe del encuentro asociado al registro
-        *
-        * @param {any} paciente un paciente
-        * @param {any} registro un registro de una prestación
-        * @returns  {string} Informe del encuentro relacionado al registro de entrada
-        * @memberof PrestacionesService
-        */
+    * Devuelve el texto del informe del encuentro asociado al registro
+    *
+    * @param {any} paciente un paciente
+    * @param {any} registro un registro de una prestación
+    * @returns  {string} Informe del encuentro relacionado al registro de entrada
+    * @memberof PrestacionesService
+    */
     mostrarInformeRelacionado(paciente, registro, concepto) {
-        let salida = '';
         if (registro.idPrestacion && concepto.conceptId !== PrestacionesService.InformeDelEncuentro) {
-            if (this.cache[paciente.id]) {
-                let unaPrestacion = this.cache[paciente.id].find(p => p.id === registro.idPrestacion);
-                if (unaPrestacion) {
-                    // vamos a buscar si en la prestación esta registrado un informe del encuentro
-                    let registroEncontrado = unaPrestacion.ejecucion.registros.find(r => r.concepto.conceptId === PrestacionesService.InformeDelEncuentro);
-                    if (registroEncontrado) {
-                        salida = registroEncontrado.valor ? '<label>Informe del encuentro</label>' + registroEncontrado.valor : null;
+            return this.getByPaciente(paciente.id).pipe(
+                map(prestaciones => prestaciones.find(p => p.id === registro.idPrestacion)),
+                map((prestacion: any) => {
+                    if (prestacion) {
+                        // vamos a buscar si en la prestación esta registrado un informe del encuentro
+                        let registroEncontrado = prestacion.ejecucion.registros.find(r => r.concepto.conceptId === PrestacionesService.InformeDelEncuentro);
+                        if (registroEncontrado) {
+                            return registroEncontrado.valor ? '<label>Informe del encuentro</label>' + registroEncontrado.valor : null;
+                        }
                     }
-                }
-            }
+                    return '';
+                })
+            );
         }
-        return salida;
+        return of('');
     }
 
     getFriendlyName(registro) {


### PR DESCRIPTION
### Requerimiento
La variable cache del servicio prestaciones ahora es un observable. Esta mal acceder directamente a ella. 

### Funcionalidad desarrollada 
1. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
