### PR TITLE
perf(huds): quita sort innecesario

### DIFF
--- a/src/app/modules/rup/services/prestaciones.service.ts
+++ b/src/app/modules/rup/services/prestaciones.service.ts
@@ -142,7 +142,6 @@ export class PrestacionesService {
             const opt = {
                 params: {
                     idPaciente: idPaciente,
-                    ordenFecha: true,
                     sinEstado: 'modificada',
                     hudsToken: this.hudsService.getHudsToken()
                 },


### PR DESCRIPTION
### Requerimiento
Quita sort innecesario de Prestaciones. Se pretende disminuir el trabajo de Mongo evitando el sort en memoría. 

![image](https://user-images.githubusercontent.com/3813270/95919130-6f0e0a00-0d83-11eb-9be0-a5eb76911bc8.png)




### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [x] No
