### PR TITLE
perf(top): evita calcular estado todo el tiempo

### DIFF
--- a/src/app/components/top/pipes/estado-solicitud.pipe.ts
+++ b/src/app/components/top/pipes/estado-solicitud.pipe.ts
@@ -9,7 +9,6 @@ export class EstadoSolicitudPipe implements PipeTransform {
     constructor(private auth: Auth) { }
     transform(prestacion: IPrestacion): any {
 
-        console.log(prestacion.id);
         if (prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'validada') {
             return 'Turno dado';
         }
@@ -19,7 +18,7 @@ export class EstadoSolicitudPipe implements PipeTransform {
             }
             const esAuditoria = prestacion.estadoActual.tipo === 'auditoria' || prestacion.estadoActual.tipo === 'rechazada';
             if (esAuditoria) {
-                return 'auditoria';
+                return prestacion.estadoActual.tipo === 'auditoria' ? 'auditoria' : 'rechazada';
             }
             if (prestacion.paciente && prestacion.estadoActual.tipo === 'asignada' && prestacion.solicitud.profesional?.id === this.auth.profesional) {
                 return 'asignada';
@@ -36,6 +35,9 @@ export class EstadoSolicitudPipe implements PipeTransform {
         }
         if (prestacion.estadoActual.tipo === 'ejecucion') {
             return 'ejecucion';
+        }
+        if (prestacion.estadoActual.tipo === 'rechazada') {
+            return 'rechazada';
         }
 
     }

--- a/src/app/components/top/pipes/estado-solicitud.pipe.ts
+++ b/src/app/components/top/pipes/estado-solicitud.pipe.ts
@@ -1,0 +1,42 @@
+import { Auth } from '@andes/auth';
+import { Pipe, PipeTransform } from '@angular/core';
+import { IPrestacion } from '../../../modules/rup/interfaces/prestacion.interface';
+
+@Pipe({
+    name: 'estadoSolicitud'
+})
+export class EstadoSolicitudPipe implements PipeTransform {
+    constructor(private auth: Auth) { }
+    transform(prestacion: IPrestacion): any {
+
+        console.log(prestacion.id);
+        if (prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'validada') {
+            return 'Turno dado';
+        }
+        if (prestacion.solicitud.organizacion.id === this.auth.organizacion.id) {
+            if (prestacion.estadoActual.tipo === 'pendiente' && prestacion?.paciente && !prestacion.solicitud.turno) {
+                return 'pendiente';
+            }
+            const esAuditoria = prestacion.estadoActual.tipo === 'auditoria' || prestacion.estadoActual.tipo === 'rechazada';
+            if (esAuditoria) {
+                return 'auditoria';
+            }
+            if (prestacion.paciente && prestacion.estadoActual.tipo === 'asignada' && prestacion.solicitud.profesional?.id === this.auth.profesional) {
+                return 'asignada';
+            }
+        }
+        if (prestacion.solicitud.organizacion && prestacion.solicitud.organizacion.id !== this.auth.organizacion.id) {
+            return 'referida';
+        }
+        if (prestacion.estadoActual.tipo === 'validada') {
+            return 'validada';
+        }
+        if (prestacion.estadoActual.tipo === 'anulada') {
+            return 'anulada';
+        }
+        if (prestacion.estadoActual.tipo === 'ejecucion') {
+            return 'ejecucion';
+        }
+
+    }
+}

--- a/src/app/components/top/solicitudes/detalleSolicitud.html
+++ b/src/app/components/top/solicitudes/detalleSolicitud.html
@@ -105,7 +105,7 @@
             {{prestacionSeleccionada.estadoActual.motivoRechazo}}</span>
         <div class="row mb-3">
             <div class="col-4">
-                <plex-label titulo="Anulada por" subtitulo="{{prestacionSeleccionada.estadoActual.createdBy}}">
+                <plex-label titulo="Anulada por" subtitulo="{{prestacionSeleccionada.estadoActual.createdBy | nombre}}">
                 </plex-label>
             </div>
             <div class="col-4">

--- a/src/app/components/top/solicitudes/solicitudes.component.ts
+++ b/src/app/components/top/solicitudes/solicitudes.component.ts
@@ -791,12 +791,13 @@ export class SolicitudesComponent implements OnInit {
             this.itemsDropdown = [];
             if (prestacion.estadoActual.tipo === 'asignada') {
                 this.itemsDropdown[0] = { icon: 'clipboard-arrow-left', label: prestacion.solicitud.profesional?.id === this.auth.profesional ? 'Devolver' : 'Deshacer', handler: () => { this.devolver(prestacion); } };
-                 if (prestacion.solicitud.organizacion.id === this.auth.organizacion.id && prestacion.solicitud.profesional?.id === this.auth.profesional && prestacion.paciente ) {
-                     this.itemsDropdown[1] = {
-                         icon: 'contacts', label: 'Ver Huds', handler: () => {
-                        this.setRouteToParams(['paciente', prestacion.paciente.id]);
-                        this.setAccesoHudsParams(prestacion.paciente, null, prestacion.solicitud.tipoPrestacion.id);
-                    }};
+                if (prestacion.solicitud.organizacion.id === this.auth.organizacion.id && prestacion.solicitud.profesional?.id === this.auth.profesional && prestacion.paciente) {
+                    this.itemsDropdown[1] = {
+                        icon: 'contacts', label: 'Ver Huds', handler: () => {
+                            this.setRouteToParams(['paciente', prestacion.paciente.id]);
+                            this.setAccesoHudsParams(prestacion.paciente, null, prestacion.solicitud.tipoPrestacion.id);
+                        }
+                    };
                 }
             }
         }

--- a/src/app/components/top/solicitudes/solicitudes.component.ts
+++ b/src/app/components/top/solicitudes/solicitudes.component.ts
@@ -803,49 +803,4 @@ export class SolicitudesComponent implements OnInit {
         }
     }
 
-    verificarEstado(prestacion, i) {
-        if (prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'validada') {
-            return 'Turno dado';
-        }
-        if (prestacion.solicitud.organizacion.id === this.auth.organizacion.id) {
-            if (this.darTurnoArrayEntrada[i] && prestacion?.paciente && !prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'anulada') {
-                return 'pendiente';
-            }
-            if (this.auditarArrayEntrada[i]) {
-                return 'auditoria';
-            }
-            if (prestacion.paciente && prestacion.estadoActual.tipo === 'asignada' && prestacion.solicitud.profesional?.id === this.auth.profesional) {
-                return 'asignada';
-            }
-        }
-        if (prestacion.solicitud.organizacion && prestacion.solicitud.organizacion.id !== this.auth.organizacion.id) {
-            return 'referida';
-        }
-        if (prestacion.estadoActual.tipo === 'validada') {
-            return 'validada';
-        }
-        if (prestacion.estadoActual.tipo === 'anulada') {
-            return 'anulada';
-        }
-        if (prestacion.estadoActual.tipo === 'ejecucion') {
-            return 'ejecucion';
-        }
-    }
-
-    mostrar(solicitud, i) {
-        switch (this.verificarEstado(solicitud, i)) {
-            case 'asignada':
-                return true;
-            case 'Turno dado':
-            case 'pendiente':
-            case 'auditoria':
-            case 'anulada':
-            case 'referida':
-            case 'validada':
-            case 'ejecucion':
-                return false;
-            default:
-                return true;
-        }
-    }
 }

--- a/src/app/components/top/solicitudes/solicitudes.html
+++ b/src/app/components/top/solicitudes/solicitudes.html
@@ -104,14 +104,14 @@
                                         *ngIf="!prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'">
                                 Registro
                                 en HUDS</plex-badge>
-                            <plex-badge type="info"
-                                        *ngIf="!prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'rechazada'">
-                                CONTRARREFERIDA</plex-badge>
-                            <plex-badge type="warning"
-                                        *ngIf=" !prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'auditoria'">
-                                {{prestacion.estadoActual.tipo}}
-                            </plex-badge>
                             <ng-container ngProjectAs="plex-button" *ngIf="prestacion | estadoSolicitud as estado">
+                                <plex-badge type="info" *ngIf="!prestacion.solicitud.turno && estado === 'rechazada'">
+                                    CONTRARREFERIDA
+                                </plex-badge>
+                                <plex-badge type="warning"
+                                            *ngIf=" !prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'auditoria'">
+                                    {{prestacion.estadoActual.tipo}} 
+                                </plex-badge>
                                 <plex-badge *ngIf="estado === 'Turno dado'" type="success">Turno dado</plex-badge>
                                 <plex-badge *ngIf="prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'"
                                             type="success">Registro en HUDS</plex-badge>
@@ -122,7 +122,7 @@
                                              type="success" (click)="$event.stopPropagation();darTurno(prestacion)"
                                              title="Dar Turno">
                                 </plex-button>
-                                <plex-button size="sm" *ngIf="estado === 'auditoria'" icon="lock-alert" type="info"
+                                <plex-button size="sm" *ngIf="estado === 'auditoria' || estado === 'rechazada'" icon="lock-alert" type="info"
                                              (click)="$event.stopPropagation();auditar(prestacion)"
                                              title="Auditar Solicitud">
                                 </plex-button>
@@ -134,15 +134,15 @@
                                              (click)="$event.stopPropagation();citar(prestacion)"
                                              title="Citar paciente">
                                 </plex-button>
+                                <plex-button type="danger" icon="delete" size="sm"
+                                             (click)="$event.stopPropagation();anular(prestacion)" title="Anular"
+                                             *ngIf="prestacion.solicitud.organizacion.id === auth.organizacion.id && permisoAnular && darTurnoArrayEntrada[i] && prestacion?.paciente && !prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'anulada'">
+                                </plex-button>
+                                <plex-dropdown *ngIf="estado === 'asignada'" class="pl-2 mr-0" [right]="true"
+                                               [items]="itemsDropdown" size="sm" icon="dots-vertical" label=""
+                                               (onOpen)="setDropDown(prestacion, drop)">
+                                </plex-dropdown>
                             </ng-container>
-                            <plex-button type="danger" icon="delete" size="sm"
-                                         (click)="$event.stopPropagation();anular(prestacion)" title="Anular"
-                                         *ngIf="prestacion.solicitud.organizacion.id === auth.organizacion.id && permisoAnular && darTurnoArrayEntrada[i] && prestacion?.paciente && !prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'anulada'">
-                            </plex-button>
-                            <plex-dropdown *ngIf="mostrar(prestacion, i)" class="pl-2 mr-0" [right]="true"
-                                           [items]="itemsDropdown" size="sm" icon="dots-vertical" label=""
-                                           (onOpen)="setDropDown(prestacion, drop)">
-                            </plex-dropdown>
                         </plex-item>
                     </plex-list>
                 </plex-tab>

--- a/src/app/components/top/solicitudes/solicitudes.html
+++ b/src/app/components/top/solicitudes/solicitudes.html
@@ -61,7 +61,7 @@
                                *ngIf="prestacionesEntrada?.length">
                         <plex-item>
                             <b label>Fecha</b>
-                            <b  *ngIf="!showSidebar" label>Paciente</b>
+                            <b *ngIf="!showSidebar" label>Paciente</b>
                             <b label>Datos de origen</b>
                             <b label>Datos de destino</b>
                             <b></b>
@@ -77,7 +77,8 @@
                                         | fecha}}">
                                 </plex-label>
                             </plex-label>
-                            <plex-label  *ngIf="!showSidebar" [tituloBold]="true" titulo="{{prestacion.paciente | nombre }}"
+                            <plex-label *ngIf="!showSidebar" [tituloBold]="true"
+                                        titulo="{{prestacion.paciente | nombre }}"
                                         subtitulo="DNI: {{prestacion.paciente.documento}}">
                             </plex-label>
                             <plex-label [tituloBold]="true" titulo="{{prestacion.solicitud.profesionalOrigen?
@@ -110,41 +111,37 @@
                                         *ngIf=" !prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'auditoria'">
                                 {{prestacion.estadoActual.tipo}}
                             </plex-badge>
-                            <plex-badge *ngIf="verificarEstado(prestacion)==='Turno dado'"
-                                        type="success">Turno dado</plex-badge>
-                            <plex-badge *ngIf="prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'"
-                                        type="success">Registro en HUDS</plex-badge>
-                            <plex-badge *ngIf="verificarEstado(prestacion)==='referida'" type="warning">
-                                REFERIDA
-                            </plex-badge>
-                            <plex-button size="sm"
-                                         *ngIf="verificarEstado(prestacion, i)==='pendiente'"
-                                         icon="calendar-plus" type="success"
-                                         (click)="$event.stopPropagation();darTurno(prestacion)" title="Dar Turno">
-                            </plex-button>
-                            <plex-button size="sm"
-                                         *ngIf="verificarEstado(prestacion, i)==='auditoria'"
-                                         icon="lock-alert" type="info"
-                                         (click)="$event.stopPropagation();auditar(prestacion)"
-                                         title="Auditar Solicitud">
-                            </plex-button>
-                            <plex-button size="sm"
-                                         *ngIf="verificarEstado(prestacion, i) === 'asignada'"
-                                         icon="check" type="success"
-                                         (click)="$event.stopPropagation();onIniciarPrestacionClick(prestacion)"
-                                         title="Iniciar prestación">
-                            </plex-button>
-                            <plex-button size="sm"
-                                         *ngIf=" verificarEstado(prestacion, i) === 'asignada'"
-                                         icon="calendar" type="warning"
-                                         (click)="$event.stopPropagation();citar(prestacion)" title="Citar paciente">
-                            </plex-button>
+                            <ng-container ngProjectAs="plex-button" *ngIf="prestacion | estadoSolicitud as estado">
+                                <plex-badge *ngIf="estado === 'Turno dado'" type="success">Turno dado</plex-badge>
+                                <plex-badge *ngIf="prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'"
+                                            type="success">Registro en HUDS</plex-badge>
+                                <plex-badge *ngIf="estado === 'referida'" type="warning">
+                                    REFERIDA
+                                </plex-badge>
+                                <plex-button size="sm" *ngIf="estado === 'pendiente'" icon="calendar-plus"
+                                             type="success" (click)="$event.stopPropagation();darTurno(prestacion)"
+                                             title="Dar Turno">
+                                </plex-button>
+                                <plex-button size="sm" *ngIf="estado === 'auditoria'" icon="lock-alert" type="info"
+                                             (click)="$event.stopPropagation();auditar(prestacion)"
+                                             title="Auditar Solicitud">
+                                </plex-button>
+                                <plex-button size="sm" *ngIf="estado === 'asignada'" icon="check" type="success"
+                                             (click)="$event.stopPropagation();onIniciarPrestacionClick(prestacion)"
+                                             title="Iniciar prestación">
+                                </plex-button>
+                                <plex-button size="sm" *ngIf=" estado === 'asignada'" icon="calendar" type="warning"
+                                             (click)="$event.stopPropagation();citar(prestacion)"
+                                             title="Citar paciente">
+                                </plex-button>
+                            </ng-container>
                             <plex-button type="danger" icon="delete" size="sm"
                                          (click)="$event.stopPropagation();anular(prestacion)" title="Anular"
                                          *ngIf="prestacion.solicitud.organizacion.id === auth.organizacion.id && permisoAnular && darTurnoArrayEntrada[i] && prestacion?.paciente && !prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'anulada'">
                             </plex-button>
-                             <plex-dropdown *ngIf="mostrar(prestacion, i)" class="pl-2 mr-0" [right]="true" [items]="itemsDropdown" size="sm"
-                                icon="dots-vertical" label="" (onOpen)="setDropDown(prestacion, drop)">
+                            <plex-dropdown *ngIf="mostrar(prestacion, i)" class="pl-2 mr-0" [right]="true"
+                                           [items]="itemsDropdown" size="sm" icon="dots-vertical" label=""
+                                           (onOpen)="setDropDown(prestacion, drop)">
                             </plex-dropdown>
                         </plex-item>
                     </plex-list>
@@ -200,7 +197,8 @@
                                         subtitulo="Fecha de solicitud: {{prestacion.solicitud.fecha
                                     | fecha}}">
                             </plex-label>
-                            <plex-label *ngIf="!showSidebar" [tituloBold]="true" titulo="{{prestacion.paciente | nombre }}"
+                            <plex-label *ngIf="!showSidebar" [tituloBold]="true"
+                                        titulo="{{prestacion.paciente | nombre }}"
                                         subtitulo="DNI: {{prestacion.paciente.documento}}">
                             </plex-label>
                             <plex-label [tituloBold]="true" titulo="{{prestacion.solicitud.profesional?

--- a/src/app/components/top/top.routing.ts
+++ b/src/app/components/top/top.routing.ts
@@ -23,6 +23,7 @@ import { BusquedaPacienteComponent } from './solicitudes/busquedaPaciente.compon
 import { DetalleSolicitudComponent } from './solicitudes/detalleSolicitud.component';
 import { PrestacionSolicitudComponent } from './solicitudes/prestacionSolicitud.component';
 import { VisualizacionReglasTopComponent } from './reglas/visualizacionReglasTop.component';
+import { EstadoSolicitudPipe } from './pipes/estado-solicitud.pipe';
 
 export const TOP_ROUTES = [
     { path: '', component: SolicitudesComponent, pathMatch: 'full' },
@@ -58,7 +59,8 @@ export const TOP_ROUTES = [
         AnularSolicitudComponent,
         ReglasComponent,
         ListaReglasComponent,
-        BusquedaPacienteComponent
+        BusquedaPacienteComponent,
+        EstadoSolicitudPipe
     ]
 })
 export class TOPRouting { }

--- a/src/app/modules/rup/interfaces/prestacion.interface.ts
+++ b/src/app/modules/rup/interfaces/prestacion.interface.ts
@@ -66,6 +66,7 @@ export class IPrestacion {
     };
     // Historia de estado de la prestación
     estados: IPrestacionEstado[];
+    estadoActual: IPrestacionEstado;
 
     createdAt: Date;
     updatedAt: Date;


### PR DESCRIPTION
### Requerimiento
Utiliza pipe para calcular el estado de la solicitud por unica vez. Evitar multiples llamados. Dejo console.log para que verifiquen el comportamiento. 

De todas forma, quedan algunas mejoras más, es un ejemplo. La función **mostrar** llama a **verificarEstado**, habŕia que refactorizar bien todo. 
También hay algunos badge que no dependian de la función verificarEstado, eso complica mucho seguir el código. Esta partido en dos. 
Antes de completar este PR, habría que **UNIFICAR** criterios. 
 
### UserStory llegó a completarse
- [ ] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
- [ ] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [ ] No

 