### PR TITLE
Turnos y prestaciones: columnas dinámicas 

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/services/turnos-prestaciones.service.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/services/turnos-prestaciones.service.ts
@@ -61,6 +61,9 @@ export class TurnosPrestacionesService {
                 case 'estado':
                     prestaciones = prestaciones.sort((a, b) => (!a.estado) ? 1 : (!b.estado) ? -1 : a.estado.localeCompare((b.estado as string)));
                     break;
+                case 'ambito':
+                    prestaciones = prestaciones.sort((a, b) => (!a.ambito) ? 1 : (!b.ambito) ? -1 : a.ambito.localeCompare((b.ambito as string)));
+                    break;
                 default:
                     break;
             }

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -43,12 +43,12 @@ export class TurnosPrestacionesComponent implements OnInit {
     public botonBuscarDisabled: Boolean = false;
     public columnas = {
         fecha: true,
-        documento: false,
+        documento: true,
         paciente: true,
         tipoPrestacion: true,
-        equipoSalud: false,
+        equipoSalud: true,
         estado: true,
-        financiador: false,
+        financiador: true,
         ambito: false
     };
 

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -41,6 +41,16 @@ export class TurnosPrestacionesComponent implements OnInit {
     public selectProfesional: Boolean = false;
     public profesional: any;
     public botonBuscarDisabled: Boolean = false;
+    public columnas = {
+        fecha: true,
+        documento: false,
+        paciente: true,
+        tipoPrestacion: true,
+        equipoSalud: false,
+        estado: true,
+        financiador: false,
+        ambito: false
+    };
 
     public sortBy: String;
     public sortOrder = 'desc';

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -80,58 +80,90 @@
         </header>
         <!-- Resultados -->
         <plex-loader *ngIf="loading"></plex-loader>
+        <plex-title titulo="Turnos y prestaciones" size="sm">
+            <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block" [right]="true">
+                <plex-grid cols="3">
+                    <plex-bool label="Fecha" [(ngModel)]="columnas.fecha">
+                    </plex-bool>
+                    <plex-bool label="Documento" [(ngModel)]="columnas.documento">
+                    </plex-bool>
+                    <plex-bool label="Paciente" [(ngModel)]="columnas.paciente">
+                    </plex-bool>
+                    <plex-bool label="Prestacion" [(ngModel)]="columnas.tipoPrestacion">
+                    </plex-bool>
+                    <plex-bool label="Equipo de Salud" [(ngModel)]="columnas.equipoSalud">
+                    </plex-bool>
+                    <plex-bool label="Estado" [(ngModel)]="columnas.estado">
+                    </plex-bool>
+                    <plex-bool label="Financiador" [(ngModel)]="columnas.financiador">
+                    </plex-bool>
+                    <plex-bool label="Ambito" [(ngModel)]="columnas.ambito">
+                    </plex-bool>
+                </plex-grid>
+            </plex-dropdown>
+        </plex-title>
         <table *ngIf="!loading" class="table table-striped table-sm">
             <thead>
-                <th class="sortable" (click)="sortTable('fecha')">
+                <th *ngIf="columnas.fecha" class="sortable" (click)="sortTable('fecha')">
                     Fecha
                     <span *ngIf="sortBy === 'fecha'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th class="sortable" (click)="sortTable('documento')">
+                <th *ngIf="columnas.documento" class="sortable" (click)="sortTable('documento')">
                     Documento
                     <span *ngIf="sortBy === 'documento'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th class="sortable" (click)="sortTable('paciente')">Paciente
+                <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">Paciente
                     <span *ngIf="sortBy === 'paciente'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th class="sortable" (click)="sortTable('prestacion')">Tipo de Prestación
+                <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">Tipo de
+                    Prestación
                     <span *ngIf="sortBy === 'prestacion'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th class="sortable" (click)="sortTable('profesional')">Equipo de Salud
+                <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">Ambito
+                    <span *ngIf="sortBy === 'ambito'">
+                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                    </span>
+                </th>
+
+                <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">Equipo de Salud
                     <span *ngIf="sortBy === 'profesional'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th class="sortable" (click)="sortTable('estado')">Estado
+                <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">Estado
                     <span *ngIf="sortBy === 'estado'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th width="20%" *ngIf="!sumarB">Financiador
+                <th width="20%" *ngIf="!sumarB && columnas.financiador">Financiador
                 </th>
                 <th *ngIf="sumarB">Comprobante</th>
             </thead>
+
             <tbody>
                 <tr *ngFor="let busqueda of busqueda$ | async" class="hover" (click)="mostrarPrestacion(busqueda)"
                     [ngClass]="{'bg-inverse text-white': busqueda.seleccionada}">
-                    <td>{{busqueda.fecha | date: "dd/MM/yyyy HH:mm " }}</td>
-                    <td>{{busqueda.paciente.documento}}</td>
-                    <td>{{busqueda.paciente | nombre}}</td>
-                    <td>{{busqueda.prestacion?.term}}</td>
-                    <td class="nombres-profesionales">
+                    <td *ngIf="columnas.fecha">{{busqueda.fecha | date: "dd/MM/yyyy HH:mm " }}</td>
+                    <td *ngIf="columnas.documento">{{busqueda.paciente.documento}}</td>
+                    <td *ngIf="columnas.paciente">{{busqueda.paciente | nombre}}</td>
+                    <td *ngIf="columnas.tipoPrestacion">{{busqueda.prestacion?.term}}</td>
+                    <td *ngIf="columnas.ambito">{{busqueda.ambito}}</td>
+                    <td *ngIf="columnas.equipoSalud" class="nombres-profesionales">
                         <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">Profesional
                             no asignado</span>
                         <ng-container *ngIf="busqueda.profesionales">
@@ -139,8 +171,9 @@
                                 enumerar:['apellido','nombre'] }}</div>
                         </ng-container>
                     </td>
-                    <td>{{busqueda.estado}}</td>
-                    <td *ngIf="!sumarB">{{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}</td>
+                    <td *ngIf="columnas.estado">{{busqueda.estado}}</td>
+                    <td *ngIf="!sumarB && columnas.financiador">
+                        {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}</td>
                     <td *ngIf="sumarB">
                         {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}</td>
                 </tr>

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -89,7 +89,7 @@
                     </plex-bool>
                     <plex-bool label="Paciente" [(ngModel)]="columnas.paciente">
                     </plex-bool>
-                    <plex-bool label="Prestacion" [(ngModel)]="columnas.tipoPrestacion">
+                    <plex-bool label="Prestación" [(ngModel)]="columnas.tipoPrestacion">
                     </plex-bool>
                     <plex-bool label="Equipo de Salud" [(ngModel)]="columnas.equipoSalud">
                     </plex-bool>
@@ -97,7 +97,7 @@
                     </plex-bool>
                     <plex-bool label="Financiador" [(ngModel)]="columnas.financiador">
                     </plex-bool>
-                    <plex-bool label="Ambito" [(ngModel)]="columnas.ambito">
+                    <plex-bool label="Ámbito" [(ngModel)]="columnas.ambito">
                     </plex-bool>
                 </plex-grid>
             </plex-dropdown>

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -118,41 +118,48 @@
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">Paciente
+                <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">
+                    Paciente
                     <span *ngIf="sortBy === 'paciente'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">Tipo de
-                    Prestación
+                <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">
+                    Tipo de Prestación
                     <span *ngIf="sortBy === 'prestacion'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">Ambito
+                <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">
+                    Ambito
                     <span *ngIf="sortBy === 'ambito'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
 
-                <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">Equipo de Salud
+                <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">
+                    Equipo de Salud
                     <span *ngIf="sortBy === 'profesional'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">Estado
+                <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">
+                    Estado
                     <span *ngIf="sortBy === 'estado'">
                         <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
                         <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                     </span>
                 </th>
-                <th width="20%" *ngIf="!sumarB && columnas.financiador">Financiador
+                <th width="20%" *ngIf="!sumarB && columnas.financiador">
+                    Financiador
                 </th>
-                <th *ngIf="sumarB">Comprobante</th>
+                <th *ngIf="sumarB">
+                    Comprobante
+                </th>
             </thead>
 
             <tbody>
@@ -164,18 +171,22 @@
                     <td *ngIf="columnas.tipoPrestacion">{{busqueda.prestacion?.term}}</td>
                     <td *ngIf="columnas.ambito">{{busqueda.ambito}}</td>
                     <td *ngIf="columnas.equipoSalud" class="nombres-profesionales">
-                        <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">Profesional
-                            no asignado</span>
+                        <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">
+                            Profesional no asignado
+                        </span>
                         <ng-container *ngIf="busqueda.profesionales">
-                            <div *ngIf="busqueda.profesionales.length > 0">{{ busqueda.profesionales |
-                                enumerar:['apellido','nombre'] }}</div>
+                            <div *ngIf="busqueda.profesionales.length > 0">
+                                {{ busqueda.profesionales | enumerar:['apellido','nombre'] }}
+                            </div>
                         </ng-container>
                     </td>
                     <td *ngIf="columnas.estado">{{busqueda.estado}}</td>
                     <td *ngIf="!sumarB && columnas.financiador">
-                        {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}</td>
+                        {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}
+                    </td>
                     <td *ngIf="sumarB">
-                        {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}</td>
+                        {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}
+                    </td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-59

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Agrego _plex-dropdown_ en la vista del buscador de turnos y prestaciones para que el usuario pueda seleccionar que columnas desea ver y cuales no. Por defecto se mostraran fecha, paciente, tipoPrestacion y estado.
2. Se agrega el ámbito a las columnas dinámicas.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1162
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

