### PR TITLE
fix(mpi): setea fecha de fallecimiento

### DIFF
--- a/src/app/core/mpi/components/paciente.component.ts
+++ b/src/app/core/mpi/components/paciente.component.ts
@@ -88,7 +88,7 @@ export class PacienteComponent implements OnInit {
         numeroIdentificacion: null,
         edad: null,
         edadReal: null,
-        fechaFallecimiento: undefined,
+        fechaFallecimiento: null,
         direccion: [this.direccion],
         estadoCivil: undefined,
         fotoId: null,
@@ -527,6 +527,7 @@ export class PacienteComponent implements OnInit {
         this.backUpDatos['fechaNacimiento'] = this.pacienteModel.fechaNacimiento;
         this.backUpDatos['foto'] = this.pacienteModel.foto;
         this.backUpDatos['cuil'] = this.pacienteModel.cuil;
+        this.backUpDatos['fechaFallecimiento'] = this.pacienteModel.fechaFallecimiento;
         if (this.pacienteModel.direccion) {
             this.backUpDatos['direccion'] = this.pacienteModel.direccion[0].valor;
             this.backUpDatos['codigoPostal'] = this.pacienteModel.direccion[0].codigoPostal;
@@ -546,6 +547,7 @@ export class PacienteComponent implements OnInit {
             this.pacienteModel.cuil = this.backUpDatos['cuil'];
             this.pacienteModel.estado = this.backUpDatos['estado'];
             this.pacienteModel.genero = this.backUpDatos['genero'];
+            this.pacienteModel.fechaFallecimiento = this.backUpDatos['fechaFallecimiento'];
             this.validado = false;
         }
         this.disableValidar = false;


### PR DESCRIPTION

### Requerimiento
Incidente 
Cuando se validaba una persona fallecida, se deshacia la validación y posteriormente se cargaba el documento de otro paciente, la fecha de fallecimiento quedaba seteada con el dato de la primera validación, causando que a la última persona validada se le asigne una fecha de fallecimiento.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Inicializa y limpia variables en backup de validación
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No



<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
