### PR TITLE
Dashboard: fix permisos actualizados

### DIFF
--- a/src/app/modules/estadisticas/components/citas/filtros.component.ts
+++ b/src/app/modules/estadisticas/components/citas/filtros.component.ts
@@ -70,8 +70,8 @@ export class FiltrosComponent implements AfterViewInit, OnChanges {
     public estadosAgendas = [];
 
     // Permisos
-    public verProfesionales = this.auth.check('dashboard:citas:verProfesionales');
-    private idPermisoPrestaciones = this.auth.getPermissions('dashboard:citas:tipoPrestacion:?');
+    public verProfesionales = this.auth.check('visualizacionInformacion:dashboard:citas:verProfesionales');
+    private idPermisoPrestaciones = this.auth.getPermissions('visualizacionInformacion:dashboard:citas:tipoPrestacion:?');
     @Output() filter = new EventEmitter();
     @Output() onDisplayChange = new EventEmitter();
 


### PR DESCRIPTION

### Requerimiento
No se estaban mostrando correctamente los dashboards de Agendas y turnos.

El error se daba porque estaban desactualizados los permisos para profesionales y prestación entonces solo filtraba por aquellos turnos o agendas del profesional logueado.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se actualizan los permisos.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

