### PR TITLE
feat(rup): agrega cache redis para frecuentes

### DIFF
--- a/src/app/modules/rup/components/ejecucion/buscador.component.ts
+++ b/src/app/modules/rup/components/ejecucion/buscador.component.ts
@@ -95,10 +95,10 @@ export class BuscadorComponent implements OnInit, OnChanges {
             this.inicializarFrecuentesTP()
         ).subscribe(([fp, frecuentesTP]) => {
             if (fp && fp.length) {
-                const frecuentesProfesional = fp.map((res: any) => {
-                    let concepto = res.concepto;
-                    (concepto as any).frecuencia = res.frecuencia;
-                    (concepto as any).esSolicitud = res.esSolicitud;
+                const frecuentesProfesional = fp.map(res => {
+                    const concepto: any = res.concepto;
+                    concepto.frecuencia = res.frecuencia;
+                    concepto.esSolicitud = res.esSolicitud;
                     return concepto;
                 });
 
@@ -110,8 +110,8 @@ export class BuscadorComponent implements OnInit, OnChanges {
             }
 
 
-            this.results['frecuentesTP']['todos'] = frecuentesTP.map(res => {
-                let concepto = res.concepto;
+            this.results['frecuentesTP']['todos'] = frecuentesTP.map((res) => {
+                const concepto: any = res.concepto;
                 concepto.frecuencia = res.frecuencia;
                 concepto.esSolicitud = res.esSolicitud;
                 return concepto;
@@ -149,7 +149,7 @@ export class BuscadorComponent implements OnInit, OnChanges {
         let queryFTP = {
             'tipoPrestacion': this.prestacion.solicitud.tipoPrestacion.conceptId
         };
-        return this.frecuentesProfesionalService.getXPrestacion(queryFTP);
+        return this.frecuentesProfesionalService.get(queryFTP);
     }
 
     /**

--- a/src/app/modules/rup/interfaces/frecuentesProfesional.interface.ts
+++ b/src/app/modules/rup/interfaces/frecuentesProfesional.interface.ts
@@ -3,15 +3,7 @@ import { ISnomedConcept } from './snomed-concept.interface';
 import { IProfesional } from './../../../interfaces/IProfesional';
 
 export interface IFrecuentesProfesional {
-    profesional: {
-        id: any,
-        nombre: any,
-        apellido: any,
-        documento: any
-    };
-    frecuentes: [{
-        concepto: ISnomedConcept,
-        esSolicitud?: boolean;
-        frecuencia: Number
-    }];
+    concepto: ISnomedConcept;
+    esSolicitud?: boolean;
+    frecuencia: Number;
 }

--- a/src/app/modules/rup/services/frecuentesProfesional.service.ts
+++ b/src/app/modules/rup/services/frecuentesProfesional.service.ts
@@ -15,13 +15,6 @@ export class FrecuentesProfesionalService {
 
     constructor(private server: Server) { }
 
-    /**
-     * Metodo getById. Trae el objeto elementoRup por su Id.
-     * @param {String} idProfesional Busca por Id
-     */
-    getById(idProfesional: String): Observable<IFrecuentesProfesional> {
-        return this.server.get(url + '/' + idProfesional);
-    }
 
     /**
      * Metodo get. Trae lista de elementosRup más frecuentes.
@@ -41,36 +34,4 @@ export class FrecuentesProfesionalService {
         return this.server.get(url, opt);
     }
 
-
-    /**
-     * Metodo getXPrestacion. Lista los frecuentes por tipo de prestación.
-     *
-     * @param {*} params Opciones de busqueda
-     * @param {*} [options={}] Options a pasar a la API
-     * @returns {Observable<any[]>}
-     *
-     * @memberof PrestacionesService
-     */
-    getXPrestacion(params: any, options: any = {}): Observable<any[]> {
-        if (typeof options.showError === 'undefined') {
-            options.showError = true;
-        }
-
-        let opt = { params: params, options };
-
-        return this.server.get(url, opt);
-    }
-
-
-    /**
-     * Metodo post. Inserta un objeto elementoRup nuevo.
-     * @param {IFrecuentesProfesional} elementoRup Recibe IFrecuentesProfesional
-     */
-    post(elementoRup: IFrecuentesProfesional): Observable<IFrecuentesProfesional> {
-        return this.server.post(url, elementoRup);
-    }
-
-    updateFrecuentes(id: String, registros: any): Observable<any> {
-        return this.server.put(url + '/' + id, registros);
-    }
 }


### PR DESCRIPTION
### Requerimiento
En algunos casos el calculo de frecuentes se hace muy demandante, todo el tiempo y ya son larga listas de conceptos.
Como primer medida vamos a aplicar Cache mediante de REDIS cuando la lista es más 20 conceptos, así mantenemos la actualización real time cuando arranca una prestación o profesional a registrar.

La idea es empezar a experimentar con algo no tan crítico como los frecuentes, antes de llegar a otras secciones.

https://github.com/andes/api/pull/1176

### Funcionalidad desarrollada  
1. Se acomodan interfaces y servicio. 


### UserStory llegó a completarse 
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos 
- [ ] Si
- [x] No

### Requiere actualizaciones en la API 
- [x] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion 
- [ ] Si
- [x] No

 