### PR TITLE
fix(TOP): realiza cambio en condiciones para anular solicitudes

### DIFF
--- a/src/app/components/top/pipes/botones.pipe.ts
+++ b/src/app/components/top/pipes/botones.pipe.ts
@@ -22,6 +22,7 @@ export class BotonesSolicitudPipe implements PipeTransform {
         if (this.esEfectorDestino(prestacion)) {
             if (prestacion.estadoActual.tipo === 'pendiente' && prestacion ?.paciente && !prestacion.solicitud.turno) {
                 botones.darTurno = true;
+                botones.anular = true;
             }
             if (prestacion.estadoActual.tipo === 'auditoria' || prestacion.estadoActual.tipo === 'rechazada') {
                 botones.auditar = true;
@@ -29,9 +30,8 @@ export class BotonesSolicitudPipe implements PipeTransform {
         }
         // Si es el mismo usuario que creó la solicitud
         if (this.esUsuarioCreador(prestacion)) {
-            // Si está en estado pendiente o auditoria Y no tuvo movimientos después de crearse, se podrá anular
-            if ((prestacion.estadoActual.tipo === 'auditoria' || prestacion.estadoActual.tipo === 'pendiente')
-                && prestacion.solicitud.historial.length === 1) {
+            // Si está en estado auditoria Y no tuvo movimientos después de crearse, se podrá anular
+            if (prestacion.estadoActual.tipo === 'auditoria' && prestacion.solicitud.historial.length === 1) {
                 botones.anular = true;
             }
         }


### PR DESCRIPTION
### Requerimiento
Quitar control que se realizaba para mostrar botón anular en solicitudes pendientes. Se estaba chequeando que no existieran movimientos en esa solicitud pero nos reportan que hay casos en los que aún habiendo movimientos las solicitudes penidentes deben ser canceladas. 

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se actualizó el pipe que realiza los chequeos para mostrar los botones

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

