### PR TITLE
COM: permitir sumar nota a origen/destino

### DIFF
--- a/src/app/modules/com/components/punto-inicio.html
+++ b/src/app/modules/com/components/punto-inicio.html
@@ -72,7 +72,7 @@
                                                     subtitulo="{{ (derivacion.paciente.documento | number) || 'Sin DNI'}}">
                                         </plex-label>
                                     </div>
-                                    <plex-button *ngIf="derivacion.historial[derivacion.historial.length - 1].createdBy?.organizacion._id === orgActual._id"
+                                    <plex-button *ngIf="esCOM || (derivacion.estado === 'aceptada' || derivacion.estado === 'encomendada') || (derivacion.historial[derivacion.historial.length - 1].createdBy?.organizacion._id === orgActual._id)"
                                                  type="info" size="sm"
                                                  (click)="actualizarEstado(derivacion);$event.stopPropagation()">
                                         SUMAR NOTA/ADJUNTO
@@ -153,8 +153,7 @@
                                                  (click)="cancelar(derivacion);$event.stopPropagation()">
                                         CANCELAR
                                     </plex-button>
-                                    <plex-button *ngIf="derivacion.historial[derivacion.historial.length - 1].createdBy?.organizacion._id === orgActual._id"
-                                                 type="info" size="sm"
+                                    <plex-button type="info" size="sm"
                                                  (click)="actualizarEstado(derivacion);$event.stopPropagation()">
                                         SUMAR NOTA/ADJUNTO
                                     </plex-button>


### PR DESCRIPTION
### Requerimiento 
https://proyectos.andes.gob.ar/browse/COM-35

### Funcionalidad desarrollada 
1. Permite asignar notas tanto desde el COM como del efector origen y desde el efector destino solo a partir desde que esta aceptada.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

