### PR TITLE
COM: hacer un único llamado a reglas de derivación

### DIFF
--- a/src/app/modules/com/components/detalle-derivacion.component.ts
+++ b/src/app/modules/com/components/detalle-derivacion.component.ts
@@ -47,10 +47,17 @@ export class DetalleDerivacionComponent implements OnInit {
         this.adjuntosEstado = [];
         this.cargarEstado();
     }
+
+    @Input('reglasDerivacion')
+    set _reglasDerivacion(value) {
+        this.reglasDerivacion = value;
+    }
+
     @Output() returnDetalle: EventEmitter<any> = new EventEmitter<any>();
     public tabIndex = 0;
     organizacionesDestino = [];
     reglasDerivacion = [];
+    reglasDerivacionFiltradas = [];
     public nuevoEstado: any = {
         organizacionDestino: '',
         estado: null,
@@ -63,7 +70,6 @@ export class DetalleDerivacionComponent implements OnInit {
         public sanitazer: DomSanitizer,
         private organizacionService: OrganizacionService,
         private derivacionService: DerivacionesService,
-        private reglasDerivacionService: ReglasDerivacionService,
         private auth: Auth,
         public plex: Plex
     ) { }
@@ -113,7 +119,7 @@ export class DetalleDerivacionComponent implements OnInit {
             if (org.esCOM) {
                 this.esCOM = true;
             }
-            this.getReglasDerivaciones();
+            this.filterReglasDerivaciones();
         });
     }
 
@@ -130,19 +136,9 @@ export class DetalleDerivacionComponent implements OnInit {
         });
     }
 
-    getReglasDerivaciones() {
-        // los efectores no pueden cambiar el estado de las derivaciones solicitadas
-        if (!(this.derivacion.organizacionOrigen.id === this.auth.organizacion.id) || this.esCOM) {
-            let query: any = {
-                estadoInicial: this.derivacion.estado,
-                soloCOM: this.esCOM
-            };
-            this.reglasDerivacionService.search(query).subscribe(resultado => {
-                this.reglasDerivacion = resultado;
-            });
-        } else {
-            this.reglasDerivacion = [];
-        }
+    filterReglasDerivaciones() {
+        this.reglasDerivacionFiltradas = this.reglasDerivacion.filter(element => element.estadoInicial === this.derivacion.estado &&
+            element.soloCOM === this.esCOM);
     }
 
     actualizarEstado($event) {

--- a/src/app/modules/com/components/detalle-derivacion.html
+++ b/src/app/modules/com/components/detalle-derivacion.html
@@ -54,14 +54,14 @@
             </ng-container>
         </div>
     </plex-grid>
-    <div *ngIf="reglasDerivacion.length > 0">
+    <div *ngIf="reglasDerivacionFiltradas.length > 0">
         <form #formEstado="ngForm">
             <plex-title size="sm" titulo="Actualizar estado">
             </plex-title>
             <plex-wrapper>
                 <plex-select [(ngModel)]="reglaSeleccionada" label="Nuevo estado" name="estado"
                              placeholder="Seleccione un nuevo estado" idField="_id" labelField="estadoFinal"
-                             [data]="reglasDerivacion" [required]="true" grow="full">
+                             [data]="reglasDerivacionFiltradas" [required]="true" grow="full">
                 </plex-select>
                 <plex-select *ngIf="reglaSeleccionada?.modificaDestino" [(ngModel)]="nuevoEstado.organizacionDestino"
                              name="organizacionOrigen" [data]="organizacionesDestino" label="Organización destino"

--- a/src/app/modules/com/components/punto-inicio.component.ts
+++ b/src/app/modules/com/components/punto-inicio.component.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { Plex } from '@andes/plex';
 import { DocumentosService } from 'src/app/services/documentos.service';
 import { Unsubscribe } from '@andes/shared';
+import { ReglasDerivacionService } from 'src/app/services/com/reglasDerivaciones.service';
 
 @Component({
     selector: 'com-punto-inicio',
@@ -26,6 +27,7 @@ export class ComPuntoInicioComponent implements OnInit {
     private scrollEnd = false;
     private skip = 0;
     private limit = 15;
+    public reglasDerivacion = [];
     derivacionSeleccionada: IDerivacion;
     public derivaciones: any[] = [];
     organizacionActual: any[];
@@ -53,12 +55,15 @@ export class ComPuntoInicioComponent implements OnInit {
     ];
 
     constructor(private derivacionesService: DerivacionesService, private organizacionService: OrganizacionService, private auth: Auth,
-        public router: Router, public plex: Plex, private documentosService: DocumentosService) { }
+        public router: Router, public plex: Plex, private reglasDerivacionService: ReglasDerivacionService, private documentosService: DocumentosService) { }
 
     ngOnInit() {
         if (!(this.auth.getPermissions('com:?').length > 0)) {
             this.router.navigate(['./inicio']);
         }
+        this.reglasDerivacionService.search({}).subscribe(resultado => {
+            this.reglasDerivacion = resultado;
+        });
         this.organizacionActual = this.auth.organizacion as any;
         this.organizacionService.getById(this.auth.organizacion.id).subscribe(org => {
             this.orgActual = org;

--- a/src/app/modules/com/components/punto-inicio.html
+++ b/src/app/modules/com/components/punto-inicio.html
@@ -182,7 +182,8 @@
             <com-busqueda-paciente (returnBusqueda)="returnBusqueda($event)"></com-busqueda-paciente>
         </ng-container>
         <div *ngIf="showDetalle">
-            <detalle-derivacion [derivacion]="derivacionSeleccionada" (returnDetalle)="returnDetalle($event)">
+            <detalle-derivacion [derivacion]="derivacionSeleccionada" [reglasDerivacion]="reglasDerivacion"
+                                (returnDetalle)="returnDetalle($event)">
             </detalle-derivacion>
         </div>
         <div *ngIf="showEditarEstado">


### PR DESCRIPTION
### Requerimiento 
https://proyectos.andes.gob.ar/browse/COM-34

### Funcionalidad desarrollada 
1. Evitar llamado a reglas de derivación al abrir el detalle de una derivación

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No
