### PR TITLE
TURNOS-PRESTACIONES: Descarga de prestaciones desde el buscador de turnos y prestaciones

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -31,7 +31,7 @@ export class TurnosPrestacionesComponent implements OnInit {
     private hoy;
     public fechaDesde: any;
     public fechaHasta: any;
-    private sumar;
+    public sumar;
     public showPrestacion;
     public loading;
     public arrayEstados;
@@ -41,7 +41,9 @@ export class TurnosPrestacionesComponent implements OnInit {
     prestacion: any;
     public prestaciones: any;
     public puedeEmitirComprobante: Boolean;
-
+    public profesionales;
+    public estado;
+    public sinOS = false;
     public selectProfesional: Boolean = false;
     public profesional: any;
     public botonBuscarDisabled: Boolean = false;

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -318,19 +318,23 @@ export class TurnosPrestacionesComponent implements OnInit, OnDestroy {
         const arraySelect = this.selectPrestaciones$.getValue();
         const exp = Object.keys(arraySelect).filter((key) => arraySelect[key] === true);
         let prestacionesTurnos = [];
-        let arrayPrestaciones = [];
+        let prestaciones = [];
         exp.forEach(element => {
             prestacionesTurnos = element.split('-');
             if (prestacionesTurnos[1] !== 'undefined') { // Me quedo solo con las prestaciones, obviando los turnos
-                arrayPrestaciones.push(prestacionesTurnos[1]);
+                prestaciones.push(prestacionesTurnos[1]);
             }
         });
-        this.exportHudsService.peticionHuds({ arrayPrestaciones }).subscribe(res => {
-            if (res) {
-                this.plex.toast('success', 'Su pedido esta siendo procesado, diríjase a descargas pendientes para obtener su reporte', 'Información', 2000);
-                this.getPendientes();
-            }
-        });
+        if (prestaciones.length) {
+            this.exportHudsService.peticionHuds({ prestaciones }).subscribe(res => {
+                if (res) {
+                    this.plex.toast('success', 'Su pedido esta siendo procesado, diríjase a descargas pendientes para obtener su reporte', 'Información', 2000);
+                    this.getPendientes();
+                }
+            });
+        } else {
+            this.plex.info('warning', 'No tiene prestaciones seleccionadas, recuerde que los turnos no pueden ser exportados');
+        }
     }
 
     selectPrestacion(item, $event) {

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -4,8 +4,6 @@
         <plex-title titulo="Turnos y prestaciones">
             <plex-button label="Descargas pendientes" size="sm" type="info" (click)="mostrarPendientes()">
             </plex-button>
-            <plex-button *ngIf="descargasPendientes" icon="close" type="danger" size="sm" (click)="mostrarPendientes()">
-            </plex-button>
         </plex-title>
         <!--Botones / Acciones-->
         <!--Filtros-->
@@ -320,6 +318,9 @@
 
     </plex-layout-sidebar>
     <plex-layout-sidebar *ngIf="descargasPendientes" [type]="'invert'">
-        <descargas-pendientes></descargas-pendientes>
+        <descargas-pendientes>
+            <plex-button justify="end" icon="close" type="danger" tooltip="Cerrar" (click)="mostrarPendientes()">
+            </plex-button>
+        </descargas-pendientes>
     </plex-layout-sidebar>
 </plex-layout>

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -1,85 +1,64 @@
-<plex-layout main="{{ showPrestacion  ? '6' : '12'}}">
+<plex-layout main="{{ showPrestacion || descargasPendientes ? '6' : '12'}}">
     <plex-layout-main>
-        <header>
-            <!--Botones / Acciones-->
 
-            <!--Filtros-->
-            <div class="row">
-                <div class='col-2'>
-                    <plex-datetime type="date" [(ngModel)]="fechaDesde" (change)="refreshSelection($event,'fechaDesde')"
-                                   name="fechaDesde" label="Desde" class="fechas" [max]="fechaHasta">
-                    </plex-datetime>
-                    <!-- <plex-button type="info" icon="chevron-right"></plex-button> -->
-                </div>
-                <div class='col-2'>
-                    <plex-datetime type="date" [(ngModel)]="fechaHasta" (change)="refreshSelection($event,'fechaHasta')"
-                                   name="fechaHasta" label="Hasta" class="fechas" [min]="fechaDesde">
-                    </plex-datetime>
-                </div>
-                <div class='col-2'>
-                    <plex-select [(ngModel)]="prestaciones" (change)="refreshSelection($event,'prestaciones')"
-                                 label="Prestación" tmPrestaciones preload="true">
-                    </plex-select>
-                </div>
-                <div class="col-2">
-                    <plex-text [(ngModel)]="documento" (change)="refreshSelection($event,'documento')"
-                               label="Documento">
-                    </plex-text>
-                </div>
-                <div *ngIf="!showPrestacion" class='col-2'>
-                    <label>
-                        <!--Spacer-->&nbsp;</label>
-                    <plex-button type="success" label="Buscar" (click)="refreshSelection($event, 'filter')"
-                                 [disabled]='botonBuscarDisabled'>
-                    </plex-button>
-                </div>
-                <div *ngIf="!showPrestacion" class='col text-right'>
-                    <label>
-                        <!--Spacer-->&nbsp;</label>
-                    <plex-button type="default" [icon]="mostrarMasOpciones ? 'chevron-up' : 'chevron-down'"
-                                 (click)="mostrarMasOpciones = !mostrarMasOpciones" name="mostrar"></plex-button>
-                </div>
+        <plex-title titulo="Turnos y prestaciones">
+            <plex-button label="Descargas pendientes" size="sm" type="info" (click)="mostrarPendientes()">
+            </plex-button>
+            <plex-button *ngIf="descargasPendientes" icon="close" type="danger" size="sm" (click)="mostrarPendientes()">
+            </plex-button>
+        </plex-title>
+        <!--Botones / Acciones-->
+        <!--Filtros-->
+        <plex-wrapper>
+            <plex-datetime type="date" [(ngModel)]="fechaDesde" (change)="refreshSelection($event,'fechaDesde')"
+                           name="fechaDesde" label="Desde" class="fechas" [max]="fechaHasta">
+            </plex-datetime>
+            <plex-datetime type="date" [(ngModel)]="fechaHasta" (change)="refreshSelection($event,'fechaHasta')"
+                           name="fechaHasta" label="Hasta" class="fechas" [min]="fechaDesde">
+            </plex-datetime>
+            <plex-text [(ngModel)]="documento" (change)="refreshSelection($event,'documento')" label="Documento">
+            </plex-text>
+            <plex-select [(ngModel)]="prestaciones" (change)="refreshSelection($event,'prestaciones')"
+                         label="Prestación" tmPrestaciones preload="true">
+            </plex-select>
+
+            <plex-button type="success" label="Buscar" (click)="refreshSelection($event, 'filter')"
+                         [disabled]='botonBuscarDisabled'>
+            </plex-button>
+            <div collapse>
+                <plex-select [(ngModel)]="profesionales" (change)="refreshSelection($event, 'profesionales')"
+                             (getData)="loadEquipoSalud($event)" label="Equipo de salud"
+                             placeholder="Buscar por equipo de salud" labelField="apellido+' '+nombre"
+                             ngModelOptions="{standalone: true}" [readonly]="selectProfesional">
+                </plex-select>
+                <plex-select [(ngModel)]="estado" (change)="refreshSelection($event,'estado')" [data]="arrayEstados"
+                             label="Estado" placeholder="Buscar por estado" ngModelOptions="{standalone: true}">
+                </plex-select>
+                <plex-select *ngIf="!sumarB && !sinOS" [(ngModel)]="financiadores"
+                             (change)="refreshSelection($event,'financiador')" tmFinanciador label="Financiador"
+                             placeholder="Buscar por financiador">
+                </plex-select>
+                <plex-select *ngIf="sumarB" [(ngModel)]="estadoFacturacion"
+                             (change)="refreshSelection($event,'estadoFacturacion')" name="estadoFacturacion"
+                             [data]="arrayEstadosFacturacion" label="Comprobante"
+                             placeholder="Buscar por estado comprobante" ngModelOptions="{standalone: true}">
+                </plex-select>
+                <plex-bool *ngIf="!sinOS" [(ngModel)]="sumar" type="slide" (change)="refreshSelection($event, 'sumar')"
+                           label="Sumar" name="sumar"></plex-bool>
+                <plex-bool *ngIf="!sumar" [(ngModel)]="sinOS" type="slide" (change)="refreshSelection($event, 'sinOS')"
+                           label="Sin obra social" name="sinOS">
+                </plex-bool>
             </div>
-            <div class="has-danger" *ngIf='botonBuscarDisabled'><span class="form-control-feedback">El rango de fecha no
-                    pueda superar los 31 días</span></div>
-            <div class="row" *ngIf="mostrarMasOpciones && !showPrestacion">
-                <div class="col-3">
-                    <plex-select [(ngModel)]="profesionales" (change)="refreshSelection($event, 'profesionales')"
-                                 (getData)="loadEquipoSalud($event)" label="Equipo de salud"
-                                 placeholder="Buscar por equipo de salud" labelField="apellido+' '+nombre"
-                                 ngModelOptions="{standalone: true}" [readonly]="selectProfesional">
-                    </plex-select>
-                </div>
-                <div class="col-3">
-                    <plex-select [(ngModel)]="estado" (change)="refreshSelection($event,'estado')" [data]="arrayEstados"
-                                 label="Estado" placeholder="Buscar por estado" ngModelOptions="{standalone: true}">
-                    </plex-select>
-                </div>
-                <div *ngIf="!sumarB && !sinOS" class="col-3">
-                    <plex-select [(ngModel)]="financiadores" (change)="refreshSelection($event,'financiador')"
-                                 tmFinanciador label="Financiador" placeholder="Buscar por financiador">
-                    </plex-select>
+        </plex-wrapper>
+        <span class="text-danger" *ngIf='botonBuscarDisabled'>El rango de fecha no
+            pueda superar los 31 días</span>
 
-                </div>
-                <div *ngIf="sumarB" class="col-3">
-                    <plex-select [(ngModel)]="estadoFacturacion" (change)="refreshSelection($event,'estadoFacturacion')"
-                                 name="estadoFacturacion" [data]="arrayEstadosFacturacion" label="Comprobante"
-                                 placeholder="Buscar por estado comprobante" ngModelOptions="{standalone: true}">
-                    </plex-select>
-
-                </div>
-                <div class="col-2 d-flex align-items-center">
-                    <plex-bool *ngIf="!sinOS" [(ngModel)]="sumar" type="slide"
-                               (change)="refreshSelection($event, 'sumar')" label="Sumar" name="sumar"></plex-bool>
-                    <plex-bool *ngIf="!sumar" [(ngModel)]="sinOS" type="slide"
-                               (change)="refreshSelection($event, 'sinOS')" label="Sin obra social" name="sinOS">
-                    </plex-bool>
-                </div>
-            </div>
-        </header>
         <!-- Resultados -->
         <plex-loader *ngIf="loading"></plex-loader>
-        <plex-title titulo="Turnos y prestaciones" size="sm">
+        <plex-title titulo="Listado" size="sm">
+            <plex-button label="Exportar" size="sm" type="success" class="mr-2" (click)="exportPrestaciones()"
+                         [disabled]="!enableExport">
+            </plex-button>
             <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block" [right]="true">
                 <plex-grid cols="3">
                     <plex-bool label="Fecha" [(ngModel)]="columnas.fecha">
@@ -101,94 +80,104 @@
                 </plex-grid>
             </plex-dropdown>
         </plex-title>
-        <table *ngIf="!loading" class="table table-striped table-sm">
-            <thead>
-                <th *ngIf="columnas.fecha" class="sortable" (click)="sortTable('fecha')">
-                    Fecha
-                    <span *ngIf="sortBy === 'fecha'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-                <th *ngIf="columnas.documento" class="sortable" (click)="sortTable('documento')">
-                    Documento
-                    <span *ngIf="sortBy === 'documento'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-                <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">
-                    Paciente
-                    <span *ngIf="sortBy === 'paciente'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-                <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">
-                    Tipo de Prestación
-                    <span *ngIf="sortBy === 'prestacion'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-                <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">
-                    Ambito
-                    <span *ngIf="sortBy === 'ambito'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-
-                <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">
-                    Equipo de Salud
-                    <span *ngIf="sortBy === 'profesional'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-                <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">
-                    Estado
-                    <span *ngIf="sortBy === 'estado'">
-                        <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                        <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                    </span>
-                </th>
-                <th width="20%" *ngIf="!sumarB && columnas.financiador">
-                    Financiador
-                </th>
-                <th *ngIf="sumarB">
-                    Comprobante
-                </th>
-            </thead>
-
-            <tbody>
-                <tr *ngFor="let busqueda of busqueda$ | async" class="hover" (click)="mostrarPrestacion(busqueda)"
-                    [ngClass]="{'bg-inverse text-white': busqueda.seleccionada}">
-                    <td *ngIf="columnas.fecha">{{busqueda.fecha | date: "dd/MM/yyyy HH:mm " }}</td>
-                    <td *ngIf="columnas.documento">{{busqueda.paciente.documento}}</td>
-                    <td *ngIf="columnas.paciente">{{busqueda.paciente | nombre}}</td>
-                    <td *ngIf="columnas.tipoPrestacion">{{busqueda.prestacion?.term}}</td>
-                    <td *ngIf="columnas.ambito">{{busqueda.ambito}}</td>
-                    <td *ngIf="columnas.equipoSalud" class="nombres-profesionales">
-                        <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">
-                            Profesional no asignado
+        <ng-container *ngIf="busqueda$ | async as busquedas">
+            <table *ngIf="!loading" class="table table-striped table-sm">
+                <thead>
+                    <th>
+                        <plex-bool *ngIf="busquedas.length" name="all" (change)="selectAll()"
+                                   [(ngModel)]="prestacionesAll">
+                        </plex-bool>
+                    </th>
+                    <th *ngIf="columnas.fecha" class="sortable" (click)="sortTable('fecha')">
+                        Fecha
+                        <span *ngIf="sortBy === 'fecha'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
                         </span>
-                        <ng-container *ngIf="busqueda.profesionales">
-                            <div *ngIf="busqueda.profesionales.length > 0">
-                                {{ busqueda.profesionales | enumerar:['apellido','nombre'] }}
-                            </div>
-                        </ng-container>
-                    </td>
-                    <td *ngIf="columnas.estado">{{busqueda.estado}}</td>
-                    <td *ngIf="!sumarB && columnas.financiador">
-                        {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}
-                    </td>
-                    <td *ngIf="sumarB">
-                        {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+                    </th>
+                    <th *ngIf="columnas.documento" class="sortable" (click)="sortTable('documento')">
+                        Documento
+                        <span *ngIf="sortBy === 'documento'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                        </span>
+                    </th>
+                    <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">
+                        Paciente
+                        <span *ngIf="sortBy === 'paciente'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                        </span>
+                    </th>
+                    <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">
+                        Tipo de Prestación
+                        <span *ngIf="sortBy === 'prestacion'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                        </span>
+                    </th>
+                    <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">
+                        Ambito
+                        <span *ngIf="sortBy === 'ambito'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                        </span>
+                    </th>
+
+                    <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">
+                        Equipo de Salud
+                        <span *ngIf="sortBy === 'profesional'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                        </span>
+                    </th>
+                    <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">
+                        Estado
+                        <span *ngIf="sortBy === 'estado'">
+                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                        </span>
+                    </th>
+                    <th width="20%" *ngIf="!sumarB && columnas.financiador">
+                        Financiador
+                    </th>
+                    <th *ngIf="sumarB">
+                        Comprobante
+                    </th>
+                </thead>
+                <tbody>
+                    <tr *ngFor="let busqueda of busquedas" class="hover" (click)="mostrarPrestacion(busqueda)"
+                        [ngClass]="{'bg-inverse text-white': busqueda.seleccionada}">
+                        <td>
+                            <plex-bool [(ngModel)]="busqueda.check" (change)="selectPrestacion(busqueda.check)">
+                            </plex-bool>
+                        </td>
+                        <td *ngIf="columnas.fecha">{{busqueda.fecha | date: "dd/MM/yyyy HH:mm " }}</td>
+                        <td *ngIf="columnas.documento">{{busqueda.paciente.documento}}</td>
+                        <td *ngIf="columnas.paciente">{{busqueda.paciente | nombre}}</td>
+                        <td *ngIf="columnas.tipoPrestacion">{{busqueda.prestacion?.term}}</td>
+                        <td *ngIf="columnas.ambito">{{busqueda.ambito}}</td>
+                        <td *ngIf="columnas.equipoSalud" class="nombres-profesionales">
+                            <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">
+                                Profesional no asignado
+                            </span>
+                            <ng-container *ngIf="busqueda.profesionales">
+                                <div *ngIf="busqueda.profesionales.length > 0">
+                                    {{ busqueda.profesionales | enumerar:['apellido','nombre'] }}
+                                </div>
+                            </ng-container>
+                        </td>
+                        <td *ngIf="columnas.estado">{{busqueda.estado}}</td>
+                        <td *ngIf="!sumarB && columnas.financiador">
+                            {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}
+                        </td>
+                        <td *ngIf="sumarB">
+                            {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </ng-container>
     </plex-layout-main>
     <!-- Prestacion -->
     <plex-layout-sidebar *ngIf="showPrestacion">
@@ -255,13 +244,8 @@
                 </div>
             </div>
         </div>
-
-
         <div class="row">
-
-
             <div class="col-md">
-
                 <div *ngIf="prestacion.paciente.estado">
                     <label class="block">Estado</label>
                     <plex-badge *ngIf="prestacion.paciente.estado === 'validado'" type="success">
@@ -280,7 +264,6 @@
         <div *ngIf="!prestacion.idPrestacion" class="col">
             <span class="text-danger">La prestación no ha sido iniciada</span>
         </div>
-
 
         <div *ngIf="prestacion.idPrestacion">
             <div class="row">
@@ -332,5 +315,8 @@
             <vista-prestacion [idPrestacion]="prestacion.idPrestacion"></vista-prestacion>
         </div>
 
+    </plex-layout-sidebar>
+    <plex-layout-sidebar *ngIf="descargasPendientes" [type]="'invert'">
+        <descargas-pendientes></descargas-pendientes>
     </plex-layout-sidebar>
 </plex-layout>

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -27,9 +27,8 @@
             </plex-button>
             <div collapse>
                 <plex-select [(ngModel)]="profesionales" (change)="refreshSelection($event, 'profesionales')"
-                             (getData)="loadEquipoSalud($event)" label="Equipo de salud"
-                             placeholder="Buscar por equipo de salud" labelField="apellido+' '+nombre"
-                             ngModelOptions="{standalone: true}" [readonly]="selectProfesional">
+                             label="Equipo de salud" placeholder="Buscar por equipo de salud" tmProfesionales
+                             [readonly]="selectProfesional">
                 </plex-select>
                 <plex-select [(ngModel)]="estado" (change)="refreshSelection($event,'estado')" [data]="arrayEstados"
                              label="Estado" placeholder="Buscar por estado" ngModelOptions="{standalone: true}">
@@ -50,133 +49,137 @@
                 </plex-bool>
             </div>
         </plex-wrapper>
-        <span class="text-danger" *ngIf='botonBuscarDisabled'>El rango de fecha no
-            pueda superar los 31 días</span>
+        <span class="text-danger" *ngIf='botonBuscarDisabled'>
+            El rango de fecha no pueda superar los 31 días</span>
 
         <!-- Resultados -->
-        <plex-loader *ngIf="loading"></plex-loader>
-        <plex-title titulo="Listado" size="sm">
-            <plex-button label="Exportar" size="sm" type="success" class="mr-2" (click)="exportPrestaciones()"
-                         [disabled]="!enableExport">
-            </plex-button>
-            <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block" [right]="true">
-                <plex-grid cols="3">
-                    <plex-bool label="Fecha" [(ngModel)]="columnas.fecha">
-                    </plex-bool>
-                    <plex-bool label="Documento" [(ngModel)]="columnas.documento">
-                    </plex-bool>
-                    <plex-bool label="Paciente" [(ngModel)]="columnas.paciente">
-                    </plex-bool>
-                    <plex-bool label="Prestación" [(ngModel)]="columnas.tipoPrestacion">
-                    </plex-bool>
-                    <plex-bool label="Equipo de Salud" [(ngModel)]="columnas.equipoSalud">
-                    </plex-bool>
-                    <plex-bool label="Estado" [(ngModel)]="columnas.estado">
-                    </plex-bool>
-                    <plex-bool label="Financiador" [(ngModel)]="columnas.financiador">
-                    </plex-bool>
-                    <plex-bool label="Ámbito" [(ngModel)]="columnas.ambito">
-                    </plex-bool>
-                </plex-grid>
-            </plex-dropdown>
-        </plex-title>
         <ng-container *ngIf="busqueda$ | async as busquedas">
-            <table *ngIf="!loading" class="table table-striped table-sm">
-                <thead>
-                    <th>
-                        <plex-bool *ngIf="busquedas.length" name="all" (change)="selectAll()"
-                                   [(ngModel)]="prestacionesAll">
-                        </plex-bool>
-                    </th>
-                    <th *ngIf="columnas.fecha" class="sortable" (click)="sortTable('fecha')">
-                        Fecha
-                        <span *ngIf="sortBy === 'fecha'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-                    <th *ngIf="columnas.documento" class="sortable" (click)="sortTable('documento')">
-                        Documento
-                        <span *ngIf="sortBy === 'documento'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-                    <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">
-                        Paciente
-                        <span *ngIf="sortBy === 'paciente'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-                    <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">
-                        Tipo de Prestación
-                        <span *ngIf="sortBy === 'prestacion'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-                    <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">
-                        Ambito
-                        <span *ngIf="sortBy === 'ambito'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-
-                    <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">
-                        Equipo de Salud
-                        <span *ngIf="sortBy === 'profesional'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-                    <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">
-                        Estado
-                        <span *ngIf="sortBy === 'estado'">
-                            <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
-                            <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
-                        </span>
-                    </th>
-                    <th width="20%" *ngIf="!sumarB && columnas.financiador">
-                        Financiador
-                    </th>
-                    <th *ngIf="sumarB">
-                        Comprobante
-                    </th>
-                </thead>
-                <tbody>
-                    <tr *ngFor="let busqueda of busquedas" class="hover" (click)="mostrarPrestacion(busqueda)"
-                        [ngClass]="{'bg-inverse text-white': busqueda.seleccionada}">
-                        <td>
-                            <plex-bool [(ngModel)]="busqueda.check" (change)="selectPrestacion(busqueda.check)">
+            <ng-container *ngIf="state$ | async as state">
+                <plex-title titulo="Listado" size="sm">
+                    <plex-button label="Exportar" size="sm" type="success" class="mr-2" (click)="exportPrestaciones()"
+                                 [disabled]="!state.enableExport">
+                    </plex-button>
+                    <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block"
+                                   [right]="true">
+                        <plex-grid cols="3">
+                            <plex-bool label="Fecha" [(ngModel)]="columnas.fecha">
                             </plex-bool>
-                        </td>
-                        <td *ngIf="columnas.fecha">{{busqueda.fecha | date: "dd/MM/yyyy HH:mm " }}</td>
-                        <td *ngIf="columnas.documento">{{busqueda.paciente.documento}}</td>
-                        <td *ngIf="columnas.paciente">{{busqueda.paciente | nombre}}</td>
-                        <td *ngIf="columnas.tipoPrestacion">{{busqueda.prestacion?.term}}</td>
-                        <td *ngIf="columnas.ambito">{{busqueda.ambito}}</td>
-                        <td *ngIf="columnas.equipoSalud" class="nombres-profesionales">
-                            <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">
-                                Profesional no asignado
-                            </span>
-                            <ng-container *ngIf="busqueda.profesionales">
-                                <div *ngIf="busqueda.profesionales.length > 0">
-                                    {{ busqueda.profesionales | enumerar:['apellido','nombre'] }}
-                                </div>
-                            </ng-container>
-                        </td>
-                        <td *ngIf="columnas.estado">{{busqueda.estado}}</td>
-                        <td *ngIf="!sumarB && columnas.financiador">
-                            {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}
-                        </td>
-                        <td *ngIf="sumarB">
-                            {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                            <plex-bool label="Documento" [(ngModel)]="columnas.documento">
+                            </plex-bool>
+                            <plex-bool label="Paciente" [(ngModel)]="columnas.paciente">
+                            </plex-bool>
+                            <plex-bool label="Prestación" [(ngModel)]="columnas.tipoPrestacion">
+                            </plex-bool>
+                            <plex-bool label="Equipo de Salud" [(ngModel)]="columnas.equipoSalud">
+                            </plex-bool>
+                            <plex-bool label="Estado" [(ngModel)]="columnas.estado">
+                            </plex-bool>
+                            <plex-bool label="Financiador" [(ngModel)]="columnas.financiador">
+                            </plex-bool>
+                            <plex-bool label="Ámbito" [(ngModel)]="columnas.ambito">
+                            </plex-bool>
+                        </plex-grid>
+                    </plex-dropdown>
+                </plex-title>
+                <ng-container *ngIf="selectPrestaciones$ | async as selectPrestaciones">
+                    <table class="table table-striped table-sm">
+                        <thead>
+                            <th>
+                                <plex-bool name="all" (change)="selectAll($event)" [ngModel]="state.selectAll">
+                                </plex-bool>
+                            </th>
+                            <th *ngIf="columnas.fecha" class="sortable" (click)="sortTable('fecha')">
+                                Fecha
+                                <span *ngIf="sortBy === 'fecha'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+                            <th *ngIf="columnas.documento" class="sortable" (click)="sortTable('documento')">
+                                Documento
+                                <span *ngIf="sortBy === 'documento'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+                            <th *ngIf="columnas.paciente" class="sortable" (click)="sortTable('paciente')">
+                                Paciente
+                                <span *ngIf="sortBy === 'paciente'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+                            <th *ngIf="columnas.tipoPrestacion" class="sortable" (click)="sortTable('prestacion')">
+                                Tipo de Prestación
+                                <span *ngIf="sortBy === 'prestacion'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+                            <th *ngIf="columnas.ambito" class="sortable" (click)="sortTable('ambito')">
+                                Ambito
+                                <span *ngIf="sortBy === 'ambito'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+
+                            <th *ngIf="columnas.equipoSalud" class="sortable" (click)="sortTable('profesional')">
+                                Equipo de Salud
+                                <span *ngIf="sortBy === 'profesional'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+                            <th *ngIf="columnas.estado" class="sortable" (click)="sortTable('estado')">
+                                Estado
+                                <span *ngIf="sortBy === 'estado'">
+                                    <plex-icon *ngIf="sortOrder === 'desc'" name="chevron-down"></plex-icon>
+                                    <plex-icon *ngIf="sortOrder === 'asc'" name="chevron-up"></plex-icon>
+                                </span>
+                            </th>
+                            <th width="20%" *ngIf="!sumarB && columnas.financiador">
+                                Financiador
+                            </th>
+                            <th *ngIf="sumarB">
+                                Comprobante
+                            </th>
+                        </thead>
+                        <tbody>
+                            <tr *ngFor="let busqueda of busquedas" class="hover" (click)="mostrarPrestacion(busqueda)"
+                                [ngClass]="{'bg-inverse text-white': busqueda.seleccionada}">
+                                <td>
+                                    <plex-bool [ngModel]="selectPrestaciones[busqueda.key]"
+                                               (change)="selectPrestacion(busqueda, $event)">
+                                    </plex-bool>
+                                </td>
+                                <td *ngIf="columnas.fecha">{{busqueda.fecha | date: "dd/MM/yyyy HH:mm " }}</td>
+                                <td *ngIf="columnas.documento">{{busqueda.paciente.documento}}</td>
+                                <td *ngIf="columnas.paciente">{{busqueda.paciente | nombre}}</td>
+                                <td *ngIf="columnas.tipoPrestacion">{{busqueda.prestacion?.term}}</td>
+                                <td *ngIf="columnas.ambito">{{busqueda.ambito}}</td>
+                                <td *ngIf="columnas.equipoSalud" class="nombres-profesionales">
+                                    <span *ngIf="busqueda.profesionales?.length == 0" class="text-danger">
+                                        Profesional no asignado
+                                    </span>
+                                    <ng-container *ngIf="busqueda.profesionales">
+                                        <div *ngIf="busqueda.profesionales.length > 0">
+                                            {{ busqueda.profesionales | enumerar:['apellido','nombre'] }}
+                                        </div>
+                                    </ng-container>
+                                </td>
+                                <td *ngIf="columnas.estado">{{busqueda.estado}}</td>
+                                <td *ngIf="!sumarB && columnas.financiador">
+                                    {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}
+                                </td>
+                                <td *ngIf="sumarB">
+                                    {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </ng-container>
+            </ng-container>
         </ng-container>
     </plex-layout-main>
     <!-- Prestacion -->

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.module.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.module.ts
@@ -10,6 +10,8 @@ import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { DirectiveLibModule } from 'src/app/directives/directives.module';
 import { TurnosPrestacionesComponent } from './turnos-prestaciones.component';
 import { ElementosRUPModule } from 'src/app/modules/rup/elementos-rup.module';
+import { ExportHudsService } from 'src/app/modules/visualizacion-informacion/services/export-huds.service';
+import { VisualizacionInformacionModule } from 'src/app/modules/visualizacion-informacion/visualizacion-informacion.module';
 
 @NgModule({
     imports: [
@@ -22,11 +24,12 @@ import { ElementosRUPModule } from 'src/app/modules/rup/elementos-rup.module';
         DirectiveLibModule,
         InfiniteScrollModule,
         ElementosRUPModule,
+        VisualizacionInformacionModule,
         RouterModule.forChild([
             { path: '', component: TurnosPrestacionesComponent, pathMatch: 'full' },
         ])
     ],
-    providers: [],
+    providers: [ExportHudsService],
     declarations: [
         TurnosPrestacionesComponent
     ]

--- a/src/app/modules/visualizacion-informacion/components/exportar-huds/descargas-pendientes.component.html
+++ b/src/app/modules/visualizacion-informacion/components/exportar-huds/descargas-pendientes.component.html
@@ -2,6 +2,7 @@
     <plex-button tooltip="Actualizar" type="success">
         <plex-icon prefix="adi" name="reload" (click)="descargasPendientes()"></plex-icon>
     </plex-button>
+    <ng-content></ng-content>
 </plex-title>
 <plex-list *ngIf="!sinPendientes; else noPendientes">
     <plex-item *ngFor="let pendiente of completed">

--- a/src/app/modules/visualizacion-informacion/components/exportar-huds/descargas-pendientes.component.html
+++ b/src/app/modules/visualizacion-informacion/components/exportar-huds/descargas-pendientes.component.html
@@ -1,0 +1,31 @@
+<plex-title titulo="Descargas pendientes">
+    <plex-button tooltip="Actualizar" type="success">
+        <plex-icon prefix="adi" name="reload" (click)="descargasPendientes()"></plex-icon>
+    </plex-button>
+</plex-title>
+<plex-list *ngIf="!sinPendientes; else noPendientes">
+    <plex-item *ngFor="let pendiente of completed">
+        <plex-label
+                    titulo="HUDS-{{pendiente.pacienteNombre?pendiente.pacienteNombre:pendiente.createdAt| date: 'dd/MM/yyyy HH:mm'}}">
+        </plex-label>
+        <plex-button type="info" size="sm" (click)="exportarHuds(pendiente)">
+            Descargar
+        </plex-button>
+    </plex-item>
+    <plex-item *ngFor="let pendiente of pending">
+        <plex-label
+                    titulo="HUDS-{{pendiente.pacienteNombre?pendiente.pacienteNombre:pendiente.createdAt| date: 'dd/MM/yyyy HH:mm'}}">
+        </plex-label>
+        <plex-button type="info" size="sm" disabled="true">
+            En proceso
+        </plex-button>
+    </plex-item>
+</plex-list>
+<ng-template #noPendientes>
+    <div justify="center" class="h-75">
+        <plex-label icon="information-variant" type="default" size="xl" direction="column"
+                    titulo='Usted no tiene descargas pendientes'
+                    subtitulo='Si generó un nuevo pedido de exportación, presione el botón ACTUALIZAR '>
+        </plex-label>
+    </div>
+</ng-template>

--- a/src/app/modules/visualizacion-informacion/components/exportar-huds/descargas-pendientes.component.ts
+++ b/src/app/modules/visualizacion-informacion/components/exportar-huds/descargas-pendientes.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { ExportHudsService } from '../../services/export-huds.service';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Auth } from '@andes/auth';
+
+@Component({
+    selector: 'descargas-pendientes',
+    templateUrl: './descargas-pendientes.component.html'
+})
+
+export class DescargasPendientesComponent implements OnInit {
+    public completed = [];
+    public pending = [];
+    public sinPendientes = false;
+    public busqueda$: Observable<any[]>;
+
+
+    constructor(
+        private exportHudsService: ExportHudsService,
+        private auth: Auth
+    ) { }
+
+    ngOnInit(): void {
+        this.descargasPendientes();
+    }
+
+    exportarHuds(pendiente) {
+        const params = {
+            id: pendiente.idHudsFiles,
+            name: pendiente.pacienteNombre ? pendiente.pacienteNombre : 'HUDS',
+            idHuds: pendiente.id
+        };
+        this.exportHudsService.descargaHuds(params).subscribe((data) => {
+            if (data) {
+                this.descargasPendientes();
+            }
+        });
+    }
+
+    descargasPendientes() {
+        this.exportHudsService.pendientes({ id: this.auth.usuario.id }).subscribe((data) => {
+            this.exportHudsService.hud$.next(data);
+        });
+        this.busqueda$ = this.exportHudsService.pendiente$;
+        this.busqueda$.pipe(
+            map((prestaciones) => {
+                this.completed = prestaciones.filter(prestacion => prestacion.status === 'completed');
+                this.pending = prestaciones.filter(prestacion => prestacion.status === 'pending');
+            })
+        ).subscribe(() => {
+            this.sinPendientes = this.completed.length || this.pending.length ? false : true;
+        });
+    }
+}

--- a/src/app/modules/visualizacion-informacion/components/exportar-huds/exportar-huds.component.html
+++ b/src/app/modules/visualizacion-informacion/components/exportar-huds/exportar-huds.component.html
@@ -22,7 +22,7 @@
         </div>
         <div *ngIf="modalAccepted">
             <plex-title titulo="Paciente">
-                <plex-button type="danger btn-sm" icon="flecha-izquierda" (click)="onSearchClear()">
+                <plex-button type="link" icon="flecha-izquierda" (click)="onSearchClear()" tooltip="Volver">
                 </plex-button>
             </plex-title>
             <paciente-detalle orientacion="horizontal" *ngIf="pacienteSelected" [paciente]="pacienteSelected"
@@ -53,34 +53,6 @@
         </div>
     </plex-layout-main>
     <plex-layout-sidebar [type]="'invert'">
-        <plex-title titulo="Descargas pendientes">
-            <plex-button tooltip="Actualizar" type="success">
-                <plex-icon prefix="adi" name="reload" (click)="descargasPendientes()"></plex-icon>
-            </plex-button>
-        </plex-title>
-        <plex-list *ngIf="completed.length || pending.length; else noPendientes">
-            <plex-item *ngFor="let pendiente of completed">
-                <plex-label titulo="HUDS-{{pendiente.pacienteNombre}}">
-                </plex-label>
-                <plex-button type="info" size="sm" (click)="exportarHuds(pendiente)">
-                    Descargar
-                </plex-button>
-            </plex-item>
-            <plex-item *ngFor="let pendiente of pending">
-                <plex-label titulo="HUDS-{{pendiente.pacienteNombre}}">
-                </plex-label>
-                <plex-button type="info" size="sm" disabled="true">
-                    En proceso
-                </plex-button>
-            </plex-item>
-        </plex-list>
-        <ng-template #noPendientes>
-            <div justify="center" class="h-75">
-                <plex-label icon="information-variant" type="default" size="xl" direction="column"
-                            titulo='Usted no tiene descargas pendientes'
-                            subtitulo='Si generó un nuevo pedido de exportación, presione el botón ACTUALIZAR '>
-                </plex-label>
-            </div>
-        </ng-template>
+        <descargas-pendientes></descargas-pendientes>
     </plex-layout-sidebar>
 </plex-layout>

--- a/src/app/modules/visualizacion-informacion/components/exportar-huds/exportar-huds.component.ts
+++ b/src/app/modules/visualizacion-informacion/components/exportar-huds/exportar-huds.component.ts
@@ -24,6 +24,7 @@ export class ExportarHudsComponent implements OnInit {
     public disabledDescarga = false;
     public completed = [];
     public pending = [];
+    public turnosPrestaciones = false;
 
 
     constructor(
@@ -101,25 +102,9 @@ export class ExportarHudsComponent implements OnInit {
         });
     }
 
-    exportarHuds(pendiente) {
-        const params = {
-            id: pendiente.idHudsFiles,
-            name: pendiente.pacienteNombre,
-            idHuds: pendiente.id
-        };
-        this.exportHudsService.descargaHuds(params).subscribe((data) => {
-            if (data) {
-                this.descargasPendientes();
-            }
-        });
-    }
-
     descargasPendientes() {
         this.exportHudsService.pendientes({ id: this.auth.usuario.id }).subscribe((data) => {
-            // Acomodo para mostrar los que estan para descargar primero y los pendientes despues
-            this.completed = data.filter(item => item.status === 'completed');
-            this.pending = data.filter(item => item.status === 'pending');
+            this.exportHudsService.hud$.next(data);
         });
     }
-
 }

--- a/src/app/modules/visualizacion-informacion/services/export-huds.service.ts
+++ b/src/app/modules/visualizacion-informacion/services/export-huds.service.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { Observable, BehaviorSubject, Subject } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { Server, saveAs } from '@andes/shared';
 
@@ -6,7 +6,12 @@ import { Server, saveAs } from '@andes/shared';
 export class ExportHudsService {
     private exportHudsUrl = '/modules/huds/export';
 
-    constructor(private server: Server) { }
+    public pendiente$: Observable<any[]>;
+    public hud$ = new Subject<any[]>();
+
+    constructor(private server: Server) {
+        this.pendiente$ = this.hud$;
+    }
 
     pendientes(params) {
         return this.server.get(this.exportHudsUrl, { params });

--- a/src/app/modules/visualizacion-informacion/visualizacion-informacion.module.ts
+++ b/src/app/modules/visualizacion-informacion/visualizacion-informacion.module.ts
@@ -9,25 +9,26 @@ import { BiQueriesComponent } from './components/bi-queries/bi-queries.component
 import { ExportarHudsComponent } from './components/exportar-huds/exportar-huds.component';
 import { MPILibModule } from '../mpi/mpi-lib.module';
 import { ExportHudsService } from './services/export-huds.service';
-import { DirectiveLibModule } from 'src/app/directives/directives.module';
+import { DescargasPendientesComponent } from './components/exportar-huds/descargas-pendientes.component';
+
 
 @NgModule({
-        declarations: [
-                VisualizacionInformacionComponent,
-                BiQueriesComponent,
-                ExportarHudsComponent,
-                BiQueriesComponent
-        ],
-        imports: [
-                CommonModule,
-                FormsModule,
-                HttpClientModule,
-                PlexModule,
-                VisualizacioninfromacionRounting,
-                MPILibModule,
-                ReactiveFormsModule,
-                DirectiveLibModule
-        ],
-        providers: [ExportHudsService]
+    declarations: [
+        VisualizacionInformacionComponent,
+        BiQueriesComponent,
+        ExportarHudsComponent,
+        DescargasPendientesComponent
+    ],
+    exports: [DescargasPendientesComponent],
+    imports: [
+        CommonModule,
+        FormsModule,
+        HttpClientModule,
+        PlexModule,
+        VisualizacioninfromacionRounting,
+        MPILibModule,
+        ReactiveFormsModule
+    ],
+    providers: [ExportHudsService]
 })
 export class VisualizacionInformacionModule { }

--- a/src/app/modules/visualizacion-informacion/visualizacion-informacion.module.ts
+++ b/src/app/modules/visualizacion-informacion/visualizacion-informacion.module.ts
@@ -9,6 +9,7 @@ import { BiQueriesComponent } from './components/bi-queries/bi-queries.component
 import { ExportarHudsComponent } from './components/exportar-huds/exportar-huds.component';
 import { MPILibModule } from '../mpi/mpi-lib.module';
 import { ExportHudsService } from './services/export-huds.service';
+import { DirectiveLibModule } from 'src/app/directives/directives.module';
 import { DescargasPendientesComponent } from './components/exportar-huds/descargas-pendientes.component';
 
 
@@ -17,9 +18,11 @@ import { DescargasPendientesComponent } from './components/exportar-huds/descarg
         VisualizacionInformacionComponent,
         BiQueriesComponent,
         ExportarHudsComponent,
+        BiQueriesComponent,
         DescargasPendientesComponent
     ],
     exports: [DescargasPendientesComponent],
+
     imports: [
         CommonModule,
         FormsModule,
@@ -27,8 +30,10 @@ import { DescargasPendientesComponent } from './components/exportar-huds/descarg
         PlexModule,
         VisualizacioninfromacionRounting,
         MPILibModule,
-        ReactiveFormsModule
+        ReactiveFormsModule,
+        DirectiveLibModule
     ],
     providers: [ExportHudsService]
+
 })
 export class VisualizacionInformacionModule { }


### PR DESCRIPTION
### Requerimiento
Descarga de prestaciones desde el buscador de turnos y prestaciones.
Refactor filtros del buscador de turnos y prestaciones.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se separa en un nuevo componente descargas-pendientes el listado de las peticiones de huds para ser usado tanto en exportar-huds como en el buscador de turnos y prestaciones.
2. Se agrega en el componente como en el html de turnos-prestaciones, la posibilidad de seleccionar/deseleccionar una o mas o todas las prestaciones que se encontraron al realizar la búsqueda.
3. Se agregan al `exportHudsService` un `Observable` y un `subject` para mantener actualizada la lista de descargas disponibles/pendientes.

### Refactor UI ( En conjunto con el equipo UI/UX)

1. Se agrupan todos los filtros dentro de un `plex-wrapper` para que se distribuyan de una mejor manera.
2. Al cerrar una prestación que se esta mostrando en el sidebar, se "despinta" la prestación seleccionada.
3. Se agregan títulos y botones necesarios para visualizar las descargas pendientes y exportar las prestaciones en un zip.
4. En el `exportar-huds.html `se modifica el botón por un link para volver atrás.

 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1206
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/andes-test-integracion/pull/300
- [ ] No

