### PR TITLE
BI-QUERIES: Campo obligatorio/no obligatorio "organización" en bi queries

### DIFF
--- a/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.html
+++ b/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.html
@@ -28,7 +28,8 @@
                         <plex-select *ngSwitchCase="'organizacion'"
                                      [label]="argumento.label?argumento.label:argumento.key" grow="2"
                                      name="{{ argumento.key }}" [(ngModel)]="argumentos[argumento.key]"
-                                     [required]="argumento.required" [data]="organizaciones$ |async">>
+                                     [required]="argumento.required && totalOrganizaciones"
+                                     [data]="organizaciones$ |async">>
                         </plex-select>
                         <plex-select *ngSwitchCase="'conceptoTurneable'"
                                      [label]="argumento.label?argumento.label:argumento.key" grow="2"

--- a/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.ts
+++ b/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.ts
@@ -22,6 +22,7 @@ export class BiQueriesComponent implements OnInit {
   public resultados;
   public mostrarSalida = false;
   public tipoPrestaciones;
+  public totalOrganizaciones = false;
 
   constructor(
     private queryService: QueriesService,
@@ -32,6 +33,7 @@ export class BiQueriesComponent implements OnInit {
 
   ngOnInit() {
     const permisos = this.auth.getPermissions('visualizacionInformacion:biQueries:?');
+    this.totalOrganizaciones = !this.auth.check('visualizacionInformacion:totalOrganizaciones');
     if (permisos.length) {
       if (permisos[0] === '*') {
         this.queries$ = this.queryService.getAllQueries({ desdeAndes: true });
@@ -95,7 +97,6 @@ export class BiQueriesComponent implements OnInit {
     let resultado = this.queries$.find(query => query.nombre === this.consultaSeleccionada.nombre);
     if (resultado) {
       const params = {};
-
       this.argumentos.forEach(arg => {
         const key = arg.key;
         const valor = this.argumentos[key];
@@ -110,6 +111,7 @@ export class BiQueriesComponent implements OnInit {
           }
         }
       });
+      params['totalOrganizaciones'] = !this.totalOrganizaciones;
       this.queryService.descargarCsv(this.consultaSeleccionada.nombre, params).subscribe();
     }
   }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-69

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se modifica el componente y la vista para chequear el nuevo permiso `totalOrganizaciones` , en el caso que el usuario lo tenga, si la query viene con el campo organizaciones requerido en true, elimina esa restricción, caso contrario la deja como esta.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1217
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

