### PR TITLE
INTERNACION - Agrega control en los registros si la unidad organizativa es null

### DIFF
--- a/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
+++ b/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { cache } from '@andes/shared';
+import { cache, notNull } from '@andes/shared';
 import { Observable, BehaviorSubject, Subject, combineLatest, of, timer } from 'rxjs';
 import { ISnapshot } from '../interfaces/ISnapshot';
 import { ICama } from '../interfaces/ICama';
 import { IMaquinaEstados, IMAQRelacion, IMAQEstado } from '../interfaces/IMaquinaEstados';
 import { MapaCamasHTTP } from './mapa-camas.http';
-import { switchMap, map, pluck, catchError, startWith, multicast, filter } from 'rxjs/operators';
+import { switchMap, map, pluck, catchError, startWith, multicast, filter, tap } from 'rxjs/operators';
 import { ISectores } from '../../../../interfaces/IOrganizacion';
 import { ISnomedConcept } from '../../../../modules/rup/interfaces/snomed-concept.interface';
 import { IPrestacion } from '../../../../modules/rup/interfaces/prestacion.interface';
@@ -312,8 +312,8 @@ export class MapaCamasService {
                     snap.paciente.documento.includes(paciente));
             } else {
                 camasFiltradas = camasFiltradas.filter((snap: ISnapshot) =>
-                    (snap.paciente.nombre.toLowerCase().includes(paciente.toLowerCase()) ||
-                        snap.paciente.apellido.toLowerCase().includes(paciente.toLowerCase()))
+                (snap.paciente.nombre.toLowerCase().includes(paciente.toLowerCase()) ||
+                    snap.paciente.apellido.toLowerCase().includes(paciente.toLowerCase()))
                 );
             }
         }
@@ -540,6 +540,7 @@ export class MapaCamasService {
         );
         const accionesCapa$ = cama.pipe(
             switchMap(_cama => this.getEstadoCama(_cama)),
+            notNull(),
             pluck('acciones')
         );
 

--- a/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
+++ b/src/app/apps/rup/mapa-camas/services/mapa-camas.service.ts
@@ -548,6 +548,9 @@ export class MapaCamasService {
             accionesCapa$
         ).pipe(
             map(([uo, acciones]) => {
+                if (!uo) {
+                    return [];
+                }
                 const registros = acciones.filter(acc => acc.tipo === 'nuevo-registro');
                 return registros.filter((registro) => {
                     const { unidadOrganizativa } = registro.parametros;


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
El error se da al seleccionar una cama, tocar en "nuevo registros" y hacer click de nuevo en la cama para deseleccionarla. Se emite null como cama seleccionada, entonces la unidad organizativa es null por lo tanto no tiene conceptId.
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Agrega control en caso de que la unidad organizativa sea null.
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
