### PR TITLE
feat(login): Se agrega la posibilidad resetear la contraseña para los usuarios externos (no OneLogin)

### DIFF
--- a/projects/auth/src/lib/auth.service.ts
+++ b/projects/auth/src/lib/auth.service.ts
@@ -144,7 +144,7 @@ export class Auth {
 
     // Metodo que invoca a la api para realizar el recovering de la password
     setValidationTokenAndNotify(usuario: Number): Observable<any> {
-        return this.server.post('/auth/getValidationTokenAndNotify', {username: usuario}, {showError: false});
+        return this.server.post('/auth/setValidationTokenAndNotify', {username: usuario}, {showError: false});
     }
 
     // Método que modifica la contraseña del usuario

--- a/projects/auth/src/lib/auth.service.ts
+++ b/projects/auth/src/lib/auth.service.ts
@@ -36,7 +36,6 @@ export interface ISession {
 export class Auth {
     private token$ = new Subject<string>();
     private session$: Observable<ISession>;
-
     private shiro = shiroTrie.new();
     public estado: Estado;
     public usuario: IUsuario;
@@ -142,6 +141,17 @@ export class Auth {
             })
         );
     }
+
+    // Metodo que invoca a la api para realizar el recovering de la password
+    setValidationTokenAndNotify(usuario: Number): Observable<any> {
+        return this.server.post('/auth/getValidationTokenAndNotify', {username: usuario}, {showError: false});
+    }
+
+    // Método que modifica la contraseña del usuario
+    resetPassword(data): Observable<any> {
+        return this.server.post('/auth/resetPassword', data, {showError: false});
+    }
+
 
 
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { finalize } from 'rxjs/operators';
 import { environment } from './../environments/environment';
 import { Component } from '@angular/core';
 import { Plex } from '@andes/plex';
-import { Server, cache, cacheStorage } from '@andes/shared';
+import { Server, cacheStorage } from '@andes/shared';
 import { Auth } from '@andes/auth';
 import { PROPERTIES } from './styles/properties';
 import { WebSocketService } from './services/websocket.service';
@@ -12,9 +12,6 @@ import { GoogleTagManagerService } from './shared/services/analytics.service';
 import { AdjuntosService } from './modules/rup/services/adjuntos.service';
 import { ModulosService } from './services/novedades/modulos.service';
 import { Observable } from 'rxjs';
-import { keyframes } from '@angular/animations';
-
-// import { RxSocket } from 'rx-socket.io-client';
 
 @Component({
     selector: 'app',

--- a/src/app/apps/auth/auth.module.ts
+++ b/src/app/apps/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { LoginComponent } from './components/login/login.component';
 import { LogoutComponent } from './components/logout/logout.component';
+import { ForgotComponent } from './components/forgot/forgot.component';
+import { RecoveryComponent } from './components/recovery/recovery.component';
 import { SelectOrganizacionComponent } from './components/select-organizacion/select-organizacion.component';
 import { AuthAppRouting } from './auth.routing';
 
@@ -22,6 +24,8 @@ import { AuthAppRouting } from './auth.routing';
     declarations: [
         LoginComponent,
         LogoutComponent,
+        ForgotComponent,
+        RecoveryComponent,
         SelectOrganizacionComponent,
         ModalDisclaimerComponent
     ]

--- a/src/app/apps/auth/auth.routing.ts
+++ b/src/app/apps/auth/auth.routing.ts
@@ -3,11 +3,15 @@ import { NgModule } from '@angular/core';
 import { SelectOrganizacionComponent } from './components/select-organizacion/select-organizacion.component';
 import { LoginComponent } from './components/login/login.component';
 import { LogoutComponent } from './components/logout/logout.component';
+import { ForgotComponent } from './components/forgot/forgot.component';
+import { RecoveryComponent } from './components/recovery/recovery.component';
 import { RoutingNavBar, RoutingGuard } from '../../app.routings-guard.class';
 
 let routes = [
     { path: 'select-organizacion', component: SelectOrganizacionComponent, canActivate: [RoutingNavBar, RoutingGuard] },
     { path: 'login', component: LoginComponent, canActivate: [RoutingNavBar] },
+    { path: 'forgot', component: ForgotComponent, canActivate: [RoutingNavBar] },
+    { path: 'resetPassword/:token', component: RecoveryComponent, canActivate: [RoutingNavBar] },
     { path: 'logout', component: LogoutComponent, canActivate: [RoutingNavBar, RoutingGuard] },
 ];
 

--- a/src/app/apps/auth/components/forgot/forgot.component.ts
+++ b/src/app/apps/auth/components/forgot/forgot.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Router } from '@angular/router';
+import { Plex } from '@andes/plex';
+import { Auth } from '@andes/auth';
+import { WebSocketService } from '../../../../services/websocket.service';
+
+
+@Component({
+    templateUrl: 'forgot.html',
+    styleUrls: ['forgot.scss'],
+    encapsulation: ViewEncapsulation.None // Use to disable CSS Encapsulation for this component
+})
+export class ForgotComponent {
+    public usuario: number;
+    public loading = false;
+
+    constructor(
+        private plex: Plex,
+        private auth: Auth,
+        private router: Router,
+        public ws: WebSocketService
+    ) { }
+
+
+
+    recover(event) {
+        if (event.formValid) {
+            this.loading = true;
+            this.auth.setValidationTokenAndNotify(this.usuario).subscribe(
+                data => {
+                    if (data.status === 'ok') {
+                        this.plex.info('success', 'Hemos enviado un e-mail para regenerar su contraseña');
+                        this.loading = false;
+                    } else {
+                        this.loading = false;
+                        this.plex.confirm('¿Desea continuar?', 'Su operación deberá ser realizada desde oneLogin.').then((resultado) => {
+                            if (resultado) {
+                                window.location.href = 'https://cas.neuquen.gov.ar/cas/login?service=https%3a%2f%2flogin.neuquen.gov.ar%2f';
+                            } else {
+                                this.cancel();
+                            }
+                        });
+
+                    }
+                    this.cancel();
+                },
+                err => {
+                    this.plex.info('danger', 'El usuario ingresado no existe. Verifique los datos ingresados y vuelva a intentar');
+                    this.loading = false;
+                    this.cancel();
+                }
+            );
+        }
+    }
+
+    cancel() {
+        this.router.navigate(['/auth/login']);
+    }
+
+}

--- a/src/app/apps/auth/components/forgot/forgot.html
+++ b/src/app/apps/auth/components/forgot/forgot.html
@@ -12,7 +12,7 @@
                     <div>
                         <h3>Restablecer contraseña</h3>
                         <span>
-                            Por favor, ingrese su usuario. Recibirá un correo electrónico con instrucciones para restablecer su contraseña. En caso que tenga usuario en onelogin se lo redirigirá al sitio web correspondiente
+                            Por favor, ingrese su usuario. Recibirá un correo electrónico con instrucciones para restablecer su contraseña. En caso que tenga usuario de onelogin se lo redirigirá al sitio web correspondiente.
                         </span>
                     </div>
                     <plex-int label="Ingrese su usuario" [autoFocus]="true" [(ngModel)]="usuario"

--- a/src/app/apps/auth/components/forgot/forgot.html
+++ b/src/app/apps/auth/components/forgot/forgot.html
@@ -1,0 +1,41 @@
+<div class="forgot-container">
+    <div class="forgot-form">
+        <form>
+            <div class="row forgot-header">
+                <div class="col">
+                    <div class="onelogin"></div>
+                    <div class="andes"></div>
+                </div>
+            </div>
+            <div class="row forgot-content">
+                <div class="col">
+                    <div>
+                        <h3>Restablecer contraseña</h3>
+                        <span>
+                            Por favor, ingrese su usuario. Recibirá un correo electrónico con instrucciones para restablecer su contraseña. En caso que tenga usuario en onelogin se lo redirigirá al sitio web correspondiente
+                        </span>
+                    </div>
+                    <plex-int label="Ingrese su usuario" [autoFocus]="true" [(ngModel)]="usuario"
+                              name="usuario" [required]="true">
+                        <plex-icon name="account-key" left></plex-icon>
+                    </plex-int>
+                    <div class="row">&nbsp;</div>
+                    <plex-button type="success" [validateForm]="true" [disabled]="loading" (click)="recover($event)">
+                        Recuperar contraseña
+                    </plex-button>
+                    <div class="row">&nbsp;</div>
+                    <plex-button type="danger" [disabled]="loading" (click)="cancel()">
+                        Cancelar
+                    </plex-button>
+                    <plex-loader *ngIf="loading" type="ball-pulse-sync"></plex-loader>
+                </div>
+            </div>
+            <div class="row forgot-footer">
+                <div class="col">
+                    <div class="redTICS"></div>
+                    <div class="ministerio"></div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/app/apps/auth/components/forgot/forgot.scss
+++ b/src/app/apps/auth/components/forgot/forgot.scss
@@ -1,0 +1,108 @@
+@import '~@andes/plex/src/lib/css/variables';
+.forgot-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    padding-top: 10%;
+    padding-left: 25vw;
+    padding-right: 25vw;
+    width: 100%;
+    height: 100%;
+    z-index: 1030;
+    background: #EEE;
+    // Form
+    .forgot-form {
+        box-shadow: 0px 0px 22px 2px rgba(0, 0, 0, 0.45);
+        // Header
+        .forgot-header {
+            height: 80px;
+            background: var(--nav-bar-color);
+            // OneLogin
+            .onelogin {
+                width: 120px;
+                float: left;
+                height: 100%;
+                background-repeat: no-repeat;
+                background-size: var(--login-logo-1-size);
+                background-position: center left;
+                background-image: var(--login-logo-1);
+            }
+            // Andes
+            .andes {
+                width: 200px;
+                float: right;
+                height: 100%;
+                background-repeat: no-repeat;
+                background-size: 80px;
+                background-position: center right;
+                background-image: url('../../../../assets/img/andes-logo-v-white.svg');
+            }
+        }
+        // Content
+        .forgot-content {
+            padding-top: 30px;
+            padding-bottom: 30px;
+            background: var(--nav-bar-icon-color);
+            color: white;
+            align-items: center;
+            
+            .input-group-addon {
+                background: var(--nav-bar-color) !important;
+            }
+            input {
+                border-color: white;
+            }
+            plex-button,
+            .btn {
+                display: block;
+                width: 100%;
+            }
+        }
+        // Footer
+        .forgot-footer {
+            height: 60px;
+            background: var(--nav-bar-color);
+            // Red TICS
+            .redTICS {
+                width: 200px;
+                float: left;
+                height: 100%;
+                background-repeat: no-repeat;
+                background-size: 100px;
+                background-position: center left;
+                background-image: var(--login-logo-3);
+            }
+            // Ministerio
+            .ministerio {
+                width: 200px;
+                float: right;
+                height: 100%;
+                background-repeat: no-repeat;
+                background-size: 100px;
+                background-position: center right;
+                background-image: var(--login-logo-4);
+            }
+        }
+    }
+
+    
+}
+
+
+@media screen and (max-width: 768px) {
+    .forgot-container {
+        padding-left: 15px;
+        padding-right: 15px;
+        padding-top: 0%;
+        height: 100vh;
+    }
+
+    .forgot-container .forgot-form .forgot-content {
+        height: calc(100vh - 140px);
+    }
+
+    .onelogin, .andes, .ministerio, .redTICS {
+        background-size: 75px;
+        width: 100px!important;
+    }
+}

--- a/src/app/apps/auth/components/login/login.component.ts
+++ b/src/app/apps/auth/components/login/login.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { Plex } from '@andes/plex';
 import { Auth } from '@andes/auth';
 import { WebSocketService } from '../../../../services/websocket.service';
+import { environment } from '../../../../../../src/environments/environment';
 
 @Component({
     templateUrl: 'login.html',
@@ -13,6 +14,7 @@ export class LoginComponent implements OnInit {
     public usuario: number;
     public password: string;
     public loading = false;
+    public enable = environment.PASSWORD_RECOVER ? environment.PASSWORD_RECOVER === 'enabled' : false;
 
     constructor(
         private plex: Plex,
@@ -29,6 +31,10 @@ export class LoginComponent implements OnInit {
     checkTimezone() {
         const timeZone = new Date().getTimezoneOffset();
         return timeZone === 180;
+    }
+
+    forgot() {
+        this.router.navigate(['/auth/forgot']);
     }
 
     login(event) {

--- a/src/app/apps/auth/components/login/login.html
+++ b/src/app/apps/auth/components/login/login.html
@@ -17,6 +17,11 @@
                                [required]="true">
                         <plex-icon name="dialpad" left></plex-icon>
                     </plex-text>
+                    <div *ngIf="enable">
+                        <a class="hover" justify="end" (click)="forgot()">
+                            (olvidé mi contraseña)
+                        </a>
+                    </div>
                     <div class="row">&nbsp;</div>
                     <plex-button type="success" [validateForm]="true" [disabled]="loading" (click)="login($event)">
                         Iniciar sesión

--- a/src/app/apps/auth/components/recovery/recovery.component.ts
+++ b/src/app/apps/auth/components/recovery/recovery.component.ts
@@ -14,16 +14,7 @@ export class RecoveryComponent implements OnInit {
     public password2 = '';
     public token = null;
 
-   @ViewChild('formulario', {static: true}) formulario;
-
-    @Input()
-    set show(value) {
-      if (value) {
-        this.formulario.show();
-      }
-    }
-
-    @Output() closeModal = new EventEmitter<any>();
+    @ViewChild('formulario', { static: true }) formulario;
 
     constructor(
         private plex: Plex,
@@ -35,48 +26,39 @@ export class RecoveryComponent implements OnInit {
 
     ngOnInit() {
         // Busca el token y activa la cuenta
-        this.activateRouter.paramMap.subscribe(params => {
-            this.token = params.get('token');
-            if (this.token) {
-                this.formulario.show();
-            }
-        });
+        this.token = this.activateRouter.snapshot.paramMap.get('token');
     }
 
     save(form) {
         if (form.valid) {
-          if (this.password1 === this.password2) {
-            this.loading = true;
-              this.auth.resetPassword({ token: this.token, password: this.password1 }).subscribe(
-                data => {
-                  if (data.status === 'ok') {
-                    this.plex.info('success', 'La contraseña ha sido restablecida correctamente');
-                  } else {
-                    this.plex.info('danger', 'Hubo un error en la actualización de la contraseña');
-                  }
-                  this.clearForm();
-                  this.cancel();
-                },
-                err => {
-                  this.plex.info('danger', err);
-                  this.loading = false;
-                }
-              );
-          }
+            if (this.password1 === this.password2) {
+                this.loading = true;
+                this.auth.resetPassword({ token: this.token, password: this.password1 }).subscribe(
+                    data => {
+                        if (data.status === 'ok') {
+                            this.plex.info('success', 'La contraseña ha sido restablecida correctamente');
+                        } else {
+                            this.plex.info('danger', 'Hubo un error en la actualización de la contraseña');
+                        }
+                        this.clearForm();
+                        this.cancel();
+                    },
+                    err => {
+                        this.plex.info('danger', err);
+                        this.loading = false;
+                    }
+                );
+            }
         }
-      }
+    }
 
-      cancel() {
-        this.formulario.showed = false;
-        this.closeModal.emit();
-        if (this.token) {
-          this.router.navigate(['/auth/login']);
-        }
-      }
+    cancel() {
+        this.router.navigate(['/auth/login']);
+    }
 
     clearForm() {
         this.loading = false;
         this.password1 = '';
         this.password2 = '';
-      }
+    }
 }

--- a/src/app/apps/auth/components/recovery/recovery.component.ts
+++ b/src/app/apps/auth/components/recovery/recovery.component.ts
@@ -1,0 +1,82 @@
+import { Component, OnInit, ViewEncapsulation, ViewChild, Input, Output, EventEmitter } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Plex } from '@andes/plex';
+import { Auth } from '@andes/auth';
+
+@Component({
+    templateUrl: 'recovery.html',
+    styleUrls: ['recovery.scss'],
+    encapsulation: ViewEncapsulation.None // Use to disable CSS Encapsulation for this component
+})
+export class RecoveryComponent implements OnInit {
+    public loading = false;
+    public password1 = '';
+    public password2 = '';
+    public token = null;
+
+   @ViewChild('formulario', {static: true}) formulario;
+
+    @Input()
+    set show(value) {
+      if (value) {
+        this.formulario.show();
+      }
+    }
+
+    @Output() closeModal = new EventEmitter<any>();
+
+    constructor(
+        private plex: Plex,
+        private auth: Auth,
+        private router: Router,
+        private activateRouter: ActivatedRoute
+    ) { }
+
+
+    ngOnInit() {
+        // Busca el token y activa la cuenta
+        this.activateRouter.paramMap.subscribe(params => {
+            this.token = params.get('token');
+            if (this.token) {
+                this.formulario.show();
+            }
+        });
+    }
+
+    save(form) {
+        if (form.valid) {
+          if (this.password1 === this.password2) {
+            this.loading = true;
+              this.auth.resetPassword({ token: this.token, password: this.password1 }).subscribe(
+                data => {
+                  if (data.status === 'ok') {
+                    this.plex.info('success', 'La contraseña ha sido restablecida correctamente');
+                  } else {
+                    this.plex.info('danger', 'Hubo un error en la actualización de la contraseña');
+                  }
+                  this.clearForm(form);
+                  this.cancel(form);
+                },
+                err => {
+                  this.plex.info('danger', err);
+                  this.loading = false;
+                }
+              );
+          }
+        }
+      }
+
+      cancel(form) {
+        this.formulario.showed = false;
+        this.closeModal.emit();
+        if (this.token) {
+          this.router.navigate(['/auth/login']);
+        }
+      }
+
+    clearForm(form) {
+        this.loading = false;
+        this.password1 = '';
+        this.password2 = '';
+      }
+}

--- a/src/app/apps/auth/components/recovery/recovery.component.ts
+++ b/src/app/apps/auth/components/recovery/recovery.component.ts
@@ -54,8 +54,8 @@ export class RecoveryComponent implements OnInit {
                   } else {
                     this.plex.info('danger', 'Hubo un error en la actualización de la contraseña');
                   }
-                  this.clearForm(form);
-                  this.cancel(form);
+                  this.clearForm();
+                  this.cancel();
                 },
                 err => {
                   this.plex.info('danger', err);
@@ -66,7 +66,7 @@ export class RecoveryComponent implements OnInit {
         }
       }
 
-      cancel(form) {
+      cancel() {
         this.formulario.showed = false;
         this.closeModal.emit();
         if (this.token) {
@@ -74,7 +74,7 @@ export class RecoveryComponent implements OnInit {
         }
       }
 
-    clearForm(form) {
+    clearForm() {
         this.loading = false;
         this.password1 = '';
         this.password2 = '';

--- a/src/app/apps/auth/components/recovery/recovery.html
+++ b/src/app/apps/auth/components/recovery/recovery.html
@@ -1,0 +1,47 @@
+  <div class="login-container">
+    <div class="login-form">
+        <form #formulario="ngForm">
+            <div class="row login-header">
+                <div class="col">
+                    <div class="onelogin"></div>
+                    <div class="andes"></div>
+                </div>
+            </div>
+            <div class="row login-content">
+                <div class="col">
+                  <div class="password mb-2">
+                    <plex-text placeholder="Ingresá una nueva contraseña" [(ngModel)]="password1" required="true" name="password1"
+                              [password]="!showPassword">
+                    </plex-text>
+                  </div>
+                  <div class="password mb-3">
+                    <plex-text placeholder="Confirmá tu nueva contraseña" [(ngModel)]="password2" required="true" name="password2"
+                              [password]="!showPassword">
+                    </plex-text>
+                  </div>
+                  <span *ngIf="formulario.form.valid && (this.password1 !== this.password2)" class="text-danger">
+                    Las contraseñas no coinciden
+                  </span>
+                  <plex-loader *ngIf="loading" type="ball-pulse-sync"></plex-loader>
+                  <plex-button modal right type="success" [validateForm]="formulario"
+                               [disabled]="!formulario.form.valid || (this.password1 !== this.password2)"
+                               (click)="save(formulario.form)">
+                    Confirmar contraseña
+                  </plex-button>
+                  <div class="row">&nbsp;</div>
+                  <plex-button modal left type="danger" (click)="cancel(formulario.form)">
+                    Cancelar
+                  </plex-button>
+                
+                </div>
+            </div>
+            <div class="row login-footer">
+                <div class="col">
+                    <div class="redTICS"></div>
+                   
+                    <div class="ministerio"></div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/app/apps/auth/components/recovery/recovery.html
+++ b/src/app/apps/auth/components/recovery/recovery.html
@@ -11,12 +11,12 @@
                 <div class="col">
                   <div class="password mb-2">
                     <plex-text placeholder="Ingresá una nueva contraseña" [(ngModel)]="password1" required="true" name="password1"
-                              [password]="!showPassword">
+                              [password]="true">
                     </plex-text>
                   </div>
                   <div class="password mb-3">
                     <plex-text placeholder="Confirmá tu nueva contraseña" [(ngModel)]="password2" required="true" name="password2"
-                              [password]="!showPassword">
+                              [password]="true">
                     </plex-text>
                   </div>
                   <span *ngIf="formulario.form.valid && (this.password1 !== this.password2)" class="text-danger">

--- a/src/app/apps/auth/components/recovery/recovery.html
+++ b/src/app/apps/auth/components/recovery/recovery.html
@@ -11,12 +11,12 @@
                 <div class="col">
                   <div class="password mb-2">
                     <plex-text placeholder="Ingresá una nueva contraseña" [(ngModel)]="password1" required="true" name="password1"
-                              [password]="true">
+                              [password]="true" minlength="8" maxlength="16">
                     </plex-text>
                   </div>
                   <div class="password mb-3">
                     <plex-text placeholder="Confirmá tu nueva contraseña" [(ngModel)]="password2" required="true" name="password2"
-                              [password]="true">
+                              [password]="true" minlength="8" maxlength="16">
                     </plex-text>
                   </div>
                   <span *ngIf="formulario.form.valid && (this.password1 !== this.password2)" class="text-danger">
@@ -29,7 +29,7 @@
                     Confirmar contraseña
                   </plex-button>
                   <div class="row">&nbsp;</div>
-                  <plex-button modal left type="danger" (click)="cancel(formulario.form)">
+                  <plex-button modal left type="danger" (click)="cancel()">
                     Cancelar
                   </plex-button>
                 

--- a/src/app/apps/auth/components/recovery/recovery.scss
+++ b/src/app/apps/auth/components/recovery/recovery.scss
@@ -1,0 +1,1 @@
+@import '../login/login.scss';

--- a/src/environments/apiKeyMaps.ts.example
+++ b/src/environments/apiKeyMaps.ts.example
@@ -15,4 +15,4 @@ export const analytics = {
 
 export const password_recovery = {
     key: 'enabled' // Para activar, si no se quiere activar poner cualquier otra cosa. Sugerencia: disabled
-}
+};

--- a/src/environments/apiKeyMaps.ts.example
+++ b/src/environments/apiKeyMaps.ts.example
@@ -12,3 +12,7 @@ export const hotjar = {
 export const analytics = {
     key: 'XXXX'
 };
+
+export const password_recovery = {
+    key: 'enabled' // Para activar, si no se quiere activar poner cualquier otra cosa. Sugerencia: disabled
+}

--- a/src/environments/environment.demo.ts
+++ b/src/environments/environment.demo.ts
@@ -1,5 +1,5 @@
 const _package = require('../../package.json');
-import { apiKeys, hotjar, analytics } from './apiKeyMaps';
+import { apiKeys, hotjar, analytics, password_recovery } from './apiKeyMaps';
 
 export const environment = {
     production: false,
@@ -11,4 +11,5 @@ export const environment = {
     MAPS_KEY: apiKeys.develop,
     HOTJAR_KEY: hotjar.key,
     ANALYTICS_KEY: analytics.key,
+    PASSWORD_RECOVER: password_recovery.key
 };

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,5 +1,5 @@
 const _package = require('../../package.json');
-import { apiKeys, analytics, hotjar } from './apiKeyMaps';
+import { apiKeys, analytics, hotjar, password_recovery } from './apiKeyMaps';
 
 export const environment = {
   production: false,
@@ -11,4 +11,5 @@ export const environment = {
   MAPS_KEY: apiKeys.develop,
   HOTJAR_KEY: hotjar.key,
   ANALYTICS_KEY: analytics.key,
+  PASSWORD_RECOVER: password_recovery.key
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 let _package = require('../../package.json');
-import { apiKeys, hotjar, analytics } from './apiKeyMaps';
+import { apiKeys, hotjar, analytics, password_recovery } from './apiKeyMaps';
 
 export const environment = {
     production: true,
@@ -11,4 +11,5 @@ export const environment = {
     MAPS_KEY: apiKeys.produccion,
     HOTJAR_KEY: hotjar.key,
     ANALYTICS_KEY: analytics.key,
+    PASSWORD_RECOVER: password_recovery.key
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,5 +1,5 @@
 const _package = require('../../package.json');
-import { apiKeys, hotjar, analytics } from './apiKeyMaps';
+import { apiKeys, hotjar, analytics, password_recovery } from './apiKeyMaps';
 
 export const environment = {
     production: false,
@@ -10,5 +10,6 @@ export const environment = {
     version: _package.version,
     MAPS_KEY: apiKeys.develop,
     HOTJAR_KEY: hotjar.key,
-    ANALYTICS_KEY: analytics.key
+    ANALYTICS_KEY: analytics.key,
+    PASSWORD_RECOVER: password_recovery.key
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,5 +14,6 @@ export const environment = {
   version: _package.version,
   MAPS_KEY: '',
   HOTJAR_KEY: '',
-  ANALYTICS_KEY: ''
+  ANALYTICS_KEY: '',
+  PASSWORD_RECOVER: ''
 };


### PR DESCRIPTION
- Posibilidad de configurar si la funcionalidad de "olvide mi contraseña" la quiero habilitada o no.
- Envío de correo con un link para el reseto de la misma si es un usuario temporal c/ mail (campos obligatorios) para poder utilizar esta funcionalidad. En caso que el usuario no sea externo, se redirecciona al sitio de onelogin para la procecusión del trámite.

### UserStory llegó a completarse
Proceso que permite el login y reset de contraseña para usuarios externos para el proceso de vacunación

<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si
- [ ] No
PR https://github.com/andes/api/pull/1233
### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si
- [ ] No

PD: Queda pendiente el test en andes-test-integración
