### PR TITLE
fix(mpi): foto paciente directiva

### DIFF
--- a/src/app/modules/mpi/components/paciente-detalle-foto.directive.ts
+++ b/src/app/modules/mpi/components/paciente-detalle-foto.directive.ts
@@ -10,6 +10,9 @@ export class FotoDirective implements OnDestroy {
     private io: IntersectionObserver;
 
     @Input() set mpiFotoPaciente(paciente: IPaciente) {
+        if (this.io) {
+            this.io.disconnect();
+        }
         if (paciente && paciente.id && paciente.fotoId) {
             this.fileService.token$.subscribe((data: any) => {
                 const { token } = data;


### PR DESCRIPTION
### Requerimiento
Error de sincronización de fotos del paciente. 

### Funcionalidad desarrollada 
1. Desconecta el viejo IntersectiónObserver antes de armar uno nuevo. 


### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion - [ ] Si
- [x] No