### PR TITLE
fix(vacunas): fix en la condicion de timepo interdosis

### DIFF
--- a/src/app/modules/rup/components/elementos/vacunas.component.ts
+++ b/src/app/modules/rup/components/elementos/vacunas.component.ts
@@ -156,7 +156,7 @@ export class VacunasComponent extends RUPComponent implements OnInit {
             const tiempoInterdosis = this.registro.valor.vacuna.dosis.tiempoInterdosis;
             let diasdiferencia = this.prestacion.ejecucion.fecha.getTime() - ultimoRegistro.fechaAplicacion.getTime();
             let contdias = Math.round(diasdiferencia / (1000 * 60 * 60 * 24));
-            if (contdias <= tiempoInterdosis) {
+            if (contdias < tiempoInterdosis) {
                 this.plex.info('danger', 'No se cumple el tiempo interdosis', 'Problemas con la dosis seleccionada');
                 this.registro.valor.vacuna.dosis = Object.assign({}, null);
             }


### PR DESCRIPTION
1- Se modifica la condición de la diferencia de días para el chequeo de interdosis, ya que la resta actual daba en números negativos.
2- Para los casos que sea el mismo día (exactamente 21 días) se modifica a menor estricto.


### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

