### PR TITLE
TURNOS-PRESTACIONES: Agregar máximo permitido al exportarHuds

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -46,6 +46,8 @@ export class TurnosPrestacionesComponent implements OnInit, OnDestroy {
     public profesionales;
     public arrayAmbito = [{ id: 'ambulatorio', nombre: 'ambulatorio' }, { id: 'internacion', nombre: 'internación' }];
     public ambito;
+    public prestacionesMax = 500;
+    public showHint = false;
 
     public columnas = {
         fecha: true,
@@ -163,6 +165,7 @@ export class TurnosPrestacionesComponent implements OnInit, OnDestroy {
                             ...selected,
                             [key]: value
                         });
+                        break;
                 }
             }),
         ).subscribe();
@@ -343,11 +346,19 @@ export class TurnosPrestacionesComponent implements OnInit, OnDestroy {
     }
 
     selectPrestacion(item, $event) {
+        let prestacionesSelected = [];
         this.accion$.next({ type: 'select', value: $event.value, key: item.key });
+        Object.values(this.selectPrestaciones$.getValue()).map(element => {
+            if (element) {
+                prestacionesSelected.push(element);
+            }
+        });
+        this.showHint = prestacionesSelected.length > this.prestacionesMax;
     }
 
     selectAll($event) {
         this.accion$.next({ type: 'select-all', value: $event.value });
+        this.showHint = Object.values(this.selectPrestaciones$.getValue()).length > this.prestacionesMax;
     }
 
     mostrarPendientes() {

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -346,13 +346,8 @@ export class TurnosPrestacionesComponent implements OnInit, OnDestroy {
     }
 
     selectPrestacion(item, $event) {
-        let prestacionesSelected = [];
         this.accion$.next({ type: 'select', value: $event.value, key: item.key });
-        Object.values(this.selectPrestaciones$.getValue()).map(element => {
-            if (element) {
-                prestacionesSelected.push(element);
-            }
-        });
+        const prestacionesSelected = Object.values(this.selectPrestaciones$.getValue()).filter(element => element);
         this.showHint = prestacionesSelected.length > this.prestacionesMax;
     }
 

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -59,7 +59,7 @@
                 <plex-button *ngIf="!showHint" label="Exportar" size="sm" type="success" (click)="exportPrestaciones()"
                              [disabled]="!state.enableExport"></plex-button>
                 <plex-button *ngIf="showHint" label="Exportar" size="sm" type="success" (click)="exportPrestaciones()"
-                             [disabled]="true" hint="El máximo permitido de prestaciones es de {{prestacionesMax}}"
+                             class="disabled" hint="El máximo permitido de prestaciones es de {{prestacionesMax}}"
                              hintType="warning" hintIcon="lock" detach="top">
                 </plex-button>
                 <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block" [right]="true"

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -56,10 +56,14 @@
         <!-- Resultados -->
         <ng-container *ngIf="state$ | async as state">
             <plex-title titulo="Listado" size="sm">
-                <plex-button label="Exportar" size="sm" type="success" class="mr-2" (click)="exportPrestaciones()"
-                             [disabled]="!state.enableExport">
+                <plex-button *ngIf="!showHint" label="Exportar" size="sm" type="success" (click)="exportPrestaciones()"
+                             [disabled]="!state.enableExport"></plex-button>
+                <plex-button *ngIf="showHint" label="Exportar" size="sm" type="success" (click)="exportPrestaciones()"
+                             [disabled]="true" hint="El máximo permitido de prestaciones es de {{prestacionesMax}}"
+                             hintType="warning" hintIcon="lock" detach="top">
                 </plex-button>
-                <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block" [right]="true">
+                <plex-dropdown icon="format-list-checks" type="info" size="sm" class="d-inline-block" [right]="true"
+                               class="ml-2">
                     <plex-grid cols="3">
                         <plex-bool label="Fecha" [(ngModel)]="columnas.fecha">
                         </plex-bool>
@@ -174,7 +178,8 @@
                                     {{busqueda.financiador ? busqueda.financiador.nombre : 'No posee'}}
                                 </td>
                                 <td *ngIf="sumarB">
-                                    {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin Comprobante'}}
+                                    {{busqueda.estadoFacturacion? busqueda.estadoFacturacion?.estado: 'Sin
+                                    Comprobante'}}
                                 </td>
                             </tr>
                         </tbody>
@@ -274,7 +279,8 @@
                 <div class="col">
 
                     <div *ngIf="prestacion.prestacion">
-                        <label>Tipo de prestación</label>{{prestacion.prestacion?.term}}</div>
+                        <label>Tipo de prestación</label>{{prestacion.prestacion?.term}}
+                    </div>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-74

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agregó un máximo permitido de 500 prestaciones al momento de exportar las mismas desde el buscador de turnos y prestaciones
2. Si ocurre que un usuario selecciono mas de 500 prestaciones, el botón exportar quedara deshabilitado mostrando un hint que indica el numero máximo permitido de prestaciones.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

![imagen](https://user-images.githubusercontent.com/56874534/109820607-ed285b80-7c13-11eb-880a-201698a033bc.png)
