### PR TITLE
feat(inscripcion): agrega control de edad mayor a 18 en grupos faltantes

### DIFF
--- a/src/app/apps/vacunacion/components/inscripcion.component.ts
+++ b/src/app/apps/vacunacion/components/inscripcion.component.ts
@@ -160,7 +160,7 @@ export class InscripcionComponent implements OnInit {
                 case 'personal-salud':
                 case 'policia':
                     this.fechaMinimaNacimiento = moment('1900-01-01').toDate();
-                    this.fechaMaximaNacimiento = moment().add(1, 'hour').toDate();
+                    this.fechaMaximaNacimiento = moment().subtract(18, 'years').toDate();
                     break;
                 case 'factores-riesgo': {
                     this.fechaMinimaNacimiento = moment().subtract(59, 'years').toDate();


### PR DESCRIPTION
### Requerimiento
Agrega control de edad mayor a 18 en fecha de nacimiento para los grupos policia y personal de salud que no tenían el control.
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega control en grupos

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
