### PR TITLE
FICHA-EPIDEMIOLÓGICA: Enviar datos de la ficha epidemiológica a MPI

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -18,7 +18,9 @@
                             Agregar contacto</plex-button>
                     </plex-title>
                     <ng-template #notContactos>
-                        <plex-title titulo="{{seccion.name}}" size="sm">
+                        <plex-title titulo="{{seccion.name}} {{seccion.name==='Mpi'? ' ( última actualización: ' + 
+                        (paciente.updatedAt ? (paciente.updatedAt | date: 'dd/MM/yyyy - HH:mm') :
+                         (paciente.createdAt | date: 'dd/MM/yyyy - HH:mm') ) + ')': '' }}" size="sm">
                         </plex-title>
                     </ng-template>
                     <plex-grid>

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -51,6 +51,12 @@
                             <plex-bool *ngSwitchCase="'boolean'" [label]="field.label?field.label:field.key" grow="auto"
                                        name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                        [required]="field.required" [readonly]="!editFicha"></plex-bool>
+                            <plex-select *ngSwitchCase="'snomed'" [label]="field.label?field.label:field.key"
+                                         grow="auto" name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
+                                         labelField="fsn" idField="conceptId" [required]="field.required"
+                                         placeholder="Ingrese concepto..."
+                                         (getData)="getSnomed(field.snomedCodeOrQuery,$event)" [readonly]="!editFicha">
+                            </plex-select>
                             <!--Campos opcionales exclusivos de la ficha covid-->
 
                             <!--MPI-->

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -448,40 +448,26 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   }
 
   setMpiPaciente(contactosPaciente) {
-    const nuevoContacto = contactosPaciente.findIndex(elem => (Object.keys(elem))[0] === 'telefonocaso');
-    if (nuevoContacto >= 0) {
-      this.addContactoMpi('celular', Object.values(contactosPaciente[nuevoContacto])[0]);
-    }
-    const dirPaciente = contactosPaciente.findIndex(elem => (Object.keys(elem))[0] === 'direccioncaso');
-    const provinciaPaciente = contactosPaciente.findIndex(elem => (Object.keys(elem))[0] === 'lugarresidencia');
-    const localidadPaciente = contactosPaciente.findIndex(elem => (Object.keys(elem))[0] === 'localidadresidencia');
-    if (dirPaciente >= 0 || provinciaPaciente >= 0 || localidadPaciente >= 0) {
-      const nuevaLocalidad = Object.values(contactosPaciente[localidadPaciente])[0];
-      const nuevaProvincia = Object.values(contactosPaciente[provinciaPaciente])[0];
-      const nuevaDireccion = {
-        valor: dirPaciente >= 0 ? Object.values(contactosPaciente[dirPaciente])[0]?.toString() : null,
-        ultimaActualizacion: new Date(),
-        activo: true,
-        ubicacion: {
-          localidad: nuevaLocalidad ? {
-            id: nuevaLocalidad['id'],
-            nombre: nuevaLocalidad['nombre'],
-          } : null,
-          provincia: nuevaProvincia ? {
-            id: nuevaProvincia['id'],
-            nombre: nuevaProvincia['nombre'],
-          } : null,
-          barrio: null,
-          pais: null
-        },
-        codigoPostal: '',
-        ranking: 0,
-        geoReferencia: null
-      };
-      this.paciente.direccion[0] = nuevaDireccion.ubicacion.localidad?.id ||
-        nuevaDireccion.ubicacion.provincia?.id ||
-        nuevaDireccion.valor ? nuevaDireccion : this.paciente.direccion[0];
-    }
+    const nuevoContacto = contactosPaciente.find(elem => (Object.keys(elem))[0] === 'telefonocaso');
+    this.addContactoMpi('celular', nuevoContacto.telefonocaso);
+    const dirPaciente = contactosPaciente.find(elem => (Object.keys(elem))[0] === 'direccioncaso');
+    const provinciaPaciente = contactosPaciente.find(elem => (Object.keys(elem))[0] === 'lugarresidencia');
+    const localidadPaciente = contactosPaciente.find(elem => (Object.keys(elem))[0] === 'localidadresidencia');
+    const nuevaDireccion = {
+      valor: dirPaciente.direccioncaso,
+      ultimaActualizacion: new Date(),
+      activo: true,
+      ubicacion: {
+        localidad: localidadPaciente.localidadresidencia,
+        provincia: provinciaPaciente.lugarresidencia,
+        barrio: null,
+        pais: null
+      },
+      codigoPostal: '',
+      ranking: 0,
+      geoReferencia: null
+    };
+    this.paciente.direccion[0] = nuevaDireccion;
     this.servicePaciente.save(this.paciente).subscribe();
   }
 

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
@@ -71,6 +71,7 @@ export class FichaEpidemiologicaComponent implements OnInit {
           this.snomedService.getQuery({ expression: element.snomedCode }).subscribe(res => {
             this.itemsDropdownFichas.push({
               'label': res[0] ? res[0].fsn : element.name, handler: () => {
+                this.selectedForm = element;
                 this.mostrarFicha(element.name);
               }
             });
@@ -78,6 +79,7 @@ export class FichaEpidemiologicaComponent implements OnInit {
         } else {
           this.itemsDropdownFichas.push({
             'label': element.name, handler: () => {
+              this.selectedForm = element;
               this.mostrarFicha(element.name);
             }
           });

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
@@ -70,7 +70,7 @@ export class FichaEpidemiologicaComponent implements OnInit {
         if (element.snomedCode) {
           this.snomedService.getQuery({ expression: element.snomedCode }).subscribe(res => {
             this.itemsDropdownFichas.push({
-              'label': res[0].fsn, handler: () => {
+              'label': res[0] ? res[0].fsn : element.name, handler: () => {
                 this.mostrarFicha(element.name);
               }
             });

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
@@ -6,6 +6,7 @@ import { FormsEpidemiologiaService } from '../../services/ficha-epidemiologia.se
 import { Observable, of } from 'rxjs';
 import { Router } from '@angular/router';
 import { Auth } from '@andes/auth';
+import { SnomedService } from 'src/app/apps/mitos/services/snomed.service';
 
 @Component({
   selector: 'app-ficha-epidemiologica',
@@ -47,7 +48,8 @@ export class FichaEpidemiologicaComponent implements OnInit {
     private formsService: FormsService,
     private formEpidemiologiaService: FormsEpidemiologiaService,
     private router: Router,
-    private auth: Auth
+    private auth: Auth,
+    private snomedService: SnomedService
   ) { }
 
   ngOnInit(): void {
@@ -65,12 +67,22 @@ export class FichaEpidemiologicaComponent implements OnInit {
 
     this.formsService.search().subscribe(fichas => {
       fichas.forEach(element => {
-        this.itemsDropdownFichas.push({
-          'label': element.name, handler: () => {
-            this.selectedForm = element;
-            this.mostrarFicha(element.name);
-          }
-        });
+        if (element.snomedCode) {
+          this.snomedService.getQuery({ expression: element.snomedCode }).subscribe(res => {
+            this.itemsDropdownFichas.push({
+              'label': res[0].fsn, handler: () => {
+                this.mostrarFicha(element.name);
+              }
+            });
+          });
+        } else {
+          this.itemsDropdownFichas.push({
+            'label': element.name, handler: () => {
+              this.mostrarFicha(element.name);
+            }
+          });
+        }
+
       });
     });
     this.permisoHuds = this.auth.check('huds:visualizacionHuds');


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-21
https://proyectos.andes.gob.ar/browse/EP-35
- Agregar la posibilidad de enviar conceptos snomed a la ficha epidemiológica.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Dado un código snomed ingresado en la creación de un nuevo formulario se obtiene el concepto y se muestra en el dropdown de selección de fichas.
2. Dado un campo de tipo snomed donde se ingrese una query snomed se obtiene el resultado de dicha query y se agregan los resultados en un plex-select.
3. Se actualiza en MPI el dato del campo telefónico ingresado en la ficha.
4. Se realiza la carga inicial de los datos del domicilio del paciente, obtenidos de MPI, si se realizan modificaciones de estos campos en la ficha, se actualizan estos datos en el documento de la base de datos del paciente.
5. Se agrega en el titulo de la sección MPI la informacion de la ultima actualización del paciente para que sirva como ayuda al momento de crear una nueva ficha. Si el paciente fue cargado recientemente, no es necesario modificar los campos MPI.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/andes-test-integracion/pull/341
- [ ] No

