### PR TITLE
fix(gestor-agendas): agrega aria-label en botoneras

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,9 @@
       }
     },
     "@andes/plex": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@andes/plex/-/plex-7.14.1.tgz",
-      "integrity": "sha512-aUuTlxOiclexCDFWZk8nMptBwCbuKNTIArPQ8/xrGITrQ8ouFvFfc18D89A5JBFQz5Y1Tv/bL74vqtiabvM1bQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@andes/plex/-/plex-7.15.0.tgz",
+      "integrity": "sha512-SNKJtJgGE896EJtlP4UgOzm1bxZ+9ipttJh9WBBZyPuvSsjzuXayV9CrANC8G4Gdg+/WilzHWaR/E/KAPtXvjg==",
       "requires": {
         "@andes/icons": "^1.1.10",
         "@mdi/font": "^5.0.45",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@agm/core": "^1.0.0-beta.5",
     "@andes/icons": "^1.1.13",
     "@andes/match": "^1.1.12",
-    "@andes/plex": "^7.14.1",
+    "@andes/plex": "^7.15.0",
     "@angular/animations": "9.1.12",
     "@angular/cdk": "^9.2.4",
     "@angular/common": "9.1.12",

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.html
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.html
@@ -1,60 +1,69 @@
 <div *ngIf="cantidadSeleccionadas > 0">
     <span *ngIf="vistaBotones.editarAgenda">
-        <plex-button icon="pencil" (click)="editarAgenda()" title="Editar">
+        <plex-button ariaLabel="editar agenda" icon="pencil" (click)="editarAgenda()" title="Editar">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.pasarDisponibleAgenda">
-        <plex-button type="success" icon="arrow-up-bold-circle-outline" (click)="actualizarEstado( 'disponible' )"
-                     title="Cambiar a disponible">
+        <plex-button ariaLabel="pasar agenda a disponible" type="success" icon="arrow-up-bold-circle-outline"
+                     (click)="actualizarEstado( 'disponible' )" title="Cambiar a disponible">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.publicarAgenda">
-        <plex-button type="success" icon="arrow-up-bold-circle" (click)="actualizarEstado( 'publicada' )"
-                     title="Publicar">
+        <plex-button ariaLabel="publicar agenda" type="success" icon="arrow-up-bold-circle"
+                     (click)="actualizarEstado( 'publicada' )" title="Publicar">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.borrarAgenda">
-        <plex-button type="danger" icon="delete" (click)="actualizarEstado( 'borrada' )" title="Borrar">
+        <plex-button ariaLabel="borrar agenda" type="danger" icon="delete" (click)="actualizarEstado( 'borrada' )"
+                     title="Borrar">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.suspenderAgenda">
-        <plex-button type="danger" icon="stop" (click)="actualizarEstado( 'suspendida' )" title="Suspender">
+        <plex-button ariaLabel="suspender agenda" type="danger" icon="stop" (click)="actualizarEstado( 'suspendida' )"
+                     title="Suspender">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.pausarAgenda">
-        <plex-button type="warning" icon="pause" (click)="actualizarEstado( 'pausada' )" title="Pausar">
+        <plex-button ariaLabel="pausar agenda" type="warning" icon="pause" (click)="actualizarEstado( 'pausada' )"
+                     title="Pausar">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.reasignarTurnos">
-        <plex-button type="info" icon="sync-alert" (click)="reasignarTurnos()" title="Reasignación de Turnos">
+        <plex-button ariaLabel="reasignar turnos" type="info" icon="sync-alert" (click)="reasignarTurnos()"
+                     title="Reasignación de Turnos">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.clonarAgenda">
-        <plex-button icon="content-copy" (click)="clonarAgenda()" title="Clonar">
+        <plex-button ariaLabel="clonar agenda" icon="content-copy" (click)="clonarAgenda()" title="Clonar">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.reanudarAgenda">
-        <plex-button type="success" icon="play" (click)="actualizarEstado( 'prePausada' )" title="Reanudar">
+        <plex-button ariaLabel="reanudar agenda" type="success" icon="play" (click)="actualizarEstado( 'prePausada' )"
+                     title="Reanudar">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.agregarNota">
-        <plex-button icon="comment-outline" (click)="agregarNotaAgenda()" title="Agregar una nota">
+        <plex-button ariaLabel="agregar nota" icon="comment-outline" (click)="agregarNotaAgenda()"
+                     title="Agregar una nota">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.agregarSobreturno">
-        <plex-button icon="account-plus" (click)="agregarSobreturno()" title="Agregar Sobreturno">
+        <plex-button ariaLabel="agregar sobreturno" icon="account-plus" (click)="agregarSobreturno()"
+                     title="Agregar Sobreturno">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.revisionAgenda">
-        <plex-button icon="format-list-checks" (click)="revisionAgenda()" title="Revisión de Agenda">
+        <plex-button ariaLabel="revisión de agenda" icon="format-list-checks" (click)="revisionAgenda()"
+                     title="Revisión de Agenda">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.listarTurnos">
-        <plex-button icon="printer" (click)="listarTurnos()" title="Imprimir">
+        <plex-button ariaLabel="imprimir listado de turnos" icon="printer" (click)="listarTurnos()" title="Imprimir">
         </plex-button>
     </span>
     <span *ngIf="vistaBotones.listarCarpetas">
-        <plex-button icon="folder-account" (click)="listarCarpetas()" title="Imprimir carpetas">
+        <plex-button ariaLabel="listar carpetas" icon="folder-account" (click)="listarCarpetas()"
+                     title="Imprimir carpetas">
         </plex-button>
     </span>
 </div>

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -6,7 +6,7 @@
                 <header>
                     <plex-title titulo="Bloques y turnos" size="sm">
                         <plex-badge [type]="estadosAgenda[agenda.estado]?.class">{{
-                        estadosAgenda[agenda.estado]?.nombre }}</plex-badge>
+                            estadosAgenda[agenda.estado]?.nombre }}</plex-badge>
                         <plex-help type="help" icon="information-variant" titulo="Detalle de agenda">
                             <div class="container mb-4">
                                 <div class="row">
@@ -16,10 +16,12 @@
                                 </div>
                                 <div class="row">
                                     <div class="col-12">
-                                        <label>Fecha</label> {{ agenda.horaInicio | date: 'EEE' | uppercase }} {{ agenda.horaInicio
-                                    | date:
-                                    'dd/MM/yyyy'}}, {{ agenda.horaInicio | date: 'HH:mm'}} a {{ agenda.horaFin | date:
-                                    'HH:mm'}} hs
+                                        <label>Fecha</label> {{ agenda.horaInicio | date: 'EEE' | uppercase }} {{
+                                        agenda.horaInicio
+                                        | date:
+                                        'dd/MM/yyyy'}}, {{ agenda.horaInicio | date: 'HH:mm'}} a {{ agenda.horaFin |
+                                        date:
+                                        'HH:mm'}} hs
                                     </div>
                                 </div>
                                 <div class="row">
@@ -47,7 +49,8 @@
                                     <div class="col-12">
                                         <label>Espacio físico</label>
                                         <span
-                                              *ngIf="agenda.espacioFisico?.nombre || agenda.otroEspacioFisico?.nombre">{{agenda | espacioFisico}}</span>
+                                              *ngIf="agenda.espacioFisico?.nombre || agenda.otroEspacioFisico?.nombre">{{agenda
+                                            | espacioFisico}}</span>
                                         <span *ngIf="!agenda.espacioFisico?.nombre && !agenda.otroEspacioFisico?.nombre"
                                               class="text-danger">Espacio físico no
                                             asignado</span>
@@ -87,30 +90,36 @@
                 </td>
                 <td colspan="3" class="text-right">
                     <div *ngIf="turnosSeleccionados.length > 0">
-                        <plex-button *ngIf="botones.sacarAsistencia" type="warning" icon="account-remove"
-                                     (click)="eventosTurno('sacarAsistencia')" title="Registrar inasistencia">
+                        <plex-button *ngIf="botones.sacarAsistencia" ariaLabel="Registrar inasistencia" type="warning"
+                                     icon="account-remove" (click)="eventosTurno('sacarAsistencia')"
+                                     title="Registrar inasistencia">
                         </plex-button>
-                        <plex-button *ngIf="botones.darAsistencia" type="success" icon="account-check"
-                                     (click)="eventosTurno('darAsistencia')" title="Registrar asistencia"></plex-button>
-                        <plex-button *ngIf="botones.reasignarTurno" type="default" icon="account-switch"
-                                     (click)="reasignarTurno(turno.paciente, turno.id, agenda.id)"
+                        <plex-button *ngIf="botones.darAsistencia" ariaLabel="Registrar asistencia" type="success"
+                                     icon="account-check" (click)="eventosTurno('darAsistencia')"
+                                     title="Registrar asistencia"></plex-button>
+                        <plex-button *ngIf="botones.reasignarTurno" ariaLabel="Reasignar turno" type="default"
+                                     icon="account-switch" (click)="reasignarTurno(turno.paciente, turno.id, agenda.id)"
                                      title="Reasignar turno">
                         </plex-button>
-                        <plex-button *ngIf="botones.turnoDoble" type="default" icon="numeric-2-box-multiple-outline"
-                                     (click)="asignarTurnoDoble('darTurnoDoble')" title="Turno doble"></plex-button>
-                        <plex-button *ngIf="botones.quitarTurnoDoble" type="default" icon="numeric-1-box-outline"
-                                     (click)="eventosTurno('quitarTurnoDoble')" title="Quitar Turno doble">
+                        <plex-button *ngIf="botones.turnoDoble" ariaLabel="Turno doble" type="default"
+                                     icon="numeric-2-box-multiple-outline" (click)="asignarTurnoDoble('darTurnoDoble')"
+                                     title="Turno doble"></plex-button>
+                        <plex-button *ngIf="botones.quitarTurnoDoble" ariaLabel="Quitar Turno doble" type="default"
+                                     icon="numeric-1-box-outline" (click)="eventosTurno('quitarTurnoDoble')"
+                                     title="Quitar Turno doble">
                         </plex-button>
-                        <plex-button *ngIf="botones.editarCarpeta" type="default" icon="folder-account"
-                                     (click)="editarCarpetaPaciente()" title="Editar Número de Carpeta"></plex-button>
-                        <plex-button *ngIf="botones.nota" type="default" icon="comment-outline"
+                        <plex-button *ngIf="botones.editarCarpeta" ariaLabel="Editar Número de Carpeta" type="default"
+                                     icon="folder-account" (click)="editarCarpetaPaciente()"
+                                     title="Editar Número de Carpeta"></plex-button>
+                        <plex-button *ngIf="botones.nota" ariaLabel="Agregar nota" type="default" icon="comment-outline"
                                      (click)="agregarNotaTurno()" title="Agregar nota"></plex-button>
-                        <plex-button *ngIf="botones.sms" type="default" icon="email-outline" (click)="enviarSMS()"
-                                     title="Enviar un mensaje al paciente"></plex-button>
-                        <plex-button *ngIf="botones.liberarTurno" type="danger" icon="account-off" title="Liberar turno"
-                                     (click)="liberarTurno()"></plex-button>
-                        <plex-button *ngIf="botones.suspenderTurno" type="danger" icon="stop" title="Suspender turno"
-                                     (click)="suspenderTurno(agenda)"></plex-button>
+                        <plex-button *ngIf="botones.sms" ariaLabel="Enviar un mensaje al paciente" type="default"
+                                     icon="email-outline" (click)="enviarSMS()" title="Enviar un mensaje al paciente">
+                        </plex-button>
+                        <plex-button *ngIf="botones.liberarTurno" ariaLabel="Liberar turno" type="danger"
+                                     icon="account-off" title="Liberar turno" (click)="liberarTurno()"></plex-button>
+                        <plex-button *ngIf="botones.suspenderTurno" ariaLabel="Suspender turno" type="danger"
+                                     icon="stop" title="Suspender turno" (click)="suspenderTurno(agenda)"></plex-button>
                     </div>
                 </td>
             </tr>
@@ -180,7 +189,8 @@
                                             <div class="col d-flex align-items-start px-2">
                                                 <span>
                                                     <h2 class="text-info">
-                                                        {{bloque.accesoDirectoProgramado ? bloque.accesoDirectoProgramado : 0}}
+                                                        {{bloque.accesoDirectoProgramado ?
+                                                        bloque.accesoDirectoProgramado : 0}}
                                                     </h2>
                                                     <span class="small">Turnos <br><b>programados</b></span>
                                                     <small *ngIf="bloque.cupoMobile"><br>
@@ -191,7 +201,8 @@
                                             <div class="col d-flex align-items-start px-2">
                                                 <span>
                                                     <h2 class="text-info">
-                                                        {{bloque.reservadoProfesional ? bloque.reservadoProfesional : 0}}
+                                                        {{bloque.reservadoProfesional ? bloque.reservadoProfesional :
+                                                        0}}
                                                     </h2>
                                                     <span class="small">Turnos <br><b>profesional</b></span>
                                                 </span>


### PR DESCRIPTION
### Requerimiento
[https://proyectos.andes.gob.ar/browse/CIT-109](https://proyectos.andes.gob.ar/browse/CIT-109)

### Contexto
Imposibilidad de percibir con lector de pantalla, determinados elementos de la interfaz del gestor de agendas, especialmente en botones sin texto (acciones iconográficas al seleccionar una agenda).

### Necesario para testear
1. Descargar el [lector de pantalla NVDA](https://nvda.es/descargas/descarga-de-nvda/) (sólo windows, sino alguno para Linux: se sugiere [ORCA](https://wiki.gnome.org/Projects/Orca))
2. Instalar [plex v7.15.0](https://github.com/andes/plex/releases/tag/v7.15.0) (npm i @andes/plex@latest)

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega atributo ariaLabel a todos los `<plex-button>` con atributo 'icon' de modo que al pasar el screen-reader describa la acción que representa el icono en cuestión. 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
