### PR TITLE
feat(mpi): Se invoca al servicio de link con la nueva ruta

### DIFF
--- a/src/app/core/mpi/services/paciente.service.ts
+++ b/src/app/core/mpi/services/paciente.service.ts
@@ -1,10 +1,10 @@
-import { Observable, combineLatest } from 'rxjs';
-import { IPaciente } from '../interfaces/IPaciente';
-import { Injectable } from '@angular/core';
-import { Server } from '@andes/shared';
-import { IPacienteMatch } from '../../../modules/mpi/interfaces/IPacienteMatch.inteface';
-import { map } from 'rxjs/operators';
 import { Plex } from '@andes/plex';
+import { Server } from '@andes/shared';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { IPacienteMatch } from '../../../modules/mpi/interfaces/IPacienteMatch.inteface';
+import { IPaciente } from '../interfaces/IPaciente';
 
 @Injectable()
 export class PacienteService {
@@ -99,17 +99,7 @@ export class PacienteService {
      */
     linkPatient(pacienteBase: IPaciente, pacienteLink: IPaciente): Observable<IPaciente[]> {
         if (pacienteBase && pacienteBase.id && pacienteLink && pacienteLink.id) {
-            const dataLink = {
-                entidad: 'ANDES',
-                valor: pacienteLink.id
-            };
-            if (pacienteBase.identificadores) {
-                pacienteBase.identificadores.push(dataLink);
-            } else {
-                pacienteBase.identificadores = [dataLink];
-            }
-            pacienteLink.activo = false;
-            return combineLatest([this.patch(pacienteBase.id, pacienteBase), this.setActivo(pacienteLink, false)]);
+            return this.server.patch(`${this.pacienteV2}/link/${pacienteBase.id}`, { pacienteLink, op: 'link' });
         }
         return;
     }
@@ -124,8 +114,9 @@ export class PacienteService {
             if (pacienteBase.identificadores) {
                 pacienteBase.identificadores = (pacienteBase.identificadores.filter((x) => x.valor !== pacienteLink.id));
             }
-            return combineLatest(this.patch(pacienteBase.id, pacienteBase), this.setActivo(pacienteLink, true));
+            return this.server.patch(`${this.pacienteV2}/link/${pacienteBase.id}`, { pacienteLink, op: 'unlink' });
         }
         return;
     }
+
 }


### PR DESCRIPTION
1. Se agrega una nueva ruta de patch para poder manejar las vinculaciones y desvinculaciones de pacientes.
2. Toda la lógica de desactivar paciente temporal y agregar la viculación se realiza en la api y se quita de la app.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si  https://github.com/andes/api/pull/1364
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No


