### PR TITLE
VAC: en la columna certificado deberá decir "No corresponde" si es factores-riesgo y tiene entre 57 y 59 años

### DIFF
--- a/src/app/apps/vacunacion/components/listado-inscriptos.component.ts
+++ b/src/app/apps/vacunacion/components/listado-inscriptos.component.ts
@@ -149,7 +149,7 @@ export class ListadoInscriptosVacunacionComponent implements OnInit {
             this.pacienteSelected = paciente;
             this.showSidebar = true;
             this.showDetalle = true;
-            this.mainSize = 8;
+            this.mainSize = 9;
             this.candidatosBuscados = false;
             this.editando = false;
             this.showAgregarNota = false;

--- a/src/app/apps/vacunacion/components/listado-inscriptos.html
+++ b/src/app/apps/vacunacion/components/listado-inscriptos.html
@@ -41,11 +41,12 @@
                     </plex-label>
                 </td>
                 <td *plTableCol="'certificado'">
-                    <plex-label *ngIf="paciente.grupo.nombre === 'factores-riesgo'"
+                    <plex-label *ngIf="paciente.grupo.nombre === 'factores-riesgo' && !paciente.factorRiesgoEdad"
                                 type="{{ paciente.idPrestacionCertificado ? 'success' : 'danger' }}" titulo=""
                                 subtitulo="" icon="{{ paciente.idPrestacionCertificado ? 'check' : 'close' }}">
                     </plex-label>
-                    <plex-label *ngIf="paciente.grupo.nombre !== 'factores-riesgo'">No corresponde
+                    <plex-label *ngIf="paciente.grupo.nombre !== 'factores-riesgo' || paciente.factorRiesgoEdad">No
+                        corresponde
                     </plex-label>
                 </td>
             </tr>


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/VAC-68

### Funcionalidad desarrollada 
1. En la columna certificado si es de factores-riesgo y tiene entre 57 y 59 años mostrar 'No corresponde'

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si https://github.com/andes/api/pull/1382
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si - https://github.com/andes/andes-test-integracion/pull/356
- [ ] No
