### PR TITLE
BI-QUERIES: Agrega select-static

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -105,14 +105,6 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
     { id: 'completa', nombre: 'Completa' },
     { id: 'incompleta', nombre: 'Incompleta' }
   ];
-  public tipoConglomerado = [
-    { id: 'hospital', nombre: 'Hospital/Clínica/Centro asistencial' },
-    { id: 'penitenciaria', nombre: 'Institución penitenciaria' },
-    { id: 'saludMental', nombre: 'Institución de Salud Mental' },
-    { id: 'residenciaMayores', nombre: 'Residencia para adultos mayores' },
-    { id: 'empresas', nombre: 'Empresas' },
-    { id: 'instituciones', nombre: 'Instituciones educativas/Instituciones de asistencia infantil (jardín, guarderías, etc)' }
-  ];
   public reqCuidado = [
     { id: 'ambulatorio', nombre: 'Ambulatorio' },
     { id: 'salaGeneral', nombre: 'Internación Sala General' },

--- a/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.html
+++ b/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.html
@@ -46,23 +46,15 @@
                                      [required]="argumento.required" labelField="nombreCompleto"
                                      (getData)="loadProfesionales($event)">
                         </plex-select>
-                        <plex-select *ngSwitchCase="'estadoAgenda'"
-                                     [label]="argumento.label?argumento.label:argumento.key" grow=" 2"
+                        <plex-select *ngSwitchCase="'select-static'"
+                                     [label]="argumento.label?argumento.label:argumento.key" grow="auto"
                                      name="{{ argumento.key }}" [(ngModel)]="argumentos[argumento.key]"
-                                     [required]="argumento.required" labelField="nombre"
-                                     (getData)="loadEstadosAgenda($event)">
-                        </plex-select>
-                        <plex-select *ngSwitchCase="'estadoTurno'"
-                                     [label]="argumento.label?argumento.label:argumento.key" grow=" 2"
-                                     name="{{ argumento.key }}" [(ngModel)]="argumentos[argumento.key]"
-                                     [required]="argumento.required" labelField="nombre"
-                                     (getData)="loadEstadosTurno($event)">
+                                     [required]="argumento.required" [data]="argumento.items">
                         </plex-select>
                         <plex-select *ngSwitchCase="'formsEpidemiologia'"
                                      [label]="argumento.label?argumento.label:argumento.key" grow=" 2"
                                      name="{{ argumento.key }}" [(ngModel)]="argumentos[argumento.key]"
-                                     [required]="argumento.required" labelField="type" 
-                                     (getData)="loadFomTypes($event)">
+                                     [required]="argumento.required" labelField="type" (getData)="loadFomTypes($event)">
                         </plex-select>
                     </ng-container>
                 </plex-wrapper>

--- a/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.ts
+++ b/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.ts
@@ -70,31 +70,6 @@ export class BiQueriesComponent implements OnInit {
         }
     }
 
-    loadEstadosAgenda(event) {
-        const estadosAgendas = [
-            { id: 'planificacion', nombre: 'Planificación' },
-            { id: 'disponible', nombre: 'Disponible' },
-            { id: 'publicada', nombre: 'Publicada' },
-            { id: 'suspendida', nombre: 'Suspendida' },
-            { id: 'pausada', nombre: 'Pausada' },
-            { id: 'pendienteAsistencia', nombre: 'Pendiente Asistencia' },
-            { id: 'pendienteAuditoria', nombre: 'Pendiente Auditoría' },
-            { id: 'auditada', nombre: 'Auditada' },
-            { id: 'borrada', nombre: 'Borrada' }
-        ];
-        event.callback(estadosAgendas);
-    }
-
-    loadEstadosTurno(event) {
-        const estadosTurnos = [
-            { id: 'disponible', nombre: 'Disponible' },
-            { id: 'asignado', nombre: 'Asignado' },
-            { id: 'suspendido', nombre: 'Suspendido' },
-            { id: 'turnoDoble', nombre: 'Turno Doble' }
-        ];
-        event.callback(estadosTurnos);
-    }
-
     loadFomTypes(event) {
         this.formsService.search().subscribe(res => event.callback(res));
     }


### PR DESCRIPTION
### Requerimiento
Agregar la opción de agregar argumentos de tipo "select-static" en las bi-queries para que al momento de necesitar algún select con opciones "estáticas" se puedan agregar desde la base de datos y no modificar el componente.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega al html de bi-queries el caso "select-static" para que cuando venga un argumento de este tipo, lo muestre como un select con las opciones ingresadas en el array "items" del argumento.
2. Se agregan el argumento en las queries que usaban select de tipo estáticos.
3. Se eliminan del componente los arrays que se usaban en los select.
4. Elimino array en desuso de la ficha epidemiológica.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si **Modificar las queries: Fichas epidemiologicas, Turnos y Agendas con las adjuntas**
- [ ] No

[agendas.txt](https://github.com/andes/app/files/6467884/agendas.txt)
[turnos.txt](https://github.com/andes/app/files/6467885/turnos.txt)

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

