### PR TITLE
BUSCADOR EPIDEMIO: Fix doble request

### DIFF
--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -47,8 +47,8 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
   public codigoSISAEdit;
   public codigoSisa;
   public registroSisaOpts = [
-    { id: 'noSISA', nombre: 'Sin registro SISA'},
-    { id: 'SISA', nombre: 'Con registro SISA'},
+    { id: 'noSISA', nombre: 'Sin registro SISA' },
+    { id: 'SISA', nombre: 'Con registro SISA' },
   ];
   public filtrarSISA;
 
@@ -115,15 +115,9 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
       { route: '/', name: 'EPIDEMIOLOGIA' },
       { name: 'Buscador Fichas epidemiologicas' }
     ]);
-    this.dataType$ = this.formsService.search().pipe(
-      cache()
-    );
-    this.localidades$ = this.localidadService.get({ codigo: 15 }).pipe(
-      cache()
-    );
-    this.zonaSanitaria$ = this.zonaSanitariaService.search().pipe(
-      cache()
-    );
+    this.dataType$ = this.formsService.search();
+    this.localidades$ = this.localidadService.get({ codigo: 15 });
+    this.zonaSanitaria$ = this.zonaSanitariaService.search();
   }
 
   searchFichas() {
@@ -162,7 +156,8 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
             return this.listado;
           })
         );
-      })
+      }),
+      cache()
     );
   }
 
@@ -243,8 +238,8 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
 
     if (!seccionOperaciones) {
       seccionOperaciones = {
-        name : 'Operaciones',
-        fields : []
+        name: 'Operaciones',
+        fields: []
       };
       secciones.push(seccionOperaciones);
     }


### PR DESCRIPTION
### Requerimiento
Eliminar doble request al hacer una nueva búsqueda.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega la función cache() al observable ficha$ para evitar un doble request.
2. Se eliminan funciones cache() que están de mas. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No