### PR TITLE
FICHA EPIDEMIOLÓGICA: Nuevo campo residencias

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -88,8 +88,8 @@
                             <plex-bool *ngIf="field.key==='resideinstitucion' "
                                        [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
                                        [(ngModel)]="seccion.fields[field.key]" [required]="field.required"
-                                       [readonly]="!editFicha"
-                                       (change)="getInstituciones(false); clearDependencias($event,'mpi', ['tipoinstitucion','lugarinstitucion'])">
+                                       [readonly]="!editFicha" (change)="getInstituciones(false); clearDependencias($event,'mpi', 
+                                       ['tipoinstitucion','lugarinstitucion','otrosreside','otrosresidenombre'])">
                             </plex-bool>
                             <plex-select *ngIf="field.key==='tipoinstitucion' && seccion.fields['resideinstitucion']"
                                          [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
@@ -101,7 +101,17 @@
                                          [(ngModel)]="seccion.fields[field.key]" [readonly]="!editFicha"
                                          [data]="residencias$ | async">
                             </plex-select>
-
+                            <plex-bool *ngIf="field.key==='otrosreside' && seccion.fields['resideinstitucion'] "
+                                       [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
+                                       [(ngModel)]="seccion.fields[field.key]" [required]="field.required"
+                                       [readonly]="!editFicha"
+                                       (change)="clearDependencias($event,'mpi', ['otrosresidenombre'])">
+                            </plex-bool>
+                            <plex-text *ngIf="field.key==='otrosresidenombre' && seccion.fields['otrosreside']"
+                                       [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
+                                       [(ngModel)]="seccion.fields[field.key]" [required]="field.required"
+                                       readonly="true" [readonly]="!editFicha">
+                            </plex-text>
                             <!--Clasificación-->
                             <ng-container *ngIf="seccion.id==='clasificacion'">
                                 <plex-select *ngIf="field.key==='clasificacion' "

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -96,7 +96,7 @@
                                          [(ngModel)]="seccion.fields[field.key]" [data]="tipoInstitucion"
                                          [readonly]="!editFicha">
                             </plex-select>
-                            <plex-select *ngIf="field.key==='lugarinstitucion' && seccion.fields['resideinstitucion']"
+                            <plex-select *ngIf="field.key==='lugarinstitucion' && seccion.fields['resideinstitucion'] && !seccion.fields['otrosreside']"
                                          [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
                                          [(ngModel)]="seccion.fields[field.key]" [readonly]="!editFicha"
                                          [data]="residencias$ | async">
@@ -105,7 +105,7 @@
                                        [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
                                        [(ngModel)]="seccion.fields[field.key]" [required]="field.required"
                                        [readonly]="!editFicha"
-                                       (change)="clearDependencias($event,'mpi', ['otrosresidenombre'])">
+                                       (change)="clearDependencias({value:false},'mpi', ['otrosresidenombre','lugarinstitucion'])">
                             </plex-bool>
                             <plex-text *ngIf="field.key==='otrosresidenombre' && seccion.fields['otrosreside']"
                                        [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
@@ -216,13 +216,13 @@
 
                             <!--Información clínica-->
                             <ng-container *ngIf="seccion.id==='informacionClinica'">
-                                <plex-datetime *ngIf="field.key==='fechasintomas'"
+                                <plex-datetime *ngIf="field.key==='fechasintomas' && showSemana"
                                                [label]="field.label?field.label:field.key" grow="auto" type="date"
                                                name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                                [required]="field.required" [readonly]="!editFicha"
                                                (change)="setSemanaEpidemiologica($event)">
                                 </plex-datetime>
-                                <plex-int *ngIf="field.key==='semanaepidemiologica'"
+                                <plex-int *ngIf="field.key==='semanaepidemiologica' && showSemana"
                                           [label]="field.label?field.label:field.key" grow="auto" name="{{ field.key }}"
                                           [(ngModel)]="seccion.fields[field.key]" [required]="field.required"
                                           readonly="true">
@@ -509,7 +509,7 @@
                                            [label]="field.label?field.label:field.key" grow="auto"
                                            name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                            [readonly]="!editFicha"
-                                           (change)="clearDependencias($event,'antecedentesEpidemiologicos',['situacionespecial'])">
+                                           (change)="ocultarFuc($event); clearDependencias($event,'antecedentesEpidemiologicos',['situacionespecial'])">
                                 </plex-bool>
                                 <plex-text *ngIf="field.key==='situacionespecial' && seccion.fields['asintomaticoespecial']"
                                            [label]="field.label?field.label:field.key" grow="auto"

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -66,7 +66,8 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   public clasificacion = [
     { id: 'casoSospechoso', nombre: 'Caso sospechoso' },
     { id: 'contactoEstrecho', nombre: 'Contacto estrecho' },
-    { id: 'otrasEstrategias', nombre: 'Otras estrategias' }
+    { id: 'otrasEstrategias', nombre: 'Otras estrategias' },
+    { id: 'controlAlta', nombre: 'Control de alta' }
   ];
   public tipoBusqueda = [
     { id: 'activa', nombre: 'Activa' },
@@ -169,6 +170,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   public organizacionesInternacion$: Observable<any>;
   public vacunas$: Observable<any>;
   public estaInternado = false;
+  public showSemana = true;
 
   constructor(
     private formsService: FormsService,
@@ -224,6 +226,9 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
                 sec.fields.map(field => {
                   if (!this.editFicha && Object.keys(field)[0] === 'organizacion') {
                     this.organizaciones$ = this.organizacionService.getById(field.organizacion.id ? field.organizacion.id : field.organizacion);
+                  }
+                  if (Object.keys(field)[0] === 'asintomaticoespecial') {
+                    this.showSemana = this.secciones[buscado].fields['asintomaticoespecial'];
                   }
                   let key = Object.keys(field);
                   this.secciones[buscado].fields[key[0]] = field[key[0]];
@@ -568,7 +573,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
     this.estaInternado = event.value.id === 'salaGeneral' || event.value.id === 'uce' ||
       event.value.id === 'ut' || event.value.id === 'uti';
     if (this.estaInternado) {
-      this.organizacionesInternacion$ = this.organizacionService.get({ internaciones: true });
+      this.organizacionesInternacion$ = this.organizacionService.get({ aceptaDerivacion: true });
     }
     return this.estaInternado;
   }
@@ -616,5 +621,13 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
         seccion.fields['semanaepidemiologica'] = resultado ? resultado : '';
       }
     });
+  }
+
+  ocultarFuc(event) {
+    if (event.value) {
+      this.showSemana = false;
+    } else {
+      this.showSemana = true;
+    }
   }
 }

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -1,6 +1,5 @@
 import { Auth } from '@andes/auth';
 import { Plex } from '@andes/plex';
-import { cache } from '@andes/shared';
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -200,6 +199,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
             const buscado = this.secciones.findIndex(seccion => seccion.name === sec.name);
             if (buscado !== -1) {
               if (sec.name === 'Usuario' && this.editFicha) {
+                this.organizaciones$ = this.auth.organizaciones();
                 sec.fields.map(field => {
                   switch (Object.keys(field)[0]) {
                     case 'responsable':
@@ -222,6 +222,9 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
                 });
               } else {
                 sec.fields.map(field => {
+                  if (!this.editFicha && Object.keys(field)[0] === 'organizacion') {
+                    this.organizaciones$ = this.organizacionService.getById(field.organizacion.id ? field.organizacion.id : field.organizacion);
+                  }
                   let key = Object.keys(field);
                   this.secciones[buscado].fields[key[0]] = field[key[0]];
                 });
@@ -245,13 +248,8 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
     if (!this.auth.getPermissions('epidemiologia:?').length) {
       this.router.navigate(['inicio']);
     }
-    this.organizaciones$ = this.auth.organizaciones();
-    this.provincias$ = this.provinciaService.get({}).pipe(
-      cache()
-    );
-    this.paises$ = this.paisService.get({}).pipe(
-      cache()
-    );
+    this.provincias$ = this.provinciaService.get({});
+    this.paises$ = this.paisService.get({});
   }
 
   registrarFicha() {
@@ -369,6 +367,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   }
 
   setFields() {
+    this.organizaciones$ = this.auth.organizaciones();
     this.secciones.map(seccion => {
       switch (seccion.id) {
         case 'usuario':


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-82
https://proyectos.andes.gob.ar/browse/EP-83

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega un nuevo campo para seleccionar en el caso que la residencia donde el paciente reside no se encuentra en el combo.
2. Se modifica el modo de obtener las organizaciones en la seccion usuario para que al visualizar una ficha se muestre correctamente la misma.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si Actualizar ficha covid19 en coleccion forms.
[fichacovid.txt](https://github.com/andes/app/files/6633159/fichacovid.txt)

- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

