### PR TITLE
FICHA EPIDEMIOLOGICA: Fix secciones

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -309,7 +309,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
         });
       }
       if (campos.length) {
-        const buscado = this.ficha.findIndex(sec => sec.name === seccion.seccion);
+        const buscado = this.ficha.findIndex(sec => sec.name === seccion.name);
         if (buscado !== -1) {
           // si ya existe la sección, la reemplazo
           this.ficha[buscado] = { name: seccion.name, fields: campos };


### PR DESCRIPTION
### Requerimiento
Al crear una ficha, si el resultado del antigeno es no reactivo y no se marca ni pcr ni lamp, muestra mensaje pidiendo que se marque alguno, cuando se marca se duplican las secciones al guardar.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se cambia el campo del findIndex por el correcto


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
