### PR TITLE
Ficha Epidemiologica: Ficha parcial

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -1,6 +1,10 @@
 <plex-layout>
     <plex-layout-main>
         <plex-title titulo="Ficha {{fichaName}}" main>
+            <plex-bool class="mr-4" [(ngModel)]="showFichaParcial" label="Cargar ficha parcial"
+                       (change)="clearDependencias({value:false},'clasificacionFinal',
+            ['segundaclasificacion','tipomuestra','antigeno','lamp','pcr','identificadorpcr','pcrM','clasificacionfinal'])">
+            </plex-bool>
             <plex-button *ngIf="!hideVolver" type="danger" (click)="toBack()">Volver
             </plex-button>
             <plex-button *ngIf="editFicha" position="right" type="success" (click)="registrarFicha()">
@@ -278,8 +282,7 @@
                                 </plex-bool>
                             </ng-container>
                             <!--Clasificación y final-->
-                            <ng-container *ngIf="seccion.id==='clasificacionFinal'">
-
+                            <ng-container *ngIf="seccion.id==='clasificacionFinal' && !showFichaParcial">
                                 <plex-select *ngIf="field.key==='segundaclasificacion'"
                                              [label]="field.label?field.label:field.key" grow="auto"
                                              name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
@@ -335,6 +338,10 @@
                                            [required]="field.required" readonly="true">
                                 </plex-text>
                             </ng-container>
+                            <plex-label *ngIf="seccion.id==='clasificacionFinal' && showFichaParcial && field.key==='parcial'"
+                                        titulo="La seccion no se encuentra disponible"
+                                        subtitulo="Destilde el campo Ficha parcial para hablitar la sección">
+                            </plex-label>
                             <!--Antecedentes epidemiológicos-->
                             <ng-container *ngIf="seccion.id==='antecedentesEpidemiologicos'">
                                 <plex-select *ngIf="field.key==='personalsalud'"

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -171,6 +171,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   public vacunas$: Observable<any>;
   public estaInternado = false;
   public showSemana = true;
+  public showFichaParcial = false;
 
   constructor(
     private formsService: FormsService,

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica/ficha-epidemiologica.component.ts
@@ -127,8 +127,22 @@ export class FichaEpidemiologicaComponent implements OnInit {
     if (ficha) {
       this.fichaPaciente$ = of(ficha);
       this.getFicha(nombreFicha);
-    } else if (this.checkDias()) {
-      this.getFicha(nombreFicha);
+    } else {
+      let check = true;
+      this.fichasPaciente.subscribe(async fichas => {
+        if (fichas.length) {
+          const fichasOrdenadas = fichas.sort((a, b) => b.createdAt - a.createdAt);
+          if (moment().diff(moment(fichasOrdenadas[0].createdAt), 'days') < 14) {
+            const respuesta = await this.plex.confirm('¿ Desea crear una ficha nueva de todas formas ?', `El paciente tiene una ficha registrada el día ${moment(fichasOrdenadas[0].createdAt).format('L')}`, 'Crear nueva ficha', 'Cancelar');
+            if (!respuesta) {
+              check = false;
+            }
+          }
+        }
+        if (check) {
+          this.getFicha(nombreFicha);
+        }
+      });
     }
   }
 
@@ -147,19 +161,5 @@ export class FichaEpidemiologicaComponent implements OnInit {
     this.showFicha = null;
     this.pacienteSelected = null;
     this.resultadoBusqueda = [];
-  }
-
-  checkDias() {
-    let check = true;
-    this.fichasPaciente.subscribe(fichas => {
-      if (fichas.length) {
-        const fichasOrdenadas = fichas.sort((a, b) => b.createdAt - a.createdAt);
-        if (moment().diff(moment(fichasOrdenadas[0].createdAt), 'days') < 14) {
-          this.plex.info('warning', ' El paciente tiene una ficha registrada en los ultimos 14 días', 'No es posible crear una nueva ficha');
-          check = false;
-        }
-      }
-    });
-    return check;
   }
 }


### PR DESCRIPTION
### Requerimiento
Agregar una opción de carga parcial que oculte la sección clasificación final y modificar el aviso al momento de crear una nueva ficha si el paciente tiene otra creada en los últimos 14 días.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega plex-bool que al tildarlo oculte la sección "Clasificacion final" para poder cargar parcialmente la ficha.
2. Se modifica el cartel de aviso de ficha dentro de los 14 dias por un "confirm" para que permita de todas formas crear una nueva ficha.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si **Actualizar en la coleccion forms la ficha Covid19** 
[fichacovid.txt](https://github.com/andes/app/files/6709452/fichacovid.txt)
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
