### PR TITLE
Ficha Epidemiologica: regex pcr

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -332,7 +332,8 @@
                                 <plex-text *ngIf="field.key==='identificadorpcr' && seccion.fields['pcrM'] && seccion.fields['segundaclasificacion']?.id!=='confirmado'"
                                            [label]="field.label?field.label:field.key" grow="auto"
                                            name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
-                                           [required]="field.required" [readonly]="!editFicha"></plex-text>
+                                           [pattern]="patronPCR" [required]="field.required" [readonly]="!editFicha">
+                                </plex-text>
                                 <plex-text *ngIf="field.key==='clasificacionfinal'"
                                            [label]="field.label?field.label:field.key" grow="auto"
                                            name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -172,6 +172,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   public estaInternado = false;
   public showSemana = true;
   public showFichaParcial = false;
+  public patronPCR = '((HISOP[0-9]+$))*([0-9]+$)*';
 
   constructor(
     private formsService: FormsService,
@@ -285,7 +286,13 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
           let params = {};
           const key = arg.key;
           if (key) {
-            const valor = seccion.fields[key];
+            let valor = seccion.fields[key];
+            if (key === 'identificadorpcr') {
+              const regexHisop = new RegExp('HISOP');
+              if (valor && !regexHisop.test(valor)) {
+                valor = 'HISOP' + valor;
+              }
+            }
             if (valor !== undefined && valor !== null) {
               params[key] = valor;
               if (valor instanceof Date) {

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -172,7 +172,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   public estaInternado = false;
   public showSemana = true;
   public showFichaParcial = false;
-  public patronPCR = '((HISOP[0-9]+$))*([0-9]+$)*';
+  public patronPCR = '([A-Za-z])*([0-9]+$)+';
 
   constructor(
     private formsService: FormsService,
@@ -288,9 +288,10 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
           if (key) {
             let valor = seccion.fields[key];
             if (key === 'identificadorpcr') {
-              const regexHisop = new RegExp('HISOP');
-              if (valor && !regexHisop.test(valor)) {
-                valor = 'HISOP' + valor;
+              const regexHisop = new RegExp('([A-Za-z])+([0-9]+$)+');
+              if (valor && regexHisop.test(valor)) {
+                const numeroPcr = valor.replace(/[a-z]/gi, '');
+                valor = numeroPcr;
               }
             }
             if (valor !== undefined && valor !== null) {


### PR DESCRIPTION
### Requerimiento
Unificar como se va a guardar el identificador del pcr (Solo números)
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrego un patrón en el plex-text del identificador pcr para que solo acepte 'letras+numero' o solo números.
2. En el componente se chequea que si lo que se ingreso en el campo idPcr son solo números, o si viene con alguna palabra delante, en el caso que sea así, se elimina la palabra y se guarda solo el número. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
