### PR TITLE
Ficha Epidemiologica: Fix set mpi

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -567,9 +567,9 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
   }
 
   setDireccion(nuevaDir) {
-    return (nuevaDir.dirPaciente.direccioncaso !== this.paciente.direccion[0].valor ||
-      nuevaDir.provinciaPaciente.lugarresidencia.id !== this.paciente.direccion[0].ubicacion.provincia.id ||
-      nuevaDir.localidadPaciente.localidadresidencia.id !== this.paciente.direccion[0].ubicacion.localidad.id);
+    return (nuevaDir.dirPaciente.direccioncaso !== this.paciente.direccion[0]?.valor ||
+      nuevaDir.provinciaPaciente.lugarresidencia.id !== this.paciente.direccion[0].ubicacion?.provincia?.id ||
+      nuevaDir.localidadPaciente.localidadresidencia.id !== this.paciente.direccion[0].ubicacion?.localidad?.id);
   }
 
   pacienteInternado(event) {


### PR DESCRIPTION
### Requerimiento
Hay pacientes que fueron cargados hace mucho y pude ser que no tengan localidad o provincia registrada, esto tira un error al hacer el seteo de los campos en MPI.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega control al verificar si la dirección cargada en la ficha es la misma que tiene el paciente.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
