### PR TITLE
Epidemiología: Nuevo regex idPcr

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -288,9 +288,10 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
           if (key) {
             let valor = seccion.fields[key];
             if (key === 'identificadorpcr') {
-              const regexHisop = new RegExp('([A-Za-z])+([0-9]+$)+');
-              if (valor && regexHisop.test(valor)) {
-                const numeroPcr = valor.replace(/[a-z]/gi, '');
+              // Regex que empieza sin 0 y tiene solo números.
+              const regexHisop = new RegExp('^[1-9]+[0-9]*$');
+              if (valor && !regexHisop.test(valor)) {
+                const numeroPcr = valor.replace(/[a-z]*0*/i, '');
                 valor = numeroPcr;
               }
             }


### PR DESCRIPTION
### Requerimiento
Como se cargan idPcr con 0 adelante y sin 0 delante. Controlar y eliminar el 0 en caso de existir (se acordó con el laboratorio hacer lo mismo de ambos lados.)

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se modifica el control al guardar el idPcr ( En el caso que exista ). Si ademas de alguna palabra tiene un 0 por delante, se elimina.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No

