### PR TITLE
Buscador Epidemiología: Agregar filtro de clasificación final y columna idPcr

### DIFF
--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
@@ -1,5 +1,5 @@
 <plex-layout *ngIf="!showFicha" [main]="(pacienteSelected) && (!fichaHistorial) && (!codigoSISAEdit) ? 12 : 8">
-    <plex-layout-main *ngIf="!showFicha; else elseFicha">
+    <plex-layout-main>
         <plex-title titulo="Fichas epidemiologicas">
             <plex-button type="success" size="md" label="Buscar Fichas" (click)="searchFichas()"
                          [disabled]="inProgress">
@@ -16,9 +16,11 @@
                 </div>
             </plex-detail>
             <plex-wrapper span="{{ pacienteSelected ? '2' : 'null' }}" (change)="changeCollapse($event)">
-                <plex-datetime grow="1" type="date" [(ngModel)]="fechaDesde" name="fechaDesde" label="Desde" [max]="fechaHasta">
+                <plex-datetime grow="1" type="date" [(ngModel)]="fechaDesde" name="fechaDesde" label="Desde"
+                               [max]="fechaHasta">
                 </plex-datetime>
-                <plex-datetime grow="1" type="date" [(ngModel)]="fechaHasta" name="fechaHasta" label="Hasta" [min]="fechaDesde">
+                <plex-datetime grow="1" type="date" [(ngModel)]="fechaHasta" name="fechaHasta" label="Hasta"
+                               [min]="fechaDesde">
                 </plex-datetime>
                 <plex-select grow="1" [(ngModel)]="typeFicha" label="Tipo de ficha" [data]="dataType$ | async"
                              labelField="name" name="selectType">
@@ -44,6 +46,9 @@
                     <plex-select grow="1" name="tipoConfirmacion" [data]="tipoConfirmacion" label="Tipo Confirmación"
                                  [(ngModel)]="idTipoConfirmacion" labelField="nombre">
                     </plex-select>
+                    <plex-select grow="1" name="clasificacionFinal" [data]="clasificacionFinal"
+                                 label="Clasificación Final" [(ngModel)]="idClasificacionFinal" labelField="nombre">
+                    </plex-select>
                 </div>
             </plex-wrapper>
         </plex-grid>
@@ -58,6 +63,7 @@
                 <td *plTableCol="'documento'">{{ficha.paciente.documento}}</td>
                 <td *plTableCol="'paciente'">{{ficha.paciente.apellido}} {{ficha.paciente.nombre}}</td>
                 <td *plTableCol="'tipo'">{{ficha.type.name}}</td>
+                <td *plTableCol="'pcr'">{{ficha.idPcr }}</td>
                 <td *plTableCol="'clasificacion'">{{ficha.secciones[2]?.fields[0]?.clasificacion.nombre}}</td>
                 <td *plTableCol="'acciones'">
                     <plex-button *ngIf="puedeEditar" type="warning" icon="pencil" size="sm" tooltip="Editar"
@@ -130,10 +136,10 @@
         </ng-container>
     </plex-layout-sidebar>
 </plex-layout>
-<plex-layout main="8" *ngIf="showFicha" resizable="true" min="1" max="4" >
+<plex-layout main="8" *ngIf="showFicha" resizable="true" min="1" max="4">
     <plex-layout-main>
         <app-ficha-epidemiologica-crud [paciente]="paciente" [fichaPaciente]="fichaPaciente" [editFicha]="editFicha"
-                                        (volver)="volver()" [fichaName]="showFicha">
+                                       (volver)="volver()" [fichaName]="showFicha">
         </app-ficha-epidemiologica-crud>
     </plex-layout-main>
     <plex-layout-sidebar type="invert">

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -129,7 +129,8 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
       key: 'sisa',
       label: 'Registro SISA',
       opcional: true,
-      sorteable: false
+      sorteable: false,
+      right: true
     }
   ];
   colsVisibles = {

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -206,14 +206,10 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
         }
         return this.formEpidemiologiaService.search(this.query).pipe(
           map(resultados => {
-            resultados.map(ficha => {
+            resultados.forEach(ficha => {
               const seccionClasificacion = ficha.secciones.find(seccion => seccion.name === 'Tipo de confirmación y Clasificación Final');
-              if (seccionClasificacion) {
-                const pcr = seccionClasificacion.fields.find(field => Object.keys(field)[0] === 'identificadorpcr');
-                ficha.idPcr = pcr ? pcr.identificadorpcr : 'Sin PCR';
-              } else {
-                ficha.idPcr = 'Sin PCR';
-              }
+              const idPcr = seccionClasificacion?.fields.find(field => field.identificadorpcr)?.identificadorpcr;
+              ficha.idPcr = idPcr ? idPcr : 'Sin PCR';
             });
             this.listado = lastResults ? lastResults.concat(resultados) : resultados;
             this.query.skip = this.listado.length;


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-114

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega la columna PCR al buscador, si la ficha tiene el campo se muestra el mismo, caso contrario se muestra 'Sin PCR'.
2. Se agrega un nuevo filtro de clasificación final al buscador.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1502
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

