### PR TITLE
Epidemiología - Agregar el profesional que confirmo y el que hisopo en la ficha covid 19

### DIFF
--- a/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
+++ b/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
@@ -17,15 +17,12 @@ export class FormsEpidemiologiaService extends ResourceBaseHttp {
 
     // Devuelve una seccion entera de una ficha o un campo especifico
     getField(ficha, seccionName: string, fieldName?: string) {
-        let fieldBuscado;
         const seccionBuscada = ficha.secciones.find(s => s.name === seccionName);
         if (fieldName) {
-            seccionBuscada.fields.map(field => {
-                if (Object.keys(field)[0] === fieldName) {
-                    fieldBuscado = Object.values(field)[0];
-                }
-            });
+            const fieldBuscado = seccionBuscada?.fields.find(field => field[fieldName]);
+            return fieldBuscado ? fieldBuscado[fieldName] : null;
+        } else {
+            return seccionBuscada;
         }
-        return fieldBuscado ? fieldBuscado : seccionBuscada;
     }
 }

--- a/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
+++ b/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
@@ -14,4 +14,18 @@ export class FormsEpidemiologiaService extends ResourceBaseHttp {
         const clasificacionfinal = seccionClasificacion?.fields.find(f => f.clasificacionfinal)?.clasificacionfinal;
         return clasificacionfinal ? clasificacionfinal : 'Sin clasificación';
     }
+
+    // Devuelve una seccion entera de una ficha o un campo especifico
+    getField(ficha, seccionName: string, fieldName?: string) {
+        let fieldBuscado;
+        const seccionBuscada = ficha.secciones.find(s => s.name === seccionName);
+        if (fieldName) {
+            seccionBuscada.fields.map(field => {
+                if (Object.keys(field)[0] === fieldName) {
+                    fieldBuscado = Object.values(field)[0];
+                }
+            });
+        }
+        return fieldBuscado ? fieldBuscado : seccionBuscada;
+    }
 }

--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
@@ -397,6 +397,8 @@ export class HudsBusquedaComponent implements AfterContentInit {
         this.formEpidemiologiaService.search({ paciente: this.paciente.id }).subscribe(fichas => {
             if (fichas.length) {
                 const fichasEpidemiologia = fichas.map(f => {
+                    const usuarioConfirma = this.formEpidemiologiaService.getField(f, 'Tipo de confirmación y Clasificación Final', 'usuarioconfirma');
+                    const usuarioPcr = this.formEpidemiologiaService.getField(f, 'Tipo de confirmación y Clasificación Final', 'usuariopcr');
                     return {
                         data: f,
                         tipo: 'ficha-epidemiologica',
@@ -404,7 +406,7 @@ export class HudsBusquedaComponent implements AfterContentInit {
                         prestacion: {
                             term: `Ficha Epidemiológica ${f.type.name}`
                         },
-                        profesional: f.createdBy.nombreCompleto,
+                        profesional: usuarioConfirma ? usuarioConfirma : usuarioPcr ? usuarioPcr : f.createdBy.nombreCompleto,
                         fecha: f.createdAt,
                         estado: this.formEpidemiologiaService.getClasificacionFinal(f)
                     };

--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
@@ -393,7 +393,6 @@ export class HudsBusquedaComponent implements AfterContentInit {
     }
 
     buscarFichasEpidemiologicas() {
-
         this.formEpidemiologiaService.search({ paciente: this.paciente.id }).subscribe(fichas => {
             if (fichas.length) {
                 const fichasEpidemiologia = fichas.map(f => {
@@ -406,7 +405,7 @@ export class HudsBusquedaComponent implements AfterContentInit {
                         prestacion: {
                             term: `Ficha Epidemiológica ${f.type.name}`
                         },
-                        profesional: usuarioConfirma ? usuarioConfirma : usuarioPcr ? usuarioPcr : f.createdBy.nombreCompleto,
+                        profesional: usuarioConfirma || usuarioPcr || f.createdBy.nombreCompleto,
                         fecha: f.createdAt,
                         estado: this.formEpidemiologiaService.getClasificacionFinal(f)
                     };


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-115

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega la función getField() al service para tener una función que al mandarle por parámetro una ficha, una sección y un campo(opcional), busque en la ficha y retorne el resultado. Esto se hizo para no seguir pegando esa búsqueda en todos lados ( queda pendiente un refactor en la ficha cada vez que se hace una búsqueda de estas).
2. Se modifica la rup card de la ficha epidemiologica para que en la parte de profesional se muestre:

- Si la ficha esta confirmada, el profesional que hizo esta acción.
- Si la ficha no esta confirmada y se pidió un hisopado que fue al laboratorio, el profesional que hizo esta acción.
- Cualquier otro caso, quien creo la ficha.

![imagen](https://user-images.githubusercontent.com/56874534/129242757-fdfe5978-103f-4950-8dee-d09d70620be6.png)


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si Actualizar en la coleccion forms la ficha covid19: 
[fichacovid.txt](https://github.com/andes/app/files/6977429/fichacovid.txt)
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1513
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
