### PR TITLE
Epidmiología - Permitir editar fichas solo a usuarios con permisos en la organizacion en la que fue creada

### DIFF
--- a/src/app/apps/gestor-usuarios/services/permisos.service.ts
+++ b/src/app/apps/gestor-usuarios/services/permisos.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Server, Cache } from '@andes/shared';
+import { Server, Cache, cacheStorage } from '@andes/shared';
 
 
 @Injectable()
@@ -15,10 +15,10 @@ export class PermisosService {
         return this.server.get(this.permisosUrl, { params });
     }
 
-    // [TODO] Poner cache
-    // @Cache({})
     organizaciones(): Observable<any> {
-        return this.server.get('/modules/gestor-usuarios/organizaciones', {});
+        return this.server.get('/modules/gestor-usuarios/organizaciones', {}).pipe(
+            cacheStorage({ key: 'organizaciones-permisos' })
+        );
     }
 
     copyPermisos = null;

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
@@ -66,8 +66,8 @@
                 <td *plTableCol="'pcr'">{{ficha.idPcr }}</td>
                 <td *plTableCol="'clasificacion'">{{ficha.secciones[2]?.fields[0]?.clasificacion.nombre}}</td>
                 <td *plTableCol="'acciones'">
-                    <plex-button *ngIf="checkEdit(ficha.secciones[0].fields[0].organizacion.id)" type="warning"
-                                 icon="pencil" size="sm" tooltip="Editar" (click)="editarVerFicha(ficha,true)">
+                    <plex-button *ngIf="ficha | checkEdit:userOrganzaciones " type="warning" icon="pencil" size="sm"
+                                 tooltip="Editar" (click)="editarVerFicha(ficha,true)">
                     </plex-button>
                     <plex-button *ngIf="puedeVer" type="success" icon="eye" size="sm" tooltip="Ver"
                                  (click)="editarVerFicha(ficha,false)">

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
@@ -66,8 +66,8 @@
                 <td *plTableCol="'pcr'">{{ficha.idPcr }}</td>
                 <td *plTableCol="'clasificacion'">{{ficha.secciones[2]?.fields[0]?.clasificacion.nombre}}</td>
                 <td *plTableCol="'acciones'">
-                    <plex-button *ngIf="puedeEditar" type="warning" icon="pencil" size="sm" tooltip="Editar"
-                                 (click)="editarVerFicha(ficha,true)">
+                    <plex-button *ngIf="checkEdit(ficha.secciones[0].fields[0].organizacion.id)" type="warning"
+                                 icon="pencil" size="sm" tooltip="Editar" (click)="editarVerFicha(ficha,true)">
                     </plex-button>
                     <plex-button *ngIf="puedeVer" type="success" icon="eye" size="sm" tooltip="Ver"
                                  (click)="editarVerFicha(ficha,false)">

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
@@ -66,7 +66,7 @@
                 <td *plTableCol="'pcr'">{{ficha.idPcr }}</td>
                 <td *plTableCol="'clasificacion'">{{ficha.secciones[2]?.fields[0]?.clasificacion.nombre}}</td>
                 <td *plTableCol="'acciones'">
-                    <plex-button *ngIf="ficha | checkEdit:userOrganzaciones " type="warning" icon="pencil" size="sm"
+                    <plex-button *ngIf="ficha | checkEdit | async" type="warning" icon="pencil" size="sm"
                                  tooltip="Editar" (click)="editarVerFicha(ficha,true)">
                     </plex-button>
                     <plex-button *ngIf="puedeVer" type="success" icon="eye" size="sm" tooltip="Ver"

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -38,7 +38,6 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
   public resultadoBusqueda = [];
   public showBusquedaPaciente = false;
   public editFicha = false;
-  public puedeEditar: boolean;
   public puedeVer: boolean;
   public puedeVerHistorial: boolean;
   public pacienteSelected: IPaciente;
@@ -164,7 +163,6 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
       this.router.navigate(['inicio']);
     }
     this.permisoHuds = this.auth.check('huds:visualizacionHuds');
-    this.puedeEditar = this.auth.check('epidemiologia:update');
     this.puedeVer = this.auth.check('epidemiologia:read');
     this.puedeVerHistorial = this.auth.check('epidemiologia:historial');
     this.plex.updateTitle([
@@ -174,7 +172,7 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
     this.dataType$ = this.formsService.search();
     this.localidades$ = this.localidadService.get({ codigo: 15 });
     this.zonaSanitaria$ = this.zonaSanitariaService.search();
-    if (this.puedeEditar) {
+    if (this.auth.check('epidemiologia:update')) {
       this.permisosService.organizaciones().subscribe(permisos => {
         this.userOrganzaciones = permisos;
       });
@@ -346,9 +344,5 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
   }
   changeCollapse(event) {
     this.collapse = event;
-  }
-
-  checkEdit(organizacion) {
-    return (this.userOrganzaciones.some(org => org.id === organizacion));
   }
 }

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -12,6 +12,7 @@ import { ZonaSanitariaService } from '../../../../services/zonaSanitaria.service
 import { FormsService } from '../../../forms-builder/services/form.service';
 import { FormsEpidemiologiaService } from '../../services/ficha-epidemiologia.service';
 import { ModalMotivoAccesoHudsService } from 'src/app/modules/rup/components/huds/modal-motivo-acceso-huds.service';
+import { PermisosService } from 'src/app/apps/gestor-usuarios/services/permisos.service';
 
 @Component({
   selector: 'app-buscador-ficha-epidemiologica',
@@ -51,6 +52,7 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
   public codigoSISAEdit;
   public codigoSisa;
   public collapse = false;
+  public userOrganzaciones = [];
   public registroSisaOpts = [
     { id: 'noSISA', nombre: 'Sin registro SISA' },
     { id: 'SISA', nombre: 'Con registro SISA' },
@@ -153,7 +155,8 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
     private localidadService: LocalidadService,
     private zonaSanitariaService: ZonaSanitariaService,
     private pacienteService: PacienteService,
-    private motivoAccesoService: ModalMotivoAccesoHudsService
+    private motivoAccesoService: ModalMotivoAccesoHudsService,
+    private permisosService: PermisosService
   ) { }
 
   ngOnInit(): void {
@@ -171,6 +174,11 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
     this.dataType$ = this.formsService.search();
     this.localidades$ = this.localidadService.get({ codigo: 15 });
     this.zonaSanitaria$ = this.zonaSanitariaService.search();
+    if (this.puedeEditar) {
+      this.permisosService.organizaciones().subscribe(permisos => {
+        this.userOrganzaciones = permisos;
+      });
+    }
   }
 
   searchFichas() {
@@ -338,5 +346,9 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
   }
   changeCollapse(event) {
     this.collapse = event;
+  }
+
+  checkEdit(organizacion) {
+    return (this.userOrganzaciones.some(org => org.id === organizacion));
   }
 }

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -12,7 +12,6 @@ import { ZonaSanitariaService } from '../../../../services/zonaSanitaria.service
 import { FormsService } from '../../../forms-builder/services/form.service';
 import { FormsEpidemiologiaService } from '../../services/ficha-epidemiologia.service';
 import { ModalMotivoAccesoHudsService } from 'src/app/modules/rup/components/huds/modal-motivo-acceso-huds.service';
-import { PermisosService } from 'src/app/apps/gestor-usuarios/services/permisos.service';
 
 @Component({
   selector: 'app-buscador-ficha-epidemiologica',
@@ -51,7 +50,6 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
   public codigoSISAEdit;
   public codigoSisa;
   public collapse = false;
-  public userOrganzaciones = [];
   public registroSisaOpts = [
     { id: 'noSISA', nombre: 'Sin registro SISA' },
     { id: 'SISA', nombre: 'Con registro SISA' },
@@ -154,8 +152,7 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
     private localidadService: LocalidadService,
     private zonaSanitariaService: ZonaSanitariaService,
     private pacienteService: PacienteService,
-    private motivoAccesoService: ModalMotivoAccesoHudsService,
-    private permisosService: PermisosService
+    private motivoAccesoService: ModalMotivoAccesoHudsService
   ) { }
 
   ngOnInit(): void {
@@ -172,11 +169,6 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
     this.dataType$ = this.formsService.search();
     this.localidades$ = this.localidadService.get({ codigo: 15 });
     this.zonaSanitaria$ = this.zonaSanitariaService.search();
-    if (this.auth.check('epidemiologia:update')) {
-      this.permisosService.organizaciones().subscribe(permisos => {
-        this.userOrganzaciones = permisos;
-      });
-    }
   }
 
   searchFichas() {

--- a/src/app/modules/epidemiologia/epidemiologia.module.ts
+++ b/src/app/modules/epidemiologia/epidemiologia.module.ts
@@ -20,6 +20,7 @@ import { DetalleSeguimientoComponent } from './components/seguimiento/detalle-se
 import { SeguimientoEpidemiologiaComponent } from './components/seguimiento/seguimientoEpidemiologia.component';
 import { EpidemiologiaRoutingModule } from './epidemiologia.routing';
 import { CodigSisaPipe } from './pipes/codigoSisa.pipe';
+import { CheckEditPipe } from './pipes/checkEdit.pipe';
 import { SeguimientoFieldsPipe } from './pipes/seguimientoFields.pipe';
 @NgModule({
   declarations: [
@@ -33,6 +34,7 @@ import { SeguimientoFieldsPipe } from './pipes/seguimientoFields.pipe';
     DetalleSeguimientoComponent,
     SeguimientoFieldsPipe,
     CodigSisaPipe,
+    CheckEditPipe,
     ActualizarSeguimientoComponent,
   ],
   imports: [

--- a/src/app/modules/epidemiologia/pipes/checkEdit.pipe.ts
+++ b/src/app/modules/epidemiologia/pipes/checkEdit.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'checkEdit'
+})
+export class CheckEditPipe implements PipeTransform {
+
+    transform(ficha: any, organizaciones: any): any {
+        return (organizaciones.some(org => org.id === ficha.secciones[0].fields[0].organizacion?.id));
+    }
+}

--- a/src/app/modules/epidemiologia/pipes/checkEdit.pipe.ts
+++ b/src/app/modules/epidemiologia/pipes/checkEdit.pipe.ts
@@ -1,11 +1,25 @@
+import { Auth } from '@andes/auth';
 import { Pipe, PipeTransform } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { PermisosService } from 'src/app/apps/gestor-usuarios/services/permisos.service';
 
 @Pipe({
     name: 'checkEdit'
 })
 export class CheckEditPipe implements PipeTransform {
+    constructor(
+        private auth: Auth,
+        private permisosService: PermisosService
+    ) { }
 
-    transform(ficha: any, organizaciones: any): any {
-        return (organizaciones.some(org => org.id === ficha.secciones[0].fields[0].organizacion?.id));
+    transform(ficha: any): Observable<boolean> {
+        if (this.auth.check('epidemiologia:update')) {
+            return this.permisosService.organizaciones().pipe(
+                map(permisos => permisos.some(org => org.id === ficha.secciones[0].fields[0].organizacion?.id))
+            );
+        } else {
+            return of(false);
+        }
     }
 }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-116

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se obtienen las organizaciones en las que el usuario tiene permisos. Con estos permisos se verifica si las ficha obtenidas en el buscador fueron creadas en alguna organización en la que el usuario logueado tenga permisos, de ser así y si el usuario puede editar fichas se le mostrara el botón "editar" caso contrario, queda oculto.
2. Se agrega cacheStorage al get de organizaciones del PermisosService.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Observacion
Este PR debe subir luego de https://github.com/andes/app/pull/2379 

