### PR TITLE
Ficha Epidemiologica - Identidad autopercibida en ficha covid19

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -338,13 +338,15 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
         id: this.paciente.id,
         documento: this.paciente.documento,
         nombre: this.paciente.nombre,
+        nombreAutopercibido: this.paciente.alias ? this.paciente.alias : null,
         apellido: this.paciente.apellido,
         fechaNacimiento: this.paciente.fechaNacimiento,
         estado: this.paciente.estado,
         tipoIdentificacion: this.paciente.tipoIdentificacion ? this.paciente.tipoIdentificacion : this.paciente.numeroIdentificacion ? 'Passport' : null,
         numeroIdentificacion: this.paciente.numeroIdentificacion ? this.paciente.numeroIdentificacion : null,
         direccion: this.paciente.direccion,
-        sexo: this.paciente.sexo
+        sexo: this.paciente.sexo,
+        genero: this.paciente.genero
       },
       zonaSanitaria: this.zonaSanitaria
     };

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -338,7 +338,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
         id: this.paciente.id,
         documento: this.paciente.documento,
         nombre: this.paciente.nombre,
-        nombreAutopercibido: this.paciente.alias ? this.paciente.alias : null,
+        alias: this.paciente.alias,
         apellido: this.paciente.apellido,
         fechaNacimiento: this.paciente.fechaNacimiento,
         estado: this.paciente.estado,


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-122

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Agrego al object paciente el campo autopercibido y el genero.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si ver https://github.com/andes/api/pull/1518
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1518
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

