### PR TITLE
RUP - Compara por orden de dosis y no por nombre

### DIFF
--- a/src/app/modules/rup/components/elementos/vacunas.component.ts
+++ b/src/app/modules/rup/components/elementos/vacunas.component.ts
@@ -169,7 +169,7 @@ export class VacunasComponent extends RUPComponent implements OnInit {
                                 vacuna: r.registro.valor.vacuna.vacuna.nombre,
                                 condicion: r.registro.valor.vacuna.condicion.nombre,
                                 esquema: r.registro.valor.vacuna.esquema.nombre,
-                                dosis: r.registro.valor.vacuna.dosis.nombre,
+                                dosis: r.registro.valor.vacuna.dosis.orden,
                                 lote: r.registro.valor.vacuna.lote
                             };
                         });
@@ -180,9 +180,7 @@ export class VacunasComponent extends RUPComponent implements OnInit {
                         );
                         if (listaVacunas && listaVacunas.length) {
                             const filtroDuplicadas = nomivacFiltradas.filter(v => {
-                                if (!listaVacunas.find(vr => vr.vacuna === v.vacuna && vr.dosis === v.dosis)) {
-                                    return v;
-                                }
+                                if (!listaVacunas.find(vr => vr.vacuna === v.vacuna && vr.dosis === v.ordenDosis)) { return v; }
                             });
                             listaVacunas = [...listaVacunas, ...filtroDuplicadas];
                         } else {

--- a/src/app/modules/rup/components/elementos/vacunas.component.ts
+++ b/src/app/modules/rup/components/elementos/vacunas.component.ts
@@ -165,6 +165,7 @@ export class VacunasComponent extends RUPComponent implements OnInit {
                         });
                         listaVacunas = registrosRup.map(r => {
                             return {
+                                codigo: r.registro.valor.vacuna.vacuna.codigo,
                                 fechaAplicacion: r.fecha,
                                 vacuna: r.registro.valor.vacuna.vacuna.nombre,
                                 condicion: r.registro.valor.vacuna.condicion.nombre,
@@ -180,7 +181,7 @@ export class VacunasComponent extends RUPComponent implements OnInit {
                         );
                         if (listaVacunas && listaVacunas.length) {
                             const filtroDuplicadas = nomivacFiltradas.filter(v => {
-                                if (!listaVacunas.find(vr => vr.vacuna === v.vacuna && vr.dosis === v.ordenDosis)) { return v; }
+                                if (!listaVacunas.find(vr => vr.codigo.toString() === v.codigo && vr.dosis === v.ordenDosis)) { return v; }
                             });
                             listaVacunas = [...listaVacunas, ...filtroDuplicadas];
                         } else {

--- a/src/app/modules/rup/components/elementos/vacunas.html
+++ b/src/app/modules/rup/components/elementos/vacunas.html
@@ -59,7 +59,7 @@
                 </plex-label>
                 <plex-label titulo="Esquema" [subtitulo]="item.esquema" size="sm">
                 </plex-label>
-                <plex-label titulo="Dosis" [subtitulo]="item.dosis" size="sm"></plex-label>
+                <plex-label titulo="Dosis" [subtitulo]="item.ordenDosis || item.dosis" size="sm"></plex-label>
                 <plex-label titulo="Lote" [subtitulo]="item.lote" size="sm"></plex-label>
             </plex-item>
         </plex-list>


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-275
https://proyectos.andes.gob.ar/browse/RUP-280

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. En la búsqueda de aplicaciones de vacunas anteriores, compara las dosis según su orden en lugar de nombre.
2. Filtra por código de aplicación para evitar duplicados en la lista de dosis aplicados.

**OBSERVACION:** Hay que actualizar la colección 'nomivac' ya que en caso de haberse cargado con el esquema viejo, el atributo 'ordenDosis' no existirá

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
