### PR TITLE
EPIDEMIOLOGÍA - Eliminar ficha parcial

### DIFF
--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
@@ -66,11 +66,14 @@
                 <td *plTableCol="'pcr'">{{ficha.idPcr }}</td>
                 <td *plTableCol="'clasificacion'">{{ficha.secciones[2]?.fields[0]?.clasificacion.nombre}}</td>
                 <td *plTableCol="'acciones'">
-                    <plex-button *ngIf="ficha | checkEdit | async" type="warning" icon="pencil" size="sm"
+                    <plex-button *ngIf="ficha | checkEdit:'edit' | async" type="warning" icon="pencil" size="sm"
                                  tooltip="Editar" (click)="editarVerFicha(ficha,true)">
                     </plex-button>
                     <plex-button *ngIf="puedeVer" type="success" icon="eye" size="sm" tooltip="Ver"
                                  (click)="editarVerFicha(ficha,false)">
+                    </plex-button>
+                    <plex-button *ngIf="ficha | checkEdit:'delete' | async" type="danger" icon="delete" size="sm"
+                                 tooltip="Eliminar" (click)="eliminar(ficha)">
                     </plex-button>
                     <plex-button *ngIf="puedeVerHistorial" type="info" icon="history" size="sm" tooltip="Ver Historial"
                                  (click)="verHistorial(ficha)">

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -337,4 +337,18 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
     changeCollapse(event) {
         this.collapse = event;
     }
+
+    eliminar(ficha) {
+        this.plex.confirm('¿ Está seguro que desea eliminar una ficha ?', 'ESTA ACCIÓN ES IRREVERSIBLE').then((resultado) => {
+            if (resultado) {
+                this.formEpidemiologiaService.delete(ficha.id).subscribe(
+                    () => {
+                        this.plex.toast('success', 'Su ficha fue eliminada correctamente');
+                        this.searchFichas();
+                    },
+                    () => { this.plex.toast('error', 'Su ficha no pudo ser eliminada'); }
+                );
+            }
+        });
+    }
 }

--- a/src/app/modules/epidemiologia/pipes/checkEdit.pipe.ts
+++ b/src/app/modules/epidemiologia/pipes/checkEdit.pipe.ts
@@ -11,13 +11,30 @@ export class CheckEditPipe implements PipeTransform {
         private auth: Auth
     ) { }
 
-    transform(ficha: any): Observable<boolean> {
+    transform(ficha: any, type: string): Observable<boolean> {
         if (this.auth.check('epidemiologia:update')) {
-            return this.auth.organizaciones().pipe(
-                map(organizacion => organizacion.some(org => org.id === ficha.secciones[0].fields[0].organizacion?.id))
-            );
+            switch (type) {
+                case 'edit': {
+                    return this.auth.organizaciones().pipe(
+                        map(organizacion => organizacion.some(org => org.id === ficha.secciones[0].fields[0].organizacion?.id))
+                    );
+                }
+                case 'delete': {
+                    if (this.esParcial(ficha)) {
+                        return this.auth.organizaciones().pipe(
+                            map(organizacion => organizacion.some(org => org.id === ficha.secciones[0].fields[0].organizacion?.id))
+                        );
+                    } else {
+                        return of(false);
+                    }
+                }
+            }
         } else {
             return of(false);
         }
+    }
+
+    esParcial(ficha) {
+        return !(ficha.secciones.some(seccion => seccion.name === 'Tipo de confirmación y Clasificación Final'));
     }
 }


### PR DESCRIPTION
### Requerimiento
Existen fichas con carga parcial ( no tienen completa la sección de clasificación final, es decir no están clasificados los casos ), las cuales no se realiza nunca la clasificación final, estas fichas deberían eliminarse del sistema.
Al eliminar una ficha, se guarda en el historial de la ficha una entrada para tener registro de esta acción.
https://proyectos.andes.gob.ar/browse/EP-139

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se modifica el pipe checkEdit para usarlo tanto para editar como para eliminar una ficha con las restricciones necesarias.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1546
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

