### PR TITLE
Turnos Prestaciones - Turnos prestaciones: agregar label "No se encontraron resultados"

### DIFF
--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.component.ts
@@ -12,6 +12,7 @@ import { Router } from '@angular/router';
 import { ExportHudsService } from '../../modules/visualizacion-informacion/services/export-huds.service';
 import { combineLatest } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { cache } from '@andes/shared';
 
 @Component({
     selector: 'turnos-prestaciones',
@@ -139,7 +140,9 @@ export class TurnosPrestacionesComponent implements OnInit, OnDestroy {
         }]);
 
 
-        this.busqueda$ = this.turnosPrestacionesService.prestacionesOrdenada$;
+        this.busqueda$ = this.turnosPrestacionesService.prestacionesOrdenada$.pipe(
+            cache()
+        );
 
         combineLatest([
             this.accion$,

--- a/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
+++ b/src/app/components/buscadorTurnosPrestaciones/turnos-prestaciones.html
@@ -86,7 +86,7 @@
             </plex-title>
             <ng-container *ngIf="selectPrestaciones$ | async as selectPrestaciones">
                 <cdk-virtual-scroll-viewport [itemSize]="50">
-                    <table class="table table-striped table-sm">
+                    <table *ngIf="(busqueda$ | async)?.length" class="table table-striped table-sm">
                         <thead>
                             <th class="selected">
                                 <plex-bool name="all" (change)="selectAll($event)" [ngModel]="state.selectAll">
@@ -184,6 +184,12 @@
                             </tr>
                         </tbody>
                     </table>
+                    <div *ngIf="!(busqueda$ | async)?.length" justify="center" class="mt-5">
+                        <plex-label class="flex-column" icon="magnify" type="info" size="xl" direction="column"
+                                    [titulo]="'No hay resultados'"
+                                    subtitulo="Complete los filtros deseados y presione Buscar">
+                        </plex-label>
+                    </div>
                 </cdk-virtual-scroll-viewport>
             </ng-container>
         </ng-container>


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/MISC-184

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega un label para mostrar que no hay resultados en el buscador de turnos y prestaciones.
2. Se agrega cache() a la subscripcion de la búsqueda.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

