### PR TITLE
CITAS - No se habilita el boton liberar turnos desde el punto de inicio

### DIFF
--- a/src/app/components/turnos/punto-inicio/turnos-paciente.component.ts
+++ b/src/app/components/turnos/punto-inicio/turnos-paciente.component.ts
@@ -79,8 +79,8 @@ export class TurnosPacienteComponent implements OnInit {
                 public serviceTurno: TurnoService, public serviceAgenda: AgendaService, public plex: Plex, public auth: Auth) { }
 
     ngOnInit() {
-        this.puedeRegistrarAsistencia = this.auth.getPermissions('turnos:turnos:registrarAsistencia').length > 0;
-        this.puedeLiberarTurno = this.auth.getPermissions('turnos:turnos:liberarTurno').length > 0;
+        this.puedeRegistrarAsistencia = this.auth.check('turnos:turnos:registrarAsistencia');
+        this.puedeLiberarTurno = this.auth.check('turnos:turnos:liberarTurno');
         this.todaysdate = new Date();
         this.todaysdate.setHours(0, 0, 0, 0);
         this.loadObraSocial();


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/CIT-122

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Si solo se habilita la opción de liberar turnos para un usuario, la funcion getPermissions devuelve un array vació, por esto se cambia la función por check para que la variable puedaLiberarTurno quede en true en el caso de tener solo ese permiso.
2. Se hace lo mismo para puedeRegistrarAsistencia


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
