### PR TITLE
BI: filtros por zonas en bi-queries

### DIFF
--- a/src/app/modules/estadisticas/components/citas/filtros.component.ts
+++ b/src/app/modules/estadisticas/components/citas/filtros.component.ts
@@ -55,7 +55,7 @@ export class FiltrosComponent implements OnInit, OnChanges {
     ngOnInit() {
         this.verProfesionales = this.auth.check('visualizacionInformacion:dashboard:citas:verProfesionales');
         this.permisosOrganizaciones = this.auth.getPermissions('visualizacionInformacion:dashboard:citas:organizaciones:?');
-        this.permisosZonas = this.auth.getPermissions('visualizacionInformacion:dashboard:citas:zonasSanitarias:?');
+        this.permisosZonas = this.auth.getPermissions('visualizacionInformacion:zonasSanitarias:?');
         if (!this.verProfesionales) {
             this.servicioProfesional.get({ id: this.auth.profesional }).subscribe(resultado => {
                 this.seleccion.profesional = resultado;

--- a/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.html
+++ b/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.html
@@ -46,6 +46,12 @@
                                      [required]="argumento.required" labelField="nombreCompleto"
                                      (getData)="loadProfesionales($event)">
                         </plex-select>
+                        <plex-select *ngSwitchCase="'zonaSanitaria'"
+                                     [label]="argumento.label?argumento.label:argumento.key" grow="2"
+                                     name="{{ argumento.key }}" [(ngModel)]="argumentos[argumento.key]"
+                                     [required]="argumento.required && permisosZonas.length > 0"
+                                     [data]="zonasSanitarias">
+                        </plex-select>
                         <plex-select *ngSwitchCase="'select-static'"
                                      [label]="argumento.label?argumento.label:argumento.key" grow="auto"
                                      name="{{ argumento.key }}" [(ngModel)]="argumentos[argumento.key]"

--- a/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.ts
+++ b/src/app/modules/visualizacion-informacion/components/bi-queries/bi-queries.component.ts
@@ -1,3 +1,4 @@
+import { ZonaSanitariaService } from './../../../../services/zonaSanitaria.service';
 import { Component, OnInit } from '@angular/core';
 import { QueriesService } from '../../../../services/query.service';
 import { Observable } from 'rxjs';
@@ -5,6 +6,7 @@ import { ProfesionalService } from '../../../../services/profesional.service';
 import { Auth } from '@andes/auth';
 import { Router } from '@angular/router';
 import { FormsService } from 'src/app/modules/forms-builder/services/form.service';
+import { IZonaSanitaria } from 'src/app/interfaces/IZonaSanitaria';
 
 
 @Component({
@@ -24,10 +26,13 @@ export class BiQueriesComponent implements OnInit {
     public mostrarSalida = false;
     public tipoPrestaciones;
     public totalOrganizaciones = false;
+    public permisosZonas: any[];
+    public zonasSanitarias: IZonaSanitaria[] = [];
 
     constructor(
         private queryService: QueriesService,
         private profesionalService: ProfesionalService,
+        private zonaSanitariaService: ZonaSanitariaService,
         private formsService: FormsService,
         private auth: Auth,
         private router: Router
@@ -36,6 +41,10 @@ export class BiQueriesComponent implements OnInit {
     ngOnInit() {
         const permisos = this.auth.getPermissions('visualizacionInformacion:biQueries:?');
         this.totalOrganizaciones = !this.auth.check('visualizacionInformacion:totalOrganizaciones');
+        this.permisosZonas = this.auth.getPermissions('visualizacionInformacion:zonasSanitarias:?');
+        if (this.permisosZonas.length > 0) {
+            this.loadZonasSanitarias();
+        }
         if (permisos.length) {
             if (permisos[0] === '*') {
                 this.queries$ = this.queryService.getAllQueries({ desdeAndes: true });
@@ -68,6 +77,16 @@ export class BiQueriesComponent implements OnInit {
         } else {
             event.callback(listaProfesionales);
         }
+    }
+
+    loadZonasSanitarias() {
+        const params = {};
+        if (this.permisosZonas[0] !== '*') {
+            params['ids'] = this.permisosZonas;
+        }
+        this.zonaSanitariaService.search(params).subscribe(resultado => {
+            this.zonasSanitarias = resultado;
+        });
     }
 
     loadFomTypes(event) {


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/BI-108

### Funcionalidad desarrollada 
1. Filtro de zonas sanitarias en bi-queries según permisos

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
En la query agendas-consolidado, reemplazar el argumento zona por:

{
            "key" : "zona",
            "label" : "Zona Sanitaria",
            "tipo" : "zonaSanitaria",
            "required" : false,
            "subquery" : {
                "organizacion.zonaSanitaria._id" : "#zona"
            }
        }

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si https://github.com/andes/api/pull/1587
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

