### PR TITLE
Epidemiologia - Fix en caso asintomatico

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -486,7 +486,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
     }
 
     private puedeRegistrar(clasificacionFinal) {
-        return this.auth.profesional && clasificacionFinal !== this.clasificacionOriginal && clasificacionFinal !== 'Descartado';
+        return this.auth.profesional && clasificacionFinal !== this.clasificacionOriginal && clasificacionFinal !== 'Descartado' && clasificacionFinal !== 'Caso asintomático';
     }
 
     private registrarPrestacion(ficha) {
@@ -679,9 +679,9 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
     setCasoAsintomatico(event) {
         this.clearDependencias({ value: false }, 'clasificacionFinal', []);
         if (event.value.id === 'casoAsintomatico') {
+            const seccionFinal = this.secciones.find(seccion => seccion.id === 'clasificacionFinal');
+            seccionFinal.fields['clasificacionfinal'] = 'Caso asintomático';
             if (!this.showFichaParcial) {
-                const seccionFinal = this.secciones.find(seccion => seccion.id === 'clasificacionFinal');
-                seccionFinal.fields['clasificacionfinal'] = 'Caso asintomático';
                 seccionFinal.fields['segundaclasificacion'] = { id: 'pcr', nombre: 'PCR-RT' };
             }
             this.asintomatico = true;


### PR DESCRIPTION
### Requerimiento
Cuando se carga una ficha parcial con un caso asintomático, al querer editarla luego de hacer un pcr no muestra clasificación final

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se setea el campo clasificación final cuando el caso es asintomático sin importar si es parcial la ficha o no.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

