### PR TITLE
Epidemiologia - Se cierra collapse al editar/ver una ficha

### DIFF
--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.html
@@ -15,7 +15,7 @@
                     </plex-button>
                 </div>
             </plex-detail>
-            <plex-wrapper span="{{ pacienteSelected ? '2' : '3' }}" (change)="changeCollapse($event)">
+            <plex-wrapper #wrapper span="{{ pacienteSelected ? '2' : '3' }}" (change)="changeCollapse($event)">
                 <plex-datetime grow="1" type="date" [(ngModel)]="fechaDesde" name="fechaDesde" label="Desde"
                                [max]="fechaHasta">
                 </plex-datetime>

--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -1,7 +1,7 @@
 import { Auth } from '@andes/auth';
 import { Plex } from '@andes/plex';
 import { cache } from '@andes/shared';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
@@ -13,6 +13,7 @@ import { FormsService } from '../../../forms-builder/services/form.service';
 import { FormsEpidemiologiaService } from '../../services/ficha-epidemiologia.service';
 import { ModalMotivoAccesoHudsService } from 'src/app/modules/rup/components/huds/modal-motivo-acceso-huds.service';
 import { SECCION_OPERACIONES } from '../../constantes';
+import { PlexWrapperComponent } from '@andes/plex/src/lib/wrapper/wrapper.component';
 
 @Component({
     selector: 'app-buscador-ficha-epidemiologica',
@@ -20,6 +21,7 @@ import { SECCION_OPERACIONES } from '../../constantes';
 })
 
 export class BuscadorFichaEpidemiologicaComponent implements OnInit {
+    @ViewChild('wrapper') wrapper: PlexWrapperComponent;
     public fechaDesde: Date;
     public fechaHasta: Date;
     public typeFicha = null;
@@ -214,6 +216,7 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
                         this.listado = lastResults ? lastResults.concat(resultados) : resultados;
                         this.query.skip = this.listado.length;
                         this.inProgress = false;
+                        this.wrapper.desplegado = this.collapse;
                         return this.listado;
                     })
                 );


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-165

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se seteal el collapse del wrapper al buscar fichas para que al volver del editar/ver una ficha quede en el estado anterior.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

