### PR TITLE
Epidemiología -  No borrar clasificacion final caso asintomatico

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -2,7 +2,7 @@
     <plex-layout-main>
         <plex-title titulo="Ficha {{fichaName}}" main>
             <plex-bool *ngIf="editFicha" class="mr-4" [(ngModel)]="showFichaParcial" label="Cargar ficha parcial"
-                       (change)="clearDependencias({value:false},'clasificacionFinal',
+                       (change)="clearDependencias((asintomatico ? {value:true} : {value:false}),'clasificacionFinal',
             ['segundaclasificacion','tipomuestra','antigeno','lamp','pcr','identificadorpcr',
             'pcrM','clasificacionfinal','fechamuestra'])">
             </plex-bool>

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -634,7 +634,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
 
     checkClasificacionFinal() {
         const seccionClasificacion = this.secciones.find(seccion => seccion.id === 'clasificacionFinal');
-        if (seccionClasificacion?.fields['antigeno']?.id === 'muestra') {
+        if (seccionClasificacion?.fields['antigeno']?.id === 'muestra' && !this.asintomatico) {
             return (seccionClasificacion.fields['lamp']?.id || seccionClasificacion.fields['pcrM']);
         } else {
             return true;


### PR DESCRIPTION
### Requerimiento
[ <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->](https://proyectos.andes.gob.ar/browse/EP-172)

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se elimina restricción de guardar fichas con antígeno no reactivo en casos asintomáticos.
2. Se elimina el borrado de la clasificación final cuando el caso es asintomático.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

