### PR TITLE
CIT - Ocultar botón disponible en agendas con turnos del dia/programados

### DIFF
--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -222,7 +222,8 @@ export class BotonesAgendaComponent implements OnInit {
         const turnosEspeciales = this.agendasSeleccionadas.some(agenda => {
             return agenda.bloques.some(b => b.reservadoGestion > 0 || b.reservadoProfesional > 0);
         });
-        return enPlanificacion && turnosEspeciales;
+        const nominalizada = !this.agendasSeleccionadas.some((agenda: any) => (agenda.nominalizada === true));
+        return (enPlanificacion && turnosEspeciales) || nominalizada;
     }
 
     puedoPublicar() {

--- a/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
+++ b/src/app/components/turnos/gestor-agendas/operaciones-agenda/botones-agenda.component.ts
@@ -217,8 +217,12 @@ export class BotonesAgendaComponent implements OnInit {
     }
 
     puedoDisponer() {
-        const disponer = this.agendasSeleccionadas.filter((agenda: any) => (agenda.estado !== 'planificacion')).length <= 0;
-        return disponer;
+        // enPlanificacion resulta true sssi todas las agendas seleccionadas estan en planificación
+        const enPlanificacion = !this.agendasSeleccionadas.some((agenda: any) => (agenda.estado !== 'planificacion'));
+        const turnosEspeciales = this.agendasSeleccionadas.some(agenda => {
+            return agenda.bloques.some(b => b.reservadoGestion > 0 || b.reservadoProfesional > 0);
+        });
+        return enPlanificacion && turnosEspeciales;
     }
 
     puedoPublicar() {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/CIT-138

### Funcionalidad desarrollada 
1. Se modifico la función puedoDisponer() agregando una condición para verificar que cuando se arma la agenda y se le asignan turnos con llave o del profesional, se modifica el valor de reservadoGestion o reservadoProfesional que aparecen en los bloques de una agenda. Y esto nos permitirá saber si tiene que figurar el botón disponible o no

### UserStory llegó a completarse
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
- [X] Si   https://github.com/andes/andes-test-integracion/pull/405
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
