### PR TITLE
Fix en error al ver la huds que no tenga registros sobre componente fecha

### DIFF
--- a/src/app/modules/rup/components/elementos/valorFecha.component.ts
+++ b/src/app/modules/rup/components/elementos/valorFecha.component.ts
@@ -9,19 +9,21 @@ import { RupElement } from '.';
 @RupElement('ValorFechaComponent')
 export class ValorFechaComponent extends RUPComponent implements OnInit {
     get DateFormat() {
-        switch (this.params.type) {
-            case 'date':
-                return moment(this.registro.valor).format('DD/MM/YYYY');
-            case 'datetime':
-                return moment(this.registro.valor).format('DD/MM/YYYY hh:mm');
-            case 'time':
-                return moment(this.registro.valor).format('hh:mm');
-            default:
-                break;
+        if (this.registro) {
+            switch (this.params.type) {
+                case 'date':
+                    return moment(this.registro.valor).format('DD/MM/YYYY');
+                case 'datetime':
+                    return moment(this.registro.valor).format('DD/MM/YYYY hh:mm');
+                case 'time':
+                    return moment(this.registro.valor).format('hh:mm');
+                default:
+                    break;
+            }
         }
     }
     ngOnInit() {
-        if (!this.registro.valor) {
+        if (this.registro && !this.registro.valor) {
             this.registro.valor = null;
         }
     }


### PR DESCRIPTION


<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
Actualemnte hay un error al ver los registros en la HUDS de controles de embarazos anteriores al cambio  del calculo de la edad gestacional

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. 
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- X ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
