### PR TITLE
fix(mapa-camas): enfermeros no ven exploracion visual

### DIFF
--- a/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/cama-detalle.component.html
+++ b/src/app/apps/rup/mapa-camas/sidebar/cama-detalle/cama-detalle.component.html
@@ -73,8 +73,7 @@
         <ng-container *ngIf="cama.paciente">
             <plex-title size="sm" justify titulo="DATOS DE PACIENTE">
 
-                <plex-button *ngIf="capa !== 'enfermeria'" label="EXPLORACIÓN VISUAL" size="sm" type="info"
-                             (click)="onVerResumen(cama)" class="mr-1">
+                <plex-button label="EXPLORACIÓN VISUAL" size="sm" type="info" (click)="onVerResumen(cama)" class="mr-1">
                 </plex-button>
 
                 <ng-container *feature="'planIndicaciones'">


### PR DESCRIPTION
### Requerimiento
Los enfermeros no estan viendo la exploración visual  de la internación. 

### UserStory llegó a completarse
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
- [ ] Si
- [x] No
 