### PR TITLE
Epidemiología - Modificar restriccion antigeno no reactivo

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -273,11 +273,7 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
             this.ngForm.control.markAllAsTouched();
         } else {
             this.getValues();
-            if (this.checkClasificacionFinal()) {
-                this.setFicha();
-            } else {
-                this.plex.info('warning', 'Si el resultado del antigeno es NO REACTIVO debe completar el campo LAMP o PCR', 'Atención');
-            }
+            this.setFicha();
         }
     }
 
@@ -630,15 +626,6 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
             this.organizacionesInternacion$ = this.organizacionService.get({ aceptaDerivacion: true });
         }
         return this.estaInternado;
-    }
-
-    checkClasificacionFinal() {
-        const seccionClasificacion = this.secciones.find(seccion => seccion.id === 'clasificacionFinal');
-        if (seccionClasificacion?.fields['antigeno']?.id === 'muestra' && !this.asintomatico) {
-            return (seccionClasificacion.fields['lamp']?.id || seccionClasificacion.fields['pcrM']);
-        } else {
-            return true;
-        }
     }
 
     getInstituciones(educativas) {


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-179

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se elimina la restricción de guardar al registrar un antígeno no reactivo, antes era obligatorio pedir pcr o lamp, ahora se modifico. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

