### PR TITLE
Epidemiología - Mostrar en la ficha el estado de vacunacion del paciente

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -455,7 +455,7 @@
                                            [label]="field.label?field.label:field.key" grow="auto"
                                            name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                            [readonly]="!editFicha"
-                                           (change)="getVacunas(); clearDependencias($event,'antecedentesEpidemiologicos',['vacunacionestado','fechadosis','nombrevacunacovid'])">
+                                           (change)="clearDependencias($event,'antecedentesEpidemiologicos',['vacunacionestado','fechadosis','nombrevacunacovid'])">
                                 </plex-bool>
                                 <plex-select *ngIf="field.key==='vacunacionestado' && seccion.fields['vacunacioncovid']"
                                              [label]="field.label?field.label:field.key" grow="auto"

--- a/src/app/services/pacientes-vacunas.service.ts
+++ b/src/app/services/pacientes-vacunas.service.ts
@@ -1,0 +1,11 @@
+import { ResourceBaseHttp, Server } from '@andes/shared';
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class PacientesVacunasService extends ResourceBaseHttp {
+    protected url = '/modules/vacunas/vacunasPacientes';
+
+    constructor(protected server: Server) {
+        super(server);
+    }
+}

--- a/src/app/services/pacientes-vacunas.service.ts
+++ b/src/app/services/pacientes-vacunas.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class PacientesVacunasService extends ResourceBaseHttp {
-    protected url = '/modules/vacunas/vacunasPacientes';
+    protected url = '/modules/vacunas/vacunas-pacientes';
 
     constructor(protected server: Server) {
         super(server);


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-180

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se setea al inicio el estado de vacunación contra el covid 19 de un paciente, si el paciente posee alguna dosis se completan los campos correspondientes, permitiendo de todas formas modificar estos.
2. 
3. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1649
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


