### PR TITLE
Epidemiología - Agregar concepto Certificado de aislamiento por covid a ficha confirmada

### DIFF
--- a/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
+++ b/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
@@ -49,6 +49,9 @@ export class FormsEpidemiologiaService extends ResourceBaseHttp {
                     if (field.clasificacionfinal === 'Sospechoso') {
                         conceptos.push(this.elementoRupService.getConceptosCovidSospechoso());
                     }
+                    if (field.clasificacionfinal === 'Confirmado') {
+                        conceptos.push(this.elementoRupService.getConceptoCertificadoAislamiento());
+                    }
                     break;
                 case 'segundaclasificacion':
                     if (field.segundaclasificacion.id === 'confirmado') {

--- a/src/app/modules/rup/services/elementosRUP.service.ts
+++ b/src/app/modules/rup/services/elementosRUP.service.ts
@@ -284,4 +284,13 @@ export class ElementosRUPService {
             semanticTag: 'situación'
         };
     }
+
+    getConceptoCertificadoAislamiento() {
+        return {
+            term: 'certificado de aislamiento por COVID-19',
+            fsn: 'certificado de aislamiento por COVID-19 (elemento de registro)',
+            conceptId: '781000246105',
+            semanticTag: 'elemento de registro'
+        };
+    }
 }


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-187

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega el concepto "Certificado de aislamiento" a la prestacion que se abre automativamente para los casos que se confirman desde la ficha covid 19.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


