### PR TITLE
Epidemiologia - Agregar autotest al select Tipo de confirmacion de la seccion "Tipo de confirmacion y calasificacion final"

### DIFF
--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.html
@@ -308,17 +308,17 @@
                                              (change)="clearDependencias({value:false},'clasificacionFinal',
                                              ['tipomuestra','antigeno','lamp','pcr','identificadorpcr','pcrM']) ; resultadoFinal(field.key)" [readonly]="!editFicha">
                                 </plex-select>
-                                <plex-select *ngIf="field.key==='tipomuestra' && seccion.fields['segundaclasificacion']?.id!=='confirmado'"
+                                <plex-select *ngIf="field.key==='tipomuestra' && checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado'"
                                              [label]="field.label?field.label:field.key" grow="auto"
                                              name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                              [required]="field.required" [data]="tipoMuestra" [readonly]="!editFicha">
                                 </plex-select>
-                                <plex-datetime *ngIf="field.key==='fechamuestra' && seccion.fields['segundaclasificacion']?.id!=='confirmado'"
+                                <plex-datetime *ngIf="field.key==='fechamuestra' && checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado'"
                                                [label]="field.label?field.label:field.key" grow="auto" type="date"
                                                name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                                [required]="field.required" [readonly]="!editFicha">
                                 </plex-datetime>
-                                <plex-select *ngIf="field.key==='antigeno' && seccion.fields['segundaclasificacion']?.id!=='confirmado' 
+                                <plex-select *ngIf="field.key==='antigeno' && checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado' 
                                               && seccion.fields['segundaclasificacion']?.id!=='lamp' && seccion.fields['segundaclasificacion']?.id!=='pcr'"
                                              [label]="field.label?field.label:field.key" grow="auto"
                                              name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
@@ -326,7 +326,7 @@
                                              [data]="resultadoAntigeno" (change)="resultadoFinal(field.key)"
                                              [readonly]="!editFicha">
                                 </plex-select>
-                                <plex-select *ngIf="field.key==='lamp' && seccion.fields['segundaclasificacion']?.id!=='confirmado'
+                                <plex-select *ngIf="field.key==='lamp' && checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado'
                                             && seccion.fields['antigeno']?.id!=='confirmado' && seccion.fields['segundaclasificacion']?.id!=='pcr'"
                                              [label]="field.label?field.label:field.key" grow="auto"
                                              name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
@@ -334,19 +334,19 @@
                                              [data]="resultadoDetectable" (change)="resultadoFinal(field.key)"
                                              [readonly]="!editFicha">
                                 </plex-select>
-                                <plex-bool *ngIf="field.key==='pcrM'&& seccion.fields['segundaclasificacion']?.id!=='confirmado'"
+                                <plex-bool *ngIf="field.key==='pcrM'&& checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado'"
                                            [label]="field.label?field.label:field.key" grow="auto"
                                            name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                            (change)="setPcr($event); clearDependencias($event,'clasificacionFinal',['pcr','identificadorpcr']); resultadoFinal(field.key)"
                                            [readonly]="!editFicha">
                                 </plex-bool>
-                                <plex-select *ngIf="field.key==='pcr' && seccion.fields['pcrM'] && seccion.fields['segundaclasificacion']?.id!=='confirmado'"
+                                <plex-select *ngIf="field.key==='pcr' && seccion.fields['pcrM'] && checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado'"
                                              [label]="field.label?field.label:field.key" grow="auto"
                                              name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                              [data]="resultadoDetectable" (change)="resultadoFinal(field.key)"
                                              readonly=true>
                                 </plex-select>
-                                <plex-text *ngIf="field.key==='identificadorpcr' && seccion.fields['pcrM'] && seccion.fields['segundaclasificacion']?.id!=='confirmado'"
+                                <plex-text *ngIf="field.key==='identificadorpcr' && seccion.fields['pcrM'] && checkConfirmados(seccion.fields['segundaclasificacion'])!=='confirmado'"
                                            [label]="field.label?field.label:field.key" grow="auto"
                                            name="{{ field.key }}" [(ngModel)]="seccion.fields[field.key]"
                                            [pattern]="patronPCR" [required]="field.required" [readonly]="!editFicha">

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -79,6 +79,9 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
     ];
     public segundaClasificacion = [
         { id: 'confirmado', nombre: 'Criterio clínico epidemiológico (Nexo)' },
+        { id: 'autotest', nombre: 'Autotest' },
+        { id: 'laboPcr', nombre: 'Laboratorio privado (PCR)' },
+        { id: 'laboAntigeno', nombre: 'Laboratorio privado (Antígeno)' },
         { id: 'antigeno', nombre: 'Antígeno' },
         { id: 'pcr', nombre: 'PCR-RT' },
         { id: 'lamp', nombre: 'LAMP (NeoKit)' }
@@ -424,13 +427,13 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
         this.secciones.map(seccion => {
             if (seccion.id === 'clasificacionFinal') {
                 const clasificaciones = {
-                    segundaclasificacion: seccion.fields['segundaclasificacion']?.id,
+                    segundaclasificacion: this.checkConfirmados(seccion.fields['segundaclasificacion']),
                     antigeno: seccion.fields['antigeno']?.id,
                     pcrM: seccion.fields['pcrM'] ? 'muestra' : '',
                     pcr: seccion.fields['pcr']?.id,
                     lamp: seccion.fields['lamp']?.id
                 };
-                if (seccion.fields['segundaclasificacion']?.nombre === 'Criterio clínico epidemiológico (Nexo)') {
+                if (this.checkConfirmados(seccion.fields['segundaclasificacion']) === 'confirmado') {
                     this.clearDependencias({ value: false }, seccion.id, ['tipomuestra', 'fechamuestra', 'antigeno', 'lamp', 'pcrM', 'pcr', 'identificadorpcr']);
                 } else {
                     if (!seccion.fields['fechamuestra']) {
@@ -700,5 +703,13 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
                 fields['nombrevacunacovid'] = { _id: ultimaDosis.vacuna.id, nombre: ultimaDosis.vacuna.nombre };
             }
         });
+    }
+
+    checkConfirmados(field) {
+        if (field?.id === 'autotest' || field?.id === 'laboPcr' || field?.id === 'laboAntigeno') {
+            return 'confirmado';
+        } else {
+            return field?.id;
+        }
     }
 }

--- a/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
+++ b/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
@@ -56,6 +56,10 @@ export class FormsEpidemiologiaService extends ResourceBaseHttp {
                 case 'segundaclasificacion':
                     if (field.segundaclasificacion.id === 'confirmado') {
                         conceptos.push(this.elementoRupService.getConceptoCovidConfirmadoNexo());
+                    } else if (field.segundaclasificacion.id === 'autotest' ||
+                        field.segundaclasificacion.id === 'laboPcr'
+                        || field.segundaclasificacion.id === 'laboAntigeno') {
+                        conceptos.push(this.elementoRupService.getConceptoEnfermedadCovid());
                     }
                     break;
                 case 'pcr':


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-192

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agregan nuevos tipos de confirmación en la sección clasificación final.
2. Se agrega el concepto Enfermedad covid 19, cuando la ficha es confirmada por los nuevos tipos.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
