### PR TITLE
Epidemiología - Eliminar confirmacion por nexo de la ficha covid 19

### DIFF
--- a/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
+++ b/src/app/modules/epidemiologia/components/buscador-ficha-epidemiologica/buscador-ficha-epidemiologica.component.ts
@@ -65,7 +65,6 @@ export class BuscadorFichaEpidemiologicaComponent implements OnInit {
         { id: 'casoAsintomatico', nombre: 'Caso asintomático estudiado en situaciones especiales' }
     ];
     public tipoConfirmacion = [
-        { id: 'confirmado', nombre: 'Criterio clínico epidemiológico (Nexo)' },
         { id: 'antigeno', nombre: 'Antígeno' },
         { id: 'pcr', nombre: 'PCR-RT' },
         { id: 'lamp', nombre: 'LAMP(NeoKit)' }

--- a/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
+++ b/src/app/modules/epidemiologia/components/ficha-epidemiologica-crud/ficha-epidemiologica-crud.component.ts
@@ -78,7 +78,6 @@ export class FichaEpidemiologicaCrudComponent implements OnInit, OnChanges {
         { id: 'demandaEspontanea', nombre: 'Demanda espontanea' },
     ];
     public segundaClasificacion = [
-        { id: 'confirmado', nombre: 'Criterio clínico epidemiológico (Nexo)' },
         { id: 'autotest', nombre: 'Autotest' },
         { id: 'laboPcr', nombre: 'Laboratorio privado (PCR)' },
         { id: 'laboAntigeno', nombre: 'Laboratorio privado (Antígeno)' },

--- a/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
+++ b/src/app/modules/epidemiologia/services/ficha-epidemiologia.service.ts
@@ -54,9 +54,7 @@ export class FormsEpidemiologiaService extends ResourceBaseHttp {
                     }
                     break;
                 case 'segundaclasificacion':
-                    if (field.segundaclasificacion.id === 'confirmado') {
-                        conceptos.push(this.elementoRupService.getConceptoCovidConfirmadoNexo());
-                    } else if (field.segundaclasificacion.id === 'autotest' ||
+                    if (field.segundaclasificacion.id === 'autotest' ||
                         field.segundaclasificacion.id === 'laboPcr'
                         || field.segundaclasificacion.id === 'laboAntigeno') {
                         conceptos.push(this.elementoRupService.getConceptoEnfermedadCovid());


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/EP-211

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se elimina la opción Nexo del select Tipo de confirmación.
2. Se elimina la opción Nexo del buscador de fichas.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si https://github.com/andes/api/pull/1728
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No
