### PR TITLE
IN - controles para pacientes duplicados en camas distintas

### DIFF
--- a/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/cambiar-cama.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/cambiar-cama.component.ts
@@ -122,6 +122,7 @@ export class CambiarCamaComponent implements OnInit {
             _id: camaNueva.id,
             estado: camaActual.estado,
             idInternacion: camaActual.idInternacion,
+            idCamaAnterior: camaActual.id,
             paciente: camaActual.paciente,
             fechaIngreso: camaActual.fechaIngreso,
             nota: (!camaActual.sala) ? camaActual.nota : null,

--- a/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/cambiar-cama.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/cambiar-cama.component.ts
@@ -45,7 +45,6 @@ export class CambiarCamaComponent implements OnInit {
         const HOY = moment().toDate();
         this.historial$ = this.mapaCamasService.fecha2.pipe(
             switchMap(fecha => {
-                // this.fecha = moment(fecha).toDate();
                 return this.mapaCamasService.historial('internacion', fecha, HOY);
             }),
             map((movimientos) => {
@@ -116,7 +115,6 @@ export class CambiarCamaComponent implements OnInit {
                 }
             }
         });
-
     }
 
     guardar(valid) {

--- a/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/desocupar-cama.component.ts
+++ b/src/app/apps/rup/mapa-camas/sidebar/desocupar-cama/desocupar-cama.component.ts
@@ -51,7 +51,7 @@ export class CamaDesocuparComponent implements OnInit, OnDestroy {
     ngOnInit() {
         const HOY = moment().toDate();
         this.inProgress = true;
-
+        this.fecha = this.mapaCamasService.fecha;
         this.historial$ = this.mapaCamasService.fecha2.pipe(
             tap(() => this.inProgress = true),
             switchMap(fecha => {
@@ -111,6 +111,9 @@ export class CamaDesocuparComponent implements OnInit, OnDestroy {
         this.camasDisponibles$ = this.camaSelectedSegunView$.pipe(
             switchMap(cama => this.mapaCamasService.getCamasDisponibles(cama))
         );
+
+        this.verificarFecha();
+
     }
 
     onType() {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/IN-489

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrego un setFecha para que en primera instancia actualice el mapa de camas antes de realizar un movimiento y con este mismo va a saber si la cama se encuentra o no disponible para realizar un cambio. También se agregaron múltiples controles al momento de guardar un cambio o pase de UO para evitar duplicados o movimientos que no corresponden.

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

Nota: anteriormente requería los cambios en la api, pero como no son necesarios se procede a cerrar el PR. 

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
