### PR TITLE
MPI - Visualización de formulario para pacientes con DNI argentino

### DIFF
--- a/src/app/core/mpi/components/busqueda-mpi.component.ts
+++ b/src/app/core/mpi/components/busqueda-mpi.component.ts
@@ -48,7 +48,6 @@ export class BusquedaMpiComponent implements OnInit {
 
     // -------------- SOBRE BUSCADOR ----------------
 
-
     onSearchEnd(pacientes: any[], scan: string) {
         this.escaneado = scan?.length > 0;
         if (this.escaneado) {
@@ -65,7 +64,8 @@ export class BusquedaMpiComponent implements OnInit {
         if (paciente) {
             this.historialBusquedaService.add(paciente);
             this.pacienteCache.setPaciente(paciente);
-            if (paciente.numeroIdentificacion || paciente.tipoIdentificacion) {
+
+            if ((paciente.numeroIdentificacion || paciente.tipoIdentificacion) && !paciente.documento) {
                 this.router.navigate(['apps/mpi/paciente/extranjero/mpi']); // abre formulario paciente extranjero
             } else {
                 this.router.navigate(['apps/mpi/paciente']); // abre formulario paciente con/sin-dni

--- a/src/app/modules/mpi/components/paciente-buscar.component.ts
+++ b/src/app/modules/mpi/components/paciente-buscar.component.ts
@@ -3,7 +3,6 @@ import { Plex } from '@andes/plex';
 import { PacienteBuscarResultado } from '../interfaces/PacienteBuscarResultado.inteface';
 import { PacienteBuscarService } from '../../../core/mpi/services/paciente-buscar.service';
 import { Subscription } from 'rxjs';
-import { PacienteService } from '../../../core/mpi/services/paciente.service';
 
 interface PacienteEscaneado {
     documento: string;


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/MPI-392
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Al ingresar un paciente en la búsqueda de MPI, si el mismo es extranjero pero posee DNI argentino (validado o sin validar), se visualiza el formulario correspondiente para pacientes argentinos.
2. Se mantiene la visualización del formulario exclusivo para pacientes extranjeros solo si tienen numero de identificación pero no tienen DNI.
3. Se mantiene la visualización del formulario correspondiente para el resto de los casos.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
