### PR TITLE
CITAS - Separar permiso de creación de solicitudes

### DIFF
--- a/src/app/components/turnos/punto-inicio/puntoInicio-turnos.component.ts
+++ b/src/app/components/turnos/punto-inicio/puntoInicio-turnos.component.ts
@@ -24,6 +24,7 @@ export class PuntoInicioTurnosComponent implements OnInit {
     @Output() escaneado: EventEmitter<any> = new EventEmitter<any>();
     public disableNuevoPaciente = true;
     public puedeCrearSolicitud = false;
+    public puedeVisualizarSolicitud = false;
     public puedeAutocitar = false;
     public puedeDarTurno = false;
     public alerta = false;
@@ -76,6 +77,7 @@ export class PuntoInicioTurnosComponent implements OnInit {
         this.autorizado = this.auth.getPermissions('turnos:puntoInicio:?').length > 0;
         this.puedeDarTurno = this.auth.getPermissions('turnos:puntoInicio:darTurnos:?').length > 0;
         this.puedeCrearSolicitud = this.auth.getPermissions('turnos:puntoInicio:solicitud:?').length > 0;
+        this.puedeVisualizarSolicitud = this.auth.check('turnos:puntoInicio:visualizarSolicitud');
         this.puedeActivarAppMobile = this.auth.getPermissions('turnos:puntoInicio:activarMobile:?').length > 0;
         this.updateTitle('Punto de inicio');
     }

--- a/src/app/components/turnos/punto-inicio/puntoInicio-turnos.html
+++ b/src/app/components/turnos/punto-inicio/puntoInicio-turnos.html
@@ -56,8 +56,9 @@
                             </plex-button>
                         </td>
                         <td class="align-middle">
-                            <plex-button *ngIf="puedeCrearSolicitud" type="info" tooltip="Solicitudes"
-                                         icon="open-in-app" (click)="verificarOperacion('ingresarSolicitud', paciente)">
+                            <plex-button *ngIf="puedeCrearSolicitud || puedeVisualizarSolicitud" type="info"
+                                         tooltip="Solicitudes" icon="open-in-app"
+                                         (click)="verificarOperacion('ingresarSolicitud', paciente)">
                             </plex-button>
                         </td>
                         <td class="align-middle">

--- a/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.component.ts
+++ b/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.component.ts
@@ -35,7 +35,7 @@ export class ListaSolicitudTurnoVentanillaComponent implements OnInit {
     showCargarSolicitud = false;
     // VER SI HACE FALTA
     // public prioridadesPrestacion = enumToArray(PrioridadesPrestacion);
-
+    public puedeCrearSolicitud = false;
     constructor(
         public servicioPrestacion: PrestacionesService,
         public auth: Auth,
@@ -43,7 +43,7 @@ export class ListaSolicitudTurnoVentanillaComponent implements OnInit {
     ) { }
 
     ngOnInit() {
-
+        this.puedeCrearSolicitud = this.auth.check('turnos:puntoInicio:solicitud');
         this.autorizado = this.auth.getPermissions('turnos:darTurnos:?').length > 0;
         // No está autorizado para ver esta pantalla
         if (!this.autorizado) {

--- a/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.html
+++ b/src/app/components/turnos/punto-inicio/solicitud-turno-ventanilla/lista-solicitud-turno-ventanilla.html
@@ -1,6 +1,7 @@
 <div *ngIf="!showCargarSolicitud">
     <plex-title main titulo="Solicitudes">
-        <plex-button type="success" label="Cargar Solicitud nueva" (click)="formularioSolicitud()"></plex-button>
+        <plex-button *ngIf="puedeCrearSolicitud" type="success" label="Cargar Solicitud nueva"
+                     (click)="formularioSolicitud()"></plex-button>
     </plex-title>
     <div class="row mt-2">
         <div class="col-12">


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/CIT-211

GLPI: https://glpi.andes.gob.ar/front/ticket.form.php?id=3708

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se incorpora un nuevo permiso _Visualizar solicitudes_ que permita visualizar el listado de solicitudes pero que no se vea el botón _Cargar Solicitud Nueva_.
2. Cuando el permiso _Visualizar solictudes_ y   _Registrar solicitud_ están desactivados, no se muestra el botón _Solicitudes_.
3. Cuando el permiso _Visualizar solictudes_ está activado no se muestra el botón _Cargar Solicitud Nueva._

En resumen:
En ventanilla (CITAS) actualmente existe un permiso para poder visualizar el listado de solicitudes  y agregar una nueva (turnos:puntoInicio:solicitud) que está en el archivo puntoInicio-turnos.component.ts.
En esta funcionalidad se incorpora un nuevo permiso que permite solo visualizar el listado de solicitudes, pero no agregar solicitudes nuevas (turnos:puntoInicio: visualizarSolicitud) que está en el archivo puntoInicio-turnos.component.ts.
### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si   https://github.com/andes/api/pull/1793
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
