### PR TITLE
TOP - Revisar y analizar comportamiento del botón continuar

### DIFF
--- a/src/app/components/top/pipes/botones.pipe.ts
+++ b/src/app/components/top/pipes/botones.pipe.ts
@@ -66,10 +66,10 @@ export class BotonesSolicitudPipe implements PipeTransform {
                 botones.anular = true;
             }
         }
-        // Si el usuario tiene permisos para rup e inicio el registro de atencion medica o tiene permisos especiales podra continuar con la prestacion
+        // Si el usuario tiene permisos para rup e inicio el registro de atencion medica o tiene permisos especiales podra continuar con la prestacion en ejecución
         if (this.auth.getPermissions('rup:?').length) {
-            botones.continuarRegistro = ((prestacion.estadoActual.tipo === 'ejecucion') &&
-                (prestacion.estadoActual.createdBy.username === this.auth.usuario.username)) || (this.auth.check(`rup:validacion:${prestacion.solicitud.tipoPrestacion.id}`));
+            botones.continuarRegistro = prestacion.estadoActual.tipo === 'ejecucion' &&
+                (prestacion.estadoActual.createdBy.username === this.auth.usuario.username || this.auth.check(`rup:validacion:${prestacion.solicitud.tipoPrestacion.id}`));
         }
         return botones;
     }

--- a/src/app/components/top/pipes/estado-prestacion.pipe.ts
+++ b/src/app/components/top/pipes/estado-prestacion.pipe.ts
@@ -21,6 +21,6 @@ export class EstadoPrestacionPipe implements PipeTransform {
             'vencida': 'danger'
         };
 
-        return prestacion.solicitud.turno ? 'success' : badge[prestacion.estadoActual.tipo];
+        return badge[prestacion.estadoActual.tipo];
     }
 }

--- a/src/app/components/top/pipes/estado-solicitud.pipe.ts
+++ b/src/app/components/top/pipes/estado-solicitud.pipe.ts
@@ -9,11 +9,11 @@ export class EstadoSolicitudPipe implements PipeTransform {
     constructor(private auth: Auth) { }
     transform(prestacion: IPrestacion): any {
 
-        if (prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'validada') {
+        if (prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'validada' && prestacion.estadoActual.tipo !== 'ejecucion') {
             return 'Turno dado';
         }
         if (prestacion.solicitud.organizacion.id === this.auth.organizacion.id) {
-            if (prestacion.estadoActual.tipo === 'pendiente' && prestacion ?.paciente && !prestacion.solicitud.turno) {
+            if (prestacion.estadoActual.tipo === 'pendiente' && prestacion?.paciente && !prestacion.solicitud.turno) {
                 return 'pendiente';
             }
             const esAuditoria = prestacion.estadoActual.tipo === 'auditoria' || prestacion.estadoActual.tipo === 'rechazada';

--- a/src/app/components/top/solicitudes/solicitudes.component.ts
+++ b/src/app/components/top/solicitudes/solicitudes.component.ts
@@ -445,7 +445,7 @@ export class SolicitudesComponent implements OnInit {
             if (this.estadoEntrada) {
                 if (this.estadoEntrada.id === 'turnoDado') {
                     params['tieneTurno'] = true;
-                    params.estados = params.estados.filter(e => e !== 'validada');
+                    params.estados = params.estados.filter(e => e !== 'validada' && e !== 'ejecucion');
                 } else if (this.estadoEntrada.id === 'registroHUDS') {
                     params['estados'] = ['validada'];
                 } else {
@@ -488,7 +488,7 @@ export class SolicitudesComponent implements OnInit {
             if (this.estadoSalida) {
                 if (this.estadoSalida.id === 'turnoDado') {
                     params['tieneTurno'] = true;
-                    params.estados = params.estados.filter(e => e !== 'validada');
+                    params.estados = params.estados.filter(e => e !== 'validada' && e !== 'ejecucion');
                 } else if (this.estadoSalida.id === 'registroHUDS') {
                     params['estados'] = ['validada'];
                 } else {

--- a/src/app/components/top/solicitudes/solicitudes.html
+++ b/src/app/components/top/solicitudes/solicitudes.html
@@ -171,8 +171,9 @@
                                 {{prestacion.solicitud.registros[0].valor.solicitudPrestacion.prioridad}}
                             </plex-badge>
                             <plex-badge type="{{prestacion | estadoPrestacion}}"
-                                        *ngIf="!prestacion.solicitud.turno && prestacion.estadoActual.tipo !== 'rechazada' && prestacion.estadoActual.tipo !== 'auditoria' && prestacion.estadoActual.tipo !== 'validada' && prestacion.estadoActual.tipo !== 'vencida'">
-                                {{prestacion | estadoSolicitud}}
+                                        *ngIf="prestacion.estadoActual.tipo !== 'rechazada' && prestacion.estadoActual.tipo !== 'auditoria' && prestacion.estadoActual.tipo !== 'validada' && prestacion.estadoActual.tipo !== 'vencida'">
+                                {{ prestacion | estadoSolicitud}}
+
                             </plex-badge>
                             <plex-badge type="{{prestacion | estadoPrestacion}}"
                                         *ngIf="!prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'">
@@ -195,7 +196,8 @@
                                         </span>
                                     </plex-badge>
                                 </ng-container>
-                                <plex-badge *ngIf="estado === 'Turno dado'" type="success">Turno dado</plex-badge>
+                                <plex-badge *ngIf="prestacion.solicitud.turno && !prestacion.estadoActual.tipo === 'ejecucion' "
+                                            type="success">Turno dado</plex-badge>
                                 <plex-badge *ngIf="prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'"
                                             type="success">
                                     Registro en HUDS</plex-badge>
@@ -321,7 +323,7 @@
                             </plex-badge>
                             <plex-badge *ngIf="prestacion.estadoActual.tipo !== 'rechazada' && prestacion.estadoActual.tipo !== 'validada' && prestacion.solicitud.turno"
                                         type="{{prestacion | estadoPrestacion}}">
-                                Turno Dado
+                                {{ prestacion | estadoSolicitud}}
                             </plex-badge>
                             <plex-badge *ngIf="prestacion.solicitud.turno && prestacion.estadoActual.tipo === 'validada'"
                                         type="success">Registro en
@@ -382,10 +384,9 @@
                                 </plex-help>
 
                                 <!-- CONTINUAR REGISTRO -->
-                                <plex-button class="mr-1"
-                                             *ngIf="botones.continuarRegistro || prestacionSeleccionada.estadoActual.tipo === 'ejecucion'"
-                                             icon="lapiz-documento" tooltip="Continuar registro" tooltipPosition="left"
-                                             size="sm" type="success" (click)="onContinuarRegistro()">
+                                <plex-button class="mr-1" *ngIf="botones.continuarRegistro " icon="lapiz-documento"
+                                             tooltip="Continuar registro" tooltipPosition="left" size="sm"
+                                             type="success" (click)="onContinuarRegistro()">
                                 </plex-button>
 
                                 <!-- VOLVER A AUDITORIA -->


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/TOP-142
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1.  Corregidos badges de solicitudes de "Turno dado" a "Ejecución"
2.  Corregidos filtros de "Turno dado" que también mostraba solicitudes en "Ejecución"
3.  Botón "Continuar registro" restringido a solicitudes donde el usuario tiene permisos para rup e inició el registro de atención medica o tiene permisos especiales, siempre con con la prestación  en ejecución.



### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
