### PR TITLE
HUDS -  Eliminar el registro de acceso a la HUDS cuando no corresponde

### DIFF
--- a/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.component.ts
@@ -914,7 +914,7 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
 
         const doRoute = () => this.routeTo(this.routeToParams[0], (this.routeToParams[1]) ? this.routeToParams[1] : null);
         if ((this.tieneAccesoHUDS || this.motivoVerContinuarPrestacion === motivo) && motivo) {
-            if (this.prestacionNominalizada) {
+            if (!this.tieneAccesoHUDS && (this.agendaSeleccionada?.nominalizada || this.agendaSeleccionada === 'fueraAgenda')) {
                 this.accesoHudsPaciente = null;
             }
             if (!this.accesoHudsPaciente && !this.accesoHudsPrestacion && this.routeToParams && this.routeToParams[0] === 'huds') {
@@ -961,7 +961,7 @@ export class PuntoInicioComponent implements OnInit, OnDestroy {
         const esPrestacionNoNominalizada = prestacion.solicitud.tipoPrestacion.noNominalizada;
         if (!esPrestacionNoNominalizada) {
             this.setRouteToParams([estado, prestacion.id]);
-            this.accesoHudsPaciente = prestacion.paciente;
+            this.tieneAccesoHUDS ? this.accesoHudsPaciente = prestacion.paciente : this.accesoHudsPaciente = null;
             this.accesoHudsTurno = null;
             this.accesoHudsPrestacion = prestacion.solicitud.tipoPrestacion.id;
             this.motivosHudsService.getMotivo('continuidad').subscribe(motivoH => {

--- a/src/app/modules/rup/components/ejecucion/puntoInicio.html
+++ b/src/app/modules/rup/components/ejecucion/puntoInicio.html
@@ -353,7 +353,7 @@
                                                 <plex-button *ngIf="turno.botonera.continuar" class="ml-1"
                                                              tooltip="Continuar registro" tooltipPosition="left"
                                                              icon="lapiz-documento" type="primary btn-sm"
-                                                             (click)="setRouteToParams(['ejecucion', chequearPrestacion(turno).id]); accesoHudsPaciente = turno.paciente; accesoHudsTurno = turno.id; accesoHudsPrestacion = turno.tipoPrestacion.id; preAccesoHuds(motivoVerContinuarPrestacion)">
+                                                             (click)="setRouteToParams(['ejecucion', chequearPrestacion(turno).id]);  accesoHudsTurno = turno.id;preAccesoHuds(motivoVerContinuarPrestacion)">
                                                 </plex-button>
                                                 <plex-button class="ml-1" tooltip="Ver resumen"
                                                              icon="documento-paciente" *ngIf="turno.botonera.resumen"


### PR DESCRIPTION
…responde

<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/HUDS-140
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se elimina el acceso a huds cuando en RUP no se tienen permisos de HUDS al presionar "Ver resumen" y "Continuar registro"


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
