### PR TITLE
CIT - Error al volver a disponible turno suspendido

### DIFF
--- a/src/app/components/turnos/gestor-agendas/pipes/botonesAgenda.pipe.ts
+++ b/src/app/components/turnos/gestor-agendas/pipes/botonesAgenda.pipe.ts
@@ -78,7 +78,7 @@ export class BotonesAgendaPipe implements PipeTransform {
 
     // Comprueba que haya algún turno con paciente, en estado suspendido
     hayTurnosSuspendidos(agenda) {
-        return !agenda.dinamica && agenda.bloques.some(bloque => bloque.turnos?.some(turno => turno.estado === 'suspendido' && turno.paciente?.id));
+        return !agenda.dinamica && agenda.bloques.some(bloque => bloque.turnos?.some(turno => turno.estado === 'suspendido' && turno.paciente?.id && !turno.reasignado?.siguiente));
     }
 
     puedeCargaMasiva(agenda) {

--- a/src/app/components/turnos/gestor-agendas/pipes/botonesTurnos.pipe.ts
+++ b/src/app/components/turnos/gestor-agendas/pipes/botonesTurnos.pipe.ts
@@ -35,10 +35,10 @@ export class BotonesTurnosPipe implements PipeTransform {
             botones.sacarAsistencia = puedeRegistrarAsistencia && this.agendaNoCerrada(agenda) && this.tienenAsistencia(turnos) && this.tienenPacientes(turnos) && !this.tienenDiagnostico(turnos);
             botones.nota = this.agendaNoCerrada(agenda);
             // Suspender turno: El turno no tiene asistencia ==> el estado pasa a "suspendido"
-            botones.suspender = puedeSuspenderTurno && this.agendaNoCerrada(agenda) && this.agendaNoSuspendida(agenda) && this.noTienenAsistencia(turnos) && this.ningunoConEstado('suspendido', turnos) && this.ningunoConEstado('turnoDoble', turnos) && !this.tienenDiagnostico(turnos);
+            botones.suspender = puedeSuspenderTurno && this.agendaNoCerrada(agenda) && this.agendaNoSuspendida(agenda) && this.noTienenAsistencia(turnos) && this.ningunoConEstado('suspendido', turnos) && this.ningunoConEstado('turnoDoble', turnos) && !this.tienenDiagnostico(turnos) && this.noTieneSuspendidos(turnos);
             // Enviar SMS
             botones.sms = this.agendaNoSuspendida(agenda) && this.todosConEstado('asignado', turnos) && this.todosConEstado('suspendido', turnos) && this.noTienenAsistencia(turnos) && (!this.hayTurnosTarde(agenda, turnos));
-            botones.cambiarDisponible = !this.tienenPacientes(turnos) && this.todosConEstado('suspendido', turnos);
+            botones.cambiarDisponible = this.pasarADisponible(turnos);
         }
         if (agenda && turnos.length === 1) {
             // Liberar turno: está "asignado" ==> el estado pasa a "disponible" y se elimina el paciente
@@ -62,6 +62,10 @@ export class BotonesTurnosPipe implements PipeTransform {
         return turnos.filter((turno) => {
             return (turno.paciente && turno.paciente.id);
         }).length === turnos.length;
+    }
+
+    pasarADisponible(turnos) {
+        return turnos.every(turno => turno.estado === 'suspendido' && !turno.paciente);
     }
 
     agendaNoSuspendida(agenda) {
@@ -164,5 +168,9 @@ export class BotonesTurnosPipe implements PipeTransform {
                 return moment(turno.horaInicio).format() < moment().format();
             }).length;
         }
+    }
+
+    noTieneSuspendidos(turnos) {
+        return !turnos.some(turno => turno.estado === 'suspendido');
     }
 }

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -359,7 +359,6 @@ export class TurnosComponent implements OnInit {
         };
         this.serviceAgenda.patch(this.agenda.id, patch).subscribe({
             next: resultado => {
-                this.saveLiberarTurno(this.agenda);
                 if (alertCount === 0) {
                     if (this.turnosSeleccionados.length === 1) {
                         this.plex.toast('success', 'El turno seleccionado fue cambiado a disponible.');
@@ -368,8 +367,7 @@ export class TurnosComponent implements OnInit {
                     }
                     alertCount++;
                 }
-
-                this.agenda = resultado;
+                this.saveLiberarTurno(this.agenda);
             },
             error: err => {
                 if (err) {

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -352,37 +352,33 @@ export class TurnosComponent implements OnInit {
 
     pasarADisponible() {
         let alertCount = 0;
-        this.turnosSeleccionados.forEach((index) => {
 
-            const patch = {
-                'op': 'liberarTurno',
-                'turnos': this.turnosSeleccionados.map(resultado => resultado._id)
-            };
-            this.serviceAgenda.patch(this.agenda.id, patch).subscribe({
-                next: resultado => {
-                    this.saveLiberarTurno(this.agenda);
-                    if (alertCount === 0) {
-                        if (this.turnosSeleccionados.length === 1) {
-                            this.plex.toast('success', 'El turno seleccionado fue cambiado a disponible.');
-                        } else {
-                            this.plex.toast('success', 'Los turnos seleccionados fueron cambiados a disponible.');
-                        }
-                        alertCount++;
+        const patch = {
+            'op': 'liberarTurno',
+            'turnos': this.turnosSeleccionados.map(resultado => resultado._id)
+        };
+        this.serviceAgenda.patch(this.agenda.id, patch).subscribe({
+            next: resultado => {
+                this.saveLiberarTurno(this.agenda);
+                if (alertCount === 0) {
+                    if (this.turnosSeleccionados.length === 1) {
+                        this.plex.toast('success', 'El turno seleccionado fue cambiado a disponible.');
+                    } else {
+                        this.plex.toast('success', 'Los turnos seleccionados fueron cambiados a disponible.');
                     }
-
-                    this.agenda = resultado;
-                    if (index === this.turnosSeleccionados.length - 1) {
-                        this.saveLiberarTurno(this.agenda);
-                    }
-                },
-                error: err => {
-                    if (err) {
-                        this.plex.info('warning', 'Turno en ejecución', 'Error');
-                        this.cancelaLiberarTurno();
-                    }
+                    alertCount++;
                 }
-            });
+
+                this.agenda = resultado;
+            },
+            error: err => {
+                if (err) {
+                    this.plex.info('warning', 'Turno en ejecución', 'Error');
+                    this.cancelaLiberarTurno();
+                }
+            }
         });
+
     }
 
     saveLiberarTurno(agenda: any) {
@@ -435,5 +431,13 @@ export class TurnosComponent implements OnInit {
 
     cerrarSidebarTurnos() {
         this.cerrarSidebar.emit();
+    }
+
+    pasarAdisponible(botones) {
+        if (this.turnosSeleccionados.length) {
+            const noDisponible = !this.turnosSeleccionados.some(turno => turno.estado === 'suspendido' && turno.paciente);
+            return noDisponible && botones.cambiarDisponible;
+        }
+        return false;
     }
 }

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -37,8 +37,8 @@
                                     (saveAgregarNotaTurno)="saveAgregarNotaTurno()">
                 </agregar-nota-turno>
             </plex-help>
-            <plex-help *ngIf="botones.suspender && turnosSeleccionados?.length" class="mr-1" btnType="danger"
-                       icon="stop" tooltip="Suspender turnos" tooltipPosition="left">
+            <plex-help *ngIf="botones.suspender" class="mr-1" btnType="danger" icon="stop" tooltip="Suspender turnos"
+                       tooltipPosition="left">
                 <suspender-turno [agenda]="agenda" [accion]="'suspenderTurno'"
                                  [turnosSeleccionados]="turnosSeleccionados" (saveSuspenderTurno)="saveSuspenderTurno()"
                                  (reasignarTurnoSuspendido)="reasignarTurnoSuspendido($event)">


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/CIT-369

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se soluciona el problema de que no se actualiza el contador de turnos cuando se suspenden los turnos y se vuelven a pasar a disponible
2. Se agregan otras soluciones como: 
- No se muestra el botón de reasignar dentro de la agenda una vez que se hayan reasignado todos los turnos. 
- Una vez que el turno se suspende (con o sin paciente) no se puede volver a suspender el mismo. 
- No se pueden liberar turnos suspendidos que presenten un paciente.  


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si   https://github.com/andes/api/pull/2026
- [ ] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
