### PR TITLE
HUDS - Visualización de badge incorrecto

### DIFF
--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
@@ -1093,4 +1093,14 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
         return this.recetasService.getRecetaPrincipal(recetas);
 
     }
+
+    estadoRegistro(estado) {
+        if (estado === 'validada') {
+            return 'success';
+        } else if (estado === 'anulada' || estado === 'vencida' || estado === 'rechazada') {
+            return 'danger';
+        } else {
+            return 'info';
+        }
+    }
 }

--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.html
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.html
@@ -6,9 +6,9 @@
     <div class="container-filtros">
         <div class="slider-filtros">
             <plex-card class="card-filtro" *ngFor="let filtro of filtros; let iPrestacion = index"
-                       (click)="filtroBuscador(filtro.key)">
+                (click)="filtroBuscador(filtro.key)">
                 <div *ngIf="mostrarItem(filtro)" class="card-content {{filtro.key}}"
-                     [ngClass]="{'active': filtroActual === filtro.key}">
+                    [ngClass]="{'active': filtroActual === filtro.key}">
                     <div class="icon-wrapper">
                         <div class="contador"><small *ngIf="getCantidadResultados(filtro.key)">
                                 {{getCantidadResultados(filtro.key)}}
@@ -26,17 +26,16 @@
 
         <div *ngIf="filtroActual === 'laboratorios'" justify="end">
             <plex-button class="mr-1" icon="refresh" type="primary" size="sm" tooltip="Actualizar listado"
-                         [autodisabled]="true" (click)="refreshLaboratorios(token)">
+                [autodisabled]="true" (click)="refreshLaboratorios(token)">
             </plex-button>
             <plex-button icon="database-search" type="success" size="sm" tooltipPosition="left"
-                         tooltip="Buscar nuevos registros" [disabled]="disabledBtnCDA" (click)="regenerarCDA()">
+                tooltip="Buscar nuevos registros" [disabled]="disabledBtnCDA" (click)="regenerarCDA()">
             </plex-button>
         </div>
 
         <suspender-medicacion *ngIf="filtroActual==='recetas' && seleccionRecetas.length > 0"
-                              [seleccionRecetas]="seleccionSuspender" [motivoSelector]="motivoSuspensionSelector"
-                              [motivosSuspension]="motivosSuspension" [profesional]="profesional"
-                              (reset)="resetSeleccionRecetas()">
+            [seleccionRecetas]="seleccionSuspender" [motivoSelector]="motivoSuspensionSelector"
+            [motivosSuspension]="motivosSuspension" [profesional]="profesional" (reset)="resetSeleccionRecetas()">
         </suspender-medicacion>
     </div>
     <div class="grow" *ngIf="filtroActual === 'planes'">
@@ -44,8 +43,8 @@
         </plex-options>
         <div class="ml-1">
             <plex-button type="info" size="sm" [icon]="showFiltros ? 'chevron-up' : 'chevron-down'"
-                         [title]="showFiltros ? 'Cerrar filtros' : 'Ver filtros'" class="float-right"
-                         tooltipPosition="left" (click)="toogleFiltros()">
+                [title]="showFiltros ? 'Cerrar filtros' : 'Ver filtros'" class="float-right" tooltipPosition="left"
+                (click)="toogleFiltros()">
             </plex-button>
         </div>
     </div>
@@ -53,16 +52,16 @@
 
 
 <ng-container
-              *ngIf="filtroActual !== 'solicitudes' && filtroActual !== 'planes' && filtroActual !== 'laboratorios' && filtroActual !== 'vacunas' && filtroActual !== 'dominios'">
+    *ngIf="filtroActual !== 'solicitudes' && filtroActual !== 'planes' && filtroActual !== 'laboratorios' && filtroActual !== 'vacunas' && filtroActual !== 'dominios'">
     <div *ngIf="hasRegistrosTotales(filtroActual)" class="mb-2">
         <plex-text [(ngModel)]="searchTerm" name="searchTerm" (change)="buscar()" placeholder="Buscar registros..."
-                   [autoFocus]="true">
+            [autoFocus]="true">
         </plex-text>
     </div>
 
     <div class="my-2" *ngIf="filtroActual === 'trastorno' && hasRegistrosTotales(filtroActual)">
         <plex-bool [(ngModel)]="filtroTrastornos" name="filtroTrastornos" (change)="filtrarTrastornos()" type="slide"
-                   label="{{filtroTrastornos ? 'Activos' : 'Todos'}}">
+            label="{{filtroTrastornos ? 'Activos' : 'Todos'}}">
         </plex-bool>
     </div>
 
@@ -70,29 +69,31 @@
     <!-- Vista Recetas -->
     <ng-container *ngIf="filtroActual === 'recetas'">
         <plex-text [(ngModel)]="searchRecetas" name="searchRecetas" (change)="filtrarRecetas()"
-                   placeholder="Buscar recetas..." [autoFocus]="true">
+            placeholder="Buscar recetas..." [autoFocus]="true">
         </plex-text>
         <div class="my-2">
             <ul *ngIf="busquedaRecetas.length" class="hover listado list-unstyled">
                 <ng-container *ngFor="let grupo of busquedaRecetas; let iReceta = index">
                     <li>
                         <plex-bool [readonly]="!esRecetaSeleccionable(grupo?.recetaVisible)"
-                                   [ngModel]="seleccionRecetas[iReceta]" name="seleccionada" type="checkbox"
-                                   (change)="seleccionarReceta($event, grupo.recetas, iReceta)">
+                            [ngModel]="seleccionRecetas[iReceta]" name="seleccionada" type="checkbox"
+                            (change)="seleccionarReceta($event, grupo.recetas, iReceta)">
                         </plex-bool>
                         <div class="total">
                             <div class="row vista-badges"
-                                 *ngIf="grupo.recetaVisible?.medicamento?.tratamientoProlongado">
+                                *ngIf="grupo.recetaVisible?.medicamento?.tratamientoProlongado">
                                 <span class="pl-2 pr-2 mr-3 upTag" [ngClass]="{'active': huds.isOpen(grupo, 'receta')}">
-                                    {{ textoTratamientoProlongado(grupo) }}
-                                </span>
+                                    Tratamiento prolongado: {{ (grupo.recetaVisible?.medicamento?.ordenTratamiento !==
+                                    null && grupo.recetaVisible?.medicamento?.ordenTratamiento !== undefined) ?
+                                    (grupo.recetaVisible.medicamento.ordenTratamiento + 1) : 0 }} de
+                                    {{grupo.recetaVisible?.medicamento.tiempoTratamiento?.id}}</span>
                             </div>
                             <div class="rup-card mini recetas total"
-                                 [ngClass]="{'active': huds.isOpen(grupo, 'receta')}"
-                                 (click)="emitTabs(grupo, 'receta', iReceta)">
+                                [ngClass]="{'active': huds.isOpen(grupo, 'receta')}"
+                                (click)="emitTabs(grupo, 'receta', iReceta)">
                                 <div class="rup-header">
                                     <div class="rup-border rup-border-recetas"
-                                         [ngClass]="{'active': huds.isOpen(grupo, 'receta')}">
+                                        [ngClass]="{'active': huds.isOpen(grupo, 'receta')}">
                                         <div class="row p-0 m-0 border-secondary border-left-0">
                                             <div class="col-9 p-0 m-0">
                                                 <div class="row m-0 p-0">
@@ -124,12 +125,12 @@
                                                 <div class="p-0 pt-1 pr-1 float-right">
                                                     <div class="vista-badges">
                                                         <plex-badge size="sm"
-                                                                    [type]="estadoReceta[grupo.recetaVisible?.estadoActual.tipo]">
+                                                            [type]="estadoReceta[grupo.recetaVisible?.estadoActual.tipo]">
                                                             {{ grupo.recetaVisible?.estadoActual?.tipo.replace('-', ' ')
                                                             }}
                                                         </plex-badge>
                                                         <plex-badge size="sm"
-                                                                    [type]="estadoDispensa[grupo.recetaVisible?.estadoDispensaActual.tipo]">
+                                                            [type]="estadoDispensa[grupo.recetaVisible?.estadoDispensaActual.tipo]">
                                                             {{
                                                             grupo.recetaVisible?.estadoDispensaActual?.tipo.replace('-',
                                                             ' ')
@@ -152,7 +153,7 @@
             <hr class="mt-0">
             <div class="item-lista-vacia">
                 <plex-label size="sm" justify="center" icon="adi adi-listado-receta"
-                            titulo="No hay recetas registradas">
+                    titulo="No hay recetas registradas">
                 </plex-label>
             </div>
         </div>
@@ -167,11 +168,11 @@
                 <ng-container *ngFor="let registro of solicitudesMezcladas; let iPrestacion = index">
                     <li>
                         <div class="rup-card mini procedimiento"
-                             [ngClass]="{'active': huds.isOpen(registro, 'solicitud') ||  huds.isOpen(registro, 'concepto'), 'solicitud': true}"
-                             (click)="clickSolicitud(registro, iPrestacion)">
+                            [ngClass]="{'active': huds.isOpen(registro, 'solicitud') ||  huds.isOpen(registro, 'concepto'), 'solicitud': true}"
+                            (click)="clickSolicitud(registro, iPrestacion)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-procedimiento"
-                                     [ngClass]="{'active': huds.isOpen(registro, 'solicitud') ||  huds.isOpen(registro, 'concepto'), 'rup-border-plan': true}">
+                                    [ngClass]="{'active': huds.isOpen(registro, 'solicitud') ||  huds.isOpen(registro, 'concepto'), 'rup-border-plan': true}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
@@ -212,18 +213,16 @@
                                         </div>
                                         <div class="col-2 p-0 m-0">
                                             <div class="p-0 pt-1 pr-1 float-right">
-                                                <plex-badge size="sm"
-                                                            [type]="registro.estadoActual.tipo === 'validada' ? 'success' :'info'"
-                                                            *ngIf="registro.estadoActual">
+                                                <plex-badge *ngIf="registro.estadoActual" size="sm"
+                                                    [type]="estadoRegistro(registro.estadoActual?.tipo)">
                                                     {{ registro.estadoActual.tipo }}
                                                     <plex-button *ngIf='registro.evoluciones' size="sm" type="info"
-                                                                 icon="information-outline"
-                                                                 title="Registrado por profesional"
-                                                                 titlePosition="left">
+                                                        icon="information-outline" title="Registrado por profesional"
+                                                        titlePosition="left">
                                                     </plex-button>
                                                     <plex-button *ngIf='!registro.evoluciones' size="sm" type="info"
-                                                                 icon="information-outline"
-                                                                 title="Registrado por gestión" titlePosition="left">
+                                                        icon="information-outline" title="Registrado por gestión"
+                                                        titlePosition="left">
                                                     </plex-button>
                                                 </plex-badge>
                                             </div>
@@ -239,7 +238,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-mano-corazon"
-                                titulo="No hay solicitudes registradas">
+                        titulo="No hay solicitudes registradas">
                     </plex-label>
                 </div>
             </div>
@@ -251,11 +250,11 @@
                 <ng-container *ngFor="let registro of registrosTotales.hallazgo ; let iConcepto = index">
                     <li>
                         <div class="rup-card mini hallazgo"
-                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                             (click)="emitTabs(registro, 'concepto', iConcepto)">
+                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                            (click)="emitTabs(registro, 'concepto', iConcepto)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-hallazgo"
-                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
+                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
@@ -299,7 +298,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-hallazgo"
-                                titulo="No hay hallazgos registrados">
+                        titulo="No hay hallazgos registrados">
                     </plex-label>
                 </div>
             </div>
@@ -311,17 +310,17 @@
                 <ng-container *ngFor="let registro of registrosTotales.trastorno; let iConcepto = index">
                     <li>
                         <div class="rup-card mini trastorno"
-                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                             (click)="emitTabs(registro, 'concepto', iConcepto)">
+                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                            (click)="emitTabs(registro, 'concepto', iConcepto)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-trastorno"
-                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
+                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
                                                 <div class="icon-rup drag-handle p-0 pt-1" draggable
-                                                     [dragScope]="'registros-rup'" [dragData]="registro.concepto"
-                                                     (onDragStart)="dragStart($event)" (onDragEnd)="dragEnd($event)">
+                                                    [dragScope]="'registros-rup'" [dragData]="registro.concepto"
+                                                    (onDragStart)="dragStart($event)" (onDragEnd)="dragEnd($event)">
                                                     <i class="adi adi-trastorno"></i>
                                                 </div>
                                                 <div class="col p-0 pl-2 float-left">
@@ -349,14 +348,14 @@
                                             <div class="p-0 pt-1 pr-1 float-right">
                                                 <ng-container *ngIf="registro.evoluciones">
                                                     <plex-badge size="sm"
-                                                                [type]="registro.evoluciones[0].estado === 'activo' ? 'success' : 'danger'">
+                                                        [type]="registro.evoluciones[0].estado === 'activo' ? 'success' : 'danger'">
                                                         {{ registro.evoluciones[0].estado }}
                                                     </plex-badge>
                                                 </ng-container>
                                                 <button class="btn btn-sm btn-primary btn-icon-rup p-0"
-                                                        *ngIf="emitirConceptos && registro?.evoluciones[0]?.estado !== 'resuelto' "
-                                                        (click)="$event.stopPropagation(); agregarRegistro(registro)"
-                                                        title="Agregar a la consulta" titlePosition="left">
+                                                    *ngIf="emitirConceptos && registro?.evoluciones[0]?.estado !== 'resuelto' "
+                                                    (click)="$event.stopPropagation(); agregarRegistro(registro)"
+                                                    title="Agregar a la consulta" titlePosition="left">
                                                     <i class="mdi mdi-plus"></i>
                                                 </button>
                                             </div>
@@ -372,7 +371,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-trastorno"
-                                titulo="No hay trastornos registrados">
+                        titulo="No hay trastornos registrados">
                     </plex-label>
                 </div>
             </div>
@@ -384,11 +383,11 @@
                 <ng-container *ngFor="let registro of registrosTotales.registro; let iConcepto = index">
                     <li>
                         <div class="rup-card mini elementoderegistro"
-                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                             (click)="emitTabs(registro, 'concepto', iConcepto)">
+                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                            (click)="emitTabs(registro, 'concepto', iConcepto)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-elementoderegistro"
-                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-registro': registro.esSolicitud}">
+                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-registro': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
@@ -433,7 +432,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-documento-lapiz"
-                                titulo="No hay elementos de registros cargados">
+                        titulo="No hay elementos de registros cargados">
                     </plex-label>
                 </div>
             </div>
@@ -445,17 +444,17 @@
                 <ng-container *ngFor="let registro of registrosTotales.procedimiento; let iPrestacion = index">
                     <li>
                         <div class="rup-card mini procedimiento"
-                             [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
-                             (click)="emitTabs(registro, 'concepto', iPrestacion)">
+                            [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'solicitud': registro.esSolicitud}"
+                            (click)="emitTabs(registro, 'concepto', iPrestacion)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-procedimiento"
-                                     [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
+                                    [ngClass]="{'active': huds.isOpen(registro, 'concepto'), 'rup-border-plan': registro.esSolicitud}">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
                                         <div class="col-10 p-0 m-0">
                                             <div class="row m-0 p-0">
                                                 <div class="col-2 icon-rup drag-handle">
                                                     <i class="adi" [class.adi-termometro]="!registro.isSolicitud"
-                                                       [class.adi-mano-corazon]="registro.esSolicitud"></i>
+                                                        [class.adi-mano-corazon]="registro.esSolicitud"></i>
                                                 </div>
                                                 <div class="col p-0 pl-2 float-left">
                                                     {{ registro.concepto.term }}
@@ -493,7 +492,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-termometro"
-                                titulo="No hay procedimientos registrados">
+                        titulo="No hay procedimientos registrados">
                     </plex-label>
                 </div>
             </div>
@@ -505,26 +504,26 @@
                 <div class="row">
                     <div class="col-12">
                         <plex-select [(ngModel)]="prestacionSeleccionada" label="Prestación" [data]="tiposPrestacion"
-                                     idField="conceptId" labelField="term" (change)="filtrar()" [multiple]="true">
+                            idField="conceptId" labelField="term" (change)="filtrar()" [multiple]="true">
                         </plex-select>
                     </div>
                 </div>
                 <div *ngIf="!efectorRestringido" class="row">
                     <div class="col-12">
                         <plex-select [(ngModel)]="organizacionSeleccionada" label="Organización" [data]="organizaciones"
-                                     idField="id" labelField="nombre" (change)="filtrar()">
+                            idField="id" labelField="nombre" (change)="filtrar()">
                         </plex-select>
                     </div>
                 </div>
                 <div class="row pb-2">
                     <div class="col-6">
                         <plex-datetime type="date" [(ngModel)]="fechaInicio" (change)="filtrar()" name="fechaInicio"
-                                       label="Fecha Desde" [debounce]="400">
+                            label="Fecha Desde" [debounce]="400">
                         </plex-datetime>
                     </div>
                     <div class="col-6">
                         <plex-datetime type="date" [(ngModel)]="fechaFin" (change)="filtrar()" name="fechaFin"
-                                       label="Fecha Hasta" [debounce]="400">
+                            label="Fecha Hasta" [debounce]="400">
                         </plex-datetime>
                     </div>
                 </div>
@@ -538,7 +537,7 @@
                                 <div plex-accordion-title case="capitalize">
                                     <div class="d-flex">
                                         <div class="icono"><plex-icon class="icon" size="lg"
-                                                       name="documento"></plex-icon></div>
+                                                name="documento"></plex-icon></div>
                                         <div>
                                             Detalle de la internacion
                                             <br>
@@ -556,9 +555,9 @@
 
                                 <div class="list-group">
                                     <div *ngFor="let registro of internacion.registros; let iInternacion = index"
-                                         class="item-prestacion list-group-item"
-                                         [ngClass]="{'activo': huds.someOpen(internacion, iInternacion)}"
-                                         (click)="emitTabs(internacion, 'internacion', iInternacion)">
+                                        class="item-prestacion list-group-item"
+                                        [ngClass]="{'activo': huds.someOpen(internacion, iInternacion)}"
+                                        (click)="emitTabs(internacion, 'internacion', iInternacion)">
                                         <div *ngIf="registro.conceptId === '430147008'" class="icono hidrico">
                                             <plex-icon class="icon" size="lg" name="mano-gota"></plex-icon>
                                         </div>
@@ -566,7 +565,7 @@
                                             <plex-icon class="icon" size="lg" name="pildoras"></plex-icon>
                                         </div>
                                         <div *ngIf="!registro.conceptId" class="icono otras"><plex-icon class="icon"
-                                                       size="lg" name="circulo-paciente"></plex-icon></div>
+                                                size="lg" name="circulo-paciente"></plex-icon></div>
                                         <div class="titulo text-capitalize">
                                             <p>{{registro.term || 'Evoluciones y otros registros'}}</p>
                                         </div>
@@ -581,7 +580,7 @@
                                 <div plex-accordion-title case="capitalize">
                                     <div class="d-flex">
                                         <div class="icono"><plex-icon class="icon" size="lg"
-                                                       name="documento"></plex-icon></div>
+                                                name="documento"></plex-icon></div>
                                         <div>
                                             Prestación fuera de internación
                                             <br>
@@ -597,15 +596,15 @@
 
                                 <div class="list-group">
                                     <div *ngFor="let indice of otrasPrestaciones.indices; let iInternacion = index"
-                                         class="item-prestacion list-group-item"
-                                         [ngClass]="{'activo': huds.someOpen(internacion, iInternacion)}"
-                                         (click)="emitTabs(otrasPrestaciones, 'internacion', iInternacion)">
+                                        class="item-prestacion list-group-item"
+                                        [ngClass]="{'activo': huds.someOpen(internacion, iInternacion)}"
+                                        (click)="emitTabs(otrasPrestaciones, 'internacion', iInternacion)">
                                         <div *ngIf="indice.conceptId === '430147008'" class="icono hidrico"><plex-icon
-                                                       class="icon" size="lg" name="mano-gota"></plex-icon></div>
+                                                class="icon" size="lg" name="mano-gota"></plex-icon></div>
                                         <div *ngIf="indice.conceptId === '33633005'" class="icono medico"><plex-icon
-                                                       class="icon" size="lg" name="pildoras"></plex-icon></div>
+                                                class="icon" size="lg" name="pildoras"></plex-icon></div>
                                         <div *ngIf="!indice.conceptId" class="icono otras"><plex-icon class="icon"
-                                                       size="lg" name="circulo-paciente"></plex-icon></div>
+                                                size="lg" name="circulo-paciente"></plex-icon></div>
                                         <div class="titulo text-capitalize">
                                             <p>{{indice.term || 'Evoluciones y otros registros'}}</p>
                                         </div>
@@ -618,7 +617,7 @@
                         <hr class="mt-0">
                         <div class="item-lista-vacia">
                             <plex-label size="sm" justify="center" icon="adi adi-clipboard-check-outline"
-                                        titulo="No hay prestaciones registradas">
+                                titulo="No hay prestaciones registradas">
                             </plex-label>
                         </div>
                     </div>
@@ -628,11 +627,11 @@
                     <ng-container *ngFor="let prestacion of prestaciones; let iPrestacion = index">
                         <li>
                             <div class="rup-card mini prestacion"
-                                 [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}"
-                                 (click)="emitTabs(prestacion, prestacion.tipo, iPrestacion)">
+                                [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}"
+                                (click)="emitTabs(prestacion, prestacion.tipo, iPrestacion)">
                                 <div class="rup-header">
                                     <div class="rup-border rup-border-prestacion"
-                                         [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}">
+                                        [ngClass]="{'active': huds.isOpen(prestacion.data, prestacion.tipo)}">
                                         <div class="row p-0 m-0 border-secondary border-left-0">
                                             <div class="col-10 p-0 m-0">
                                                 <div class="row m-0 p-0">
@@ -666,7 +665,7 @@
                                             <div class="col-2 p-0 m-0">
                                                 <div class="p-0 pt-1 pr-1 float-right">
                                                     <plex-badge size="sm"
-                                                                [type]=" prestacion.tipo !== 'ficha-epidemiologica' ? 'success' : 'info'">
+                                                        [type]=" prestacion.tipo !== 'ficha-epidemiologica' ? 'success' : 'info'">
                                                         {{prestacion.estado}}
                                                     </plex-badge>
                                                 </div>
@@ -681,7 +680,7 @@
                         <hr class="mt-0">
                         <div class="item-lista-vacia">
                             <plex-label size="sm" justify="center" icon="adi adi-clipboard-check-outline"
-                                        titulo="No hay prestaciones registradas">
+                                titulo="No hay prestaciones registradas">
                             </plex-label>
                         </div>
                     </div>
@@ -695,7 +694,7 @@
                 <ng-container *ngFor="let registro of this.registrosTotales.producto; let iCronico = index">
                     <li>
                         <div class="rup-card mini producto" [ngClass]="{'active': huds.isOpen(registro, 'concepto')}"
-                             (click)="emitTabs(registro, 'concepto', iCronico)">
+                            (click)="emitTabs(registro, 'concepto', iCronico)">
                             <div class="rup-header">
                                 <div class="rup-border rup-border-producto">
                                     <div class="row p-0 m-0 border-secondary border-left-0">
@@ -721,7 +720,7 @@
                                             <div class="p-0 pt-1 pr-1 float-right">
                                                 <ng-container *ngIf="registro.evoluciones">
                                                     <plex-badge size="sm"
-                                                                [type]="registro.evoluciones[registro.evoluciones.length-1].estado === 'activo' ? 'success' : 'danger'">
+                                                        [type]="registro.evoluciones[registro.evoluciones.length-1].estado === 'activo' ? 'success' : 'danger'">
                                                         {{ registro.evoluciones[registro.evoluciones.length-1].estado }}
                                                     </plex-badge>
                                                 </ng-container>
@@ -738,7 +737,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-pildoras"
-                                titulo="No hay productos registrados">
+                        titulo="No hay productos registrados">
                     </plex-label>
                 </div>
             </div>
@@ -754,7 +753,7 @@
                     <ng-container *ngFor="let laboratorio of laboratorios; let iLaboratorio = index">
                         <li>
                             <div class="rup-card mini laboratorio"
-                                 [ngClass]="{'active': huds.isOpen(laboratorio,  laboratorio.idProtocolo ? 'laboratorio' : 'cda')}">
+                                [ngClass]="{'active': huds.isOpen(laboratorio,  laboratorio.idProtocolo ? 'laboratorio' : 'cda')}">
                                 <div class="rup-header">
                                     <div class="rup-border rup-border-laboratorio">
                                         <div class="row p-0 m-0 border-secondary border-left-0">
@@ -766,7 +765,7 @@
                                                         </div>
                                                     </ng-container>
                                                     <div class="col p-0 pl-2 float-left"
-                                                         (click)="emitTabs(laboratorio, laboratorio.idProtocolo ? 'laboratorio' : 'cda', iLaboratorio)">
+                                                        (click)="emitTabs(laboratorio, laboratorio.idProtocolo ? 'laboratorio' : 'cda', iLaboratorio)">
                                                         <div>
                                                             <small>
                                                                 <span *ngIf="laboratorio?.prestacion?.term">{{
@@ -795,7 +794,7 @@
                                                                             fecha}}</b></small>
                                                                 </div>
                                                                 <div *ngIf="laboratorio?.efectorSolicitante || laboratorio?.profesional"
-                                                                     class="text-sm">
+                                                                    class="text-sm">
                                                                     <small>Médico solicitante: <b>{{
                                                                             laboratorio?.medicoSolicitante ||
                                                                             laboratorio?.profesional }}</b></small>
@@ -817,7 +816,7 @@
                 <hr class="mt-0">
                 <div class="item-lista-vacia">
                     <plex-label size="sm" justify="center" icon="adi adi-recipiente"
-                                titulo="No hay laboratorios registrados">
+                        titulo="No hay laboratorios registrados">
                     </plex-label>
                 </div>
             </div>
@@ -842,7 +841,7 @@
                                                         </div>
                                                     </ng-container>
                                                     <div class="col p-0 pl-2 float-left"
-                                                         (click)="emitTabs(unaVacuna, 'cda', iVacuna)">
+                                                        (click)="emitTabs(unaVacuna, 'cda', iVacuna)">
                                                         {{ unaVacuna?.prestacion.term }}
                                                         <div class="row p-0 m-0">
                                                             <div class="col-10 p-0 m-0">

--- a/src/app/modules/rup/components/ejecucion/vistaHuds.html
+++ b/src/app/modules/rup/components/ejecucion/vistaHuds.html
@@ -5,9 +5,9 @@
         </plex-title>
         <div class="w-100 h-100 mt-4">
             <plex-tabs (close)=" onCloseTab($event)" [activeIndex]="activeIndexPrestacion"
-                       *ngIf="elementosRUPService.ready | async">
+                *ngIf="elementosRUPService.ready | async">
                 <plex-button *feature="'hudsExploracion'" label="Exploración" tooltip="Exploración Visual de HUDS"
-                             type="info" size="sm" class="mr-2" (click)="onExploracionClick()">
+                    type="info" size="sm" class="mr-2" (click)="onExploracionClick()">
                 </plex-button>
 
                 <plex-tab label="Resumen del Paciente">
@@ -17,7 +17,7 @@
                     <plex-tabs [activeIndex]="activeIndexResumen">
                         <plex-tab label="Registros del Paciente">
                             <rup-resumenPaciente-dinamico-nino *ngIf="paciente?.edad <= 6" [paciente]="paciente"
-                                                               esTab="true">
+                                esTab="true">
                             </rup-resumenPaciente-dinamico-nino>
                             <rup-resumenPaciente-dinamico *ngIf="paciente?.edad > 6" [paciente]="paciente" esTab="true">
                             </rup-resumenPaciente-dinamico>
@@ -46,36 +46,37 @@
 
                 <ng-container *ngFor="let registro of registros">
                     <plex-tab [allowClose]="true" [label]="registro.data.concepto.term" [class]="registro.data.class"
-                              [color]="registro.data.class" *ngIf="registro.tipo === 'concepto'">
+                        [color]="registro.data.class" *ngIf="registro.tipo === 'concepto'">
 
-                        <detalle-registro *ngIf="detalleRegistro(registro)" [registro]="registro.data"
-                                          [paciente]="paciente">
+                        <detalle-registro *ngIf="registro.data.class === 'situación' || 
+                     registro.data.class === 'hallazgo' || registro.data.class === 'trastorno'"
+                            [registro]="registro.data" [paciente]="paciente">
                         </detalle-registro>
 
                         <detalle-procedimiento *ngIf="registro.data.class === 'procedimiento'"
-                                               [registro]="registro.data" [paciente]="paciente">
+                            [registro]="registro.data" [paciente]="paciente">
                         </detalle-procedimiento>
 
                         <detalle-prestacion *ngIf="prestacionVisible(registro)" [registro]="registro.data"
-                                            [paciente]="paciente">
+                            [paciente]="paciente">
                         </detalle-prestacion>
                     </plex-tab>
 
                     <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term"
-                              [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'rup'">
+                        [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'rup'">
                         <vista-prestacion [prestacion]="registro.data" [paciente]="paciente">
                         </vista-prestacion>
                     </plex-tab>
 
                     <!-- Incluye registros de internaciones -->
                     <plex-tab *ngIf="registro.tipo === 'internacion'" [allowClose]="true" label="Internacion"
-                              color="solicitud">
+                        color="solicitud">
                         <detalle-registro-internacion [internacion]="registro"
-                                                      [paciente]="paciente"></detalle-registro-internacion>
+                            [paciente]="paciente"></detalle-registro-internacion>
                     </plex-tab>
 
                     <plex-tab [allowClose]="true" [label]="registro.data[0].solicitud.tipoPrestacion.term"
-                              [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'rup-group'">
+                        [class]="registro.data.class" color="solicitud" *ngIf="registro.tipo === 'rup-group'">
 
                         <ng-container *ngFor="let prestacion of registro.data">
                             <vista-prestacion [prestacion]="prestacion" [paciente]="paciente">
@@ -84,17 +85,17 @@
                     </plex-tab>
 
                     <plex-tab *ngIf="registro.tipo === 'laboratorio'" [allowClose]="true"
-                              label="Informe de Laboratorio">
+                        label="Informe de Laboratorio">
                         <vista-laboratorio [protocolo]="registro"></vista-laboratorio>
                     </plex-tab>
 
                     <plex-tab [allowClose]="true" [label]="registro.data.solicitud.tipoPrestacion.term"
-                              [class]="registro.class" *ngIf="registro.tipo === 'solicitud'">
+                        [class]="registro.class" *ngIf="registro.tipo === 'solicitud'">
                         <vista-solicitud-top [registro]="registro.data"></vista-solicitud-top>
                     </plex-tab>
 
                     <plex-tab *ngIf="registro.tipo === 'cda'" [allowClose]="true"
-                              [label]="registro.data.prestacion.snomed.term" [class]="registro.data.class">
+                        [label]="registro.data.prestacion.snomed.term" [class]="registro.data.class">
                         <vista-cda [registro]="registro"></vista-cda>
                     </plex-tab>
 
@@ -104,26 +105,24 @@
                     </plex-tab>
 
                     <plex-tab [allowClose]="true" label="Ficha Epidemilógica"
-                              *ngIf="registro.tipo === 'ficha-epidemiologica'">
+                        *ngIf="registro.tipo === 'ficha-epidemiologica'">
                         <app-ficha-epidemiologica-crud *ngIf="registro.data.type.name == 'covid19'"
-                                                       [paciente]="paciente" [fichaPaciente]="registro.data"
-                                                       [editFicha]="false" [fichaName]="registro.data.type.name"
-                                                       [hideVolver]="true" [accesoHuds]="true">
+                            [paciente]="paciente" [fichaPaciente]="registro.data" [editFicha]="false"
+                            [fichaName]="registro.data.type.name" [hideVolver]="true" [accesoHuds]="true">
                         </app-ficha-epidemiologica-crud>
                         <app-ficha-epidemiologica-generic *ngIf="registro.data.type.name != 'covid19'"
-                                                          [paciente]="paciente" [fichaPaciente]="registro.data"
-                                                          [editFicha]="false" [fichaName]="registro.data.type.name"
-                                                          [volverBuscador]="false" [accesoHuds]="true">
+                            [paciente]="paciente" [fichaPaciente]="registro.data" [editFicha]="false"
+                            [fichaName]="registro.data.type.name" [volverBuscador]="false" [accesoHuds]="true">
                         </app-ficha-epidemiologica-generic>
                     </plex-tab>
 
                     <plex-tab *ngIf="registro.tipo === 'dominio'" [allowClose]="true" [label]="registro.data.name"
-                              [class]="registro.data.class">
+                        [class]="registro.data.class">
                         <vista-ips [registro]="registro.data"></vista-ips>
                     </plex-tab>
 
                     <plex-tab *ngIf="registro.tipo === 'receta'" color="receta" class="tab-receta" [allowClose]="true"
-                              [label]="recetaService.getLabel(registro.data.recetas)">
+                        [label]="recetaService.getLabel(registro.data.recetas)">
                         <vista-receta [registro]="registro.data" [paciente]="paciente"></vista-receta>
                     </plex-tab>
                 </ng-container>

--- a/src/app/modules/rup/components/huds/detallePrestacion.html
+++ b/src/app/modules/rup/components/huds/detallePrestacion.html
@@ -2,7 +2,7 @@
     <plex-title *ngIf="registro?.concepto"
                 titulo="{{ registro.concepto.term[0].toUpperCase() + registro.concepto.term.slice(1) }}" size="lg">
         <div class="titulo-badges">
-            <plex-badge type="danger">
+            <plex-badge type="danger" *ngIf="registro?.privacy === 'private'">
                 Registro Privado
             </plex-badge>
             <plex-badge type="{{ !registro.esSolicitud ? registro.concepto.semanticTag : 'solicitud' }}">

--- a/src/app/modules/rup/components/huds/vistaCDA.html
+++ b/src/app/modules/rup/components/huds/vistaCDA.html
@@ -1,11 +1,5 @@
 <ng-container *ngIf="registro?.data">
-    <plex-title titulo="{{ registro.data.prestacion.snomed.term }}" size="lg">
-        <div class="titulo-badges">
-            <plex-badge type="{{ registro.data.prestacion.snomed.semanticTag || 'solicitud' }}">
-                {{ registro.data.prestacion.snomed.semanticTag || 'solicitud' }}
-            </plex-badge>
-        </div>
-    </plex-title>
+    <plex-title titulo="{{ registro.data.prestacion.snomed.term }}" size="lg"></plex-title>
     <div class="mt-4">
         <plex-grid cols="2">
             <div class="registros">
@@ -23,20 +17,20 @@
                             <div class="d-flex align-items-end mb-1">
                                 <plex-badge type="info mr-1">PDF</plex-badge>
                                 <plex-button type="info" size="sm" icon="download mdi-18px" (click)="descargar(archivo)"
-                                             tooltip="Descargar PDF">
+                                    tooltip="Descargar PDF">
                                 </plex-button>
                             </div>
                         </ng-container>
                         <ng-container
-                                      *ngIf="!registro.data.adjuntos && registro?.data?.prestacion?.snomed?.conceptId !== '33879002'">
+                            *ngIf="!registro.data.adjuntos && registro?.data?.prestacion?.snomed?.conceptId !== '33879002'">
                             <div class="d-flex align-items-end mb-1">
                                 <plex-badge type="info mr-1">PDF</plex-badge>
                                 <plex-button type="info" size="sm" icon="download mdi-18px" tooltip="Descargar CDA"
-                                             (click)="descargarCDA(registro)">
+                                    (click)="descargarCDA(registro)">
                                 </plex-button>
 
                                 <plex-button type="info" size="sm" icon="download mdi-18px" (click)="descargar(archivo)"
-                                             tooltip="Descargar PDF">
+                                    tooltip="Descargar PDF">
                                 </plex-button>
                             </div>
                         </ng-container>

--- a/src/app/modules/rup/components/huds/vistaSolicitudTop.html
+++ b/src/app/modules/rup/components/huds/vistaSolicitudTop.html
@@ -4,9 +4,7 @@
             <plex-badge type="{{ tipoEstado[estado] }}">
                 {{ estado }}
             </plex-badge>
-            <plex-badge type="{{ registro.solicitud.tipoPrestacion.semanticTag || 'solicitud' }}">
-                {{ registro.solicitud.tipoPrestacion.semanticTag || 'solicitud' }}
-            </plex-badge>
+            <plex-badge type="{{ 'solicitud' }}"> Solicitud </plex-badge>
         </div>
     </plex-title>
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/HUDS-164

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se modificaron diferentes badges dentro del módulo HUDS ya que estos mismos aparecian dentro de diferentes tabs cuando no correspondían. Para hacer una buena comparativa tener en una pestaña el localhost:4200 y en otra demo para ver mejor las diferencias. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta--
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

NOTA: Hasta el momento solo se encontraron, dentro de un CDA de laboratorio, el badge de "procedimiento" como así también el de "elemento de registro". En cualquier "elemento de registro" siempre se iba a visualizar el badge "registro privado" cuando solamente lo tienen que contener las "notas privadas" o "notas confidencial". En las vacunas se observa "Procedimiento", en los productos de fármaco tenemos "Registro privado" al igual que en algunas solitudes y por último en las solicitudes vemos los badges de "prodecimiento".
<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
