### PR TITLE
RUP - No se debería suspeder turno con registro en curso

### DIFF
--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -9,6 +9,7 @@ import { ListaEsperaService } from '../../../services/turnos/listaEspera.service
 import { EstadosAgenda } from './../enums';
 import * as moment from 'moment';
 import { TurnoService } from 'src/app/services/turnos/turno.service';
+import { PrestacionesService } from 'src/app/modules/rup/services/prestaciones.service';
 
 @Component({
     selector: 'turnos',
@@ -102,7 +103,12 @@ export class TurnosComponent implements OnInit {
     public arrayDelDia = [];
     public sortBy: string;
     public sortOrder = 'desc';
+    public prestacionTurno = [];
+    puedeSuspenderLiberar = true;
+    validSuspensionLiberacion = false;
     botonera = true;
+    private validacionesPendientesSuspension = 0;
+    private turnosConPrestacionEnEjecucion = new Set<string>();
 
     public columns = [
         {
@@ -136,7 +142,8 @@ export class TurnosComponent implements OnInit {
         public serviceAgenda: AgendaService,
         public listaEsperaService: ListaEsperaService,
         public auth: Auth,
-        public serviceTurno: TurnoService) { }
+        public serviceTurno: TurnoService,
+        public prestacionService: PrestacionesService) { }
 
     ngOnInit() {
         const agendaActualizar = this.agenda;
@@ -147,17 +154,77 @@ export class TurnosComponent implements OnInit {
         this.showSeleccionarTodos = (this.bloqueSelected.turnos.length > 0);
     }
 
+    private getTurnoId(turno: any): string {
+        return String(turno?.id || turno?._id || '');
+    }
+
+    private actualizarEstadoSuspension() {
+        if (!this.turnosSeleccionados.length) {
+            this.puedeSuspenderLiberar = true;
+            return;
+        }
+        this.puedeSuspenderLiberar = this.turnosConPrestacionEnEjecucion.size === 0;
+    }
+
+    private validarPrestacionEnEjecucion(turno: any) {
+        const turnoId = this.getTurnoId(turno);
+        if (!turnoId) {
+            this.actualizarEstadoSuspension();
+            return;
+        }
+
+        this.validacionesPendientesSuspension++;
+        this.validSuspensionLiberacion = true;
+
+        const params: any = {
+            solicitudTurno: turno._id
+        };
+
+        this.prestacionService.getSolicitudes(params).subscribe({
+            next: resultado => {
+                const sigueSeleccionado = this.turnosSeleccionados.some(x => this.getTurnoId(x) === turnoId);
+                if (!sigueSeleccionado) {
+                    return;
+                }
+
+                const enEjecucion = resultado?.some(item => item?.estadoActual?.tipo === 'ejecucion');
+                if (enEjecucion) {
+                    this.turnosConPrestacionEnEjecucion.add(turnoId);
+                } else {
+                    this.turnosConPrestacionEnEjecucion.delete(turnoId);
+                }
+                this.actualizarEstadoSuspension();
+            },
+            error: () => {
+                const sigueSeleccionado = this.turnosSeleccionados.some(x => this.getTurnoId(x) === turnoId);
+                if (sigueSeleccionado) {
+                    this.puedeSuspenderLiberar = false;
+                }
+            },
+            complete: () => {
+                this.validacionesPendientesSuspension = Math.max(0, this.validacionesPendientesSuspension - 1);
+                this.validSuspensionLiberacion = this.validacionesPendientesSuspension > 0;
+            }
+        });
+    }
+
     seleccionarTurno(turno, multiple = false, sobreturno) {
         turno.sobreturno = sobreturno;
+        const turnoId = this.getTurnoId(turno);
+        const estabaSeleccionado = this.turnosSeleccionados.some(x => this.getTurnoId(x) === turnoId);
+
         if (!multiple) {
-            this.turnosSeleccionados = [];
-            this.turnosSeleccionados = [...this.turnosSeleccionados, turno];
+            this.turnosSeleccionados = [turno];
+            this.turnosConPrestacionEnEjecucion.clear();
+            this.validarPrestacionEnEjecucion(turno);
         } else {
-            if (this.turnosSeleccionados.find(x => x.id === turno._id)) {
-                this.turnosSeleccionados.splice(this.turnosSeleccionados.indexOf(turno), 1);
-                this.turnosSeleccionados = [... this.turnosSeleccionados];
+            if (estabaSeleccionado) {
+                this.turnosSeleccionados = this.turnosSeleccionados.filter(x => this.getTurnoId(x) !== turnoId);
+                this.turnosConPrestacionEnEjecucion.delete(turnoId);
+                this.actualizarEstadoSuspension();
             } else {
                 this.turnosSeleccionados = [... this.turnosSeleccionados, turno];
+                this.validarPrestacionEnEjecucion(turno);
             }
         }
 
@@ -437,5 +504,17 @@ export class TurnosComponent implements OnInit {
             return noDisponible && botones.cambiarDisponible;
         }
         return false;
+    }
+
+    puedeSuspenderTurno(botonSuspender) {
+        return botonSuspender && !this.validSuspensionLiberacion && this.puedeSuspenderLiberar;
+    }
+
+    puedeLiberarTurno(botonLiberar, turnoSeleccionado, turno) {
+        return botonLiberar && turnoSeleccionado?.id === turno.id && !this.validSuspensionLiberacion && this.puedeSuspenderLiberar;
+    }
+
+    puedeLiberarSobreturno(botonLiberar, turnoSeleccionado, sobreturno) {
+        return botonLiberar && turnoSeleccionado?.id === sobreturno.id && !this.validSuspensionLiberacion && this.puedeSuspenderLiberar;
     }
 }

--- a/src/app/components/turnos/gestor-agendas/turnos.component.ts
+++ b/src/app/components/turnos/gestor-agendas/turnos.component.ts
@@ -176,18 +176,19 @@ export class TurnosComponent implements OnInit {
         this.validacionesPendientesSuspension++;
         this.validSuspensionLiberacion = true;
 
-        const params: any = {
-            solicitudTurno: turno._id
+        const params = {
+            estado: 'ejecucion',
+            turnos: [turnoId]
         };
 
-        this.prestacionService.getSolicitudes(params).subscribe({
+        this.prestacionService.get(params).subscribe({
             next: resultado => {
                 const sigueSeleccionado = this.turnosSeleccionados.some(x => this.getTurnoId(x) === turnoId);
                 if (!sigueSeleccionado) {
                     return;
                 }
 
-                const enEjecucion = resultado?.some(item => item?.estadoActual?.tipo === 'ejecucion');
+                const enEjecucion = resultado?.length > 0;
                 if (enEjecucion) {
                     this.turnosConPrestacionEnEjecucion.add(turnoId);
                 } else {
@@ -246,11 +247,13 @@ export class TurnosComponent implements OnInit {
 
     seleccionarTodos() {
         this.turnosSeleccionados = [];
+        this.turnosConPrestacionEnEjecucion.clear();
 
         this.bloqueSelected.turnos.map(turno => {
             if (!this.todos) {
                 turno.checked = true;
                 this.turnosSeleccionados = [...this.turnosSeleccionados, turno];
+                this.validarPrestacionEnEjecucion(turno);
             } else {
                 turno.checked = false;
             }
@@ -260,6 +263,7 @@ export class TurnosComponent implements OnInit {
             if (!this.todos) {
                 sobreturno.checked = true;
                 this.turnosSeleccionados = [...this.turnosSeleccionados, sobreturno];
+                this.validarPrestacionEnEjecucion(sobreturno);
             } else {
                 sobreturno.checked = false;
             }
@@ -267,6 +271,7 @@ export class TurnosComponent implements OnInit {
 
         this.todos = !this.todos;
         this.cantSel = this.turnosSeleccionados.length;
+        this.actualizarEstadoSuspension();
     }
 
     // retorna true si algun bloque de la agenda es exclusivo de gestión

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -14,39 +14,39 @@
             <plex-label align="center" size="md" titulo="Con llave" subtitulo="{{countBloques[mostrar]?.gestion}}">
             </plex-label>
             <plex-label align="center" size="md" titulo="Profesional"
-                        subtitulo="{{countBloques[mostrar]?.profesional}}">
+                subtitulo="{{countBloques[mostrar]?.profesional}}">
             </plex-label>
         </plex-grid>
     </ng-container>
     <plex-title class="titulo-bloque" size="sm"
-                titulo="BLOQUE | {{ bloqueSelected.horaInicio | date: 'HH:mm'}} a {{ bloqueSelected.horaFin |date:'HH:mm'}} hs">
+        titulo="BLOQUE | {{ bloqueSelected.horaInicio | date: 'HH:mm'}} a {{ bloqueSelected.horaFin |date:'HH:mm'}} hs">
         <ng-container *ngIf="agenda | botonesTurnos:turnosSeleccionados as botones">
             <plex-button *ngIf="botones.sacarAsistencia && turnosSeleccionados?.length" class="mr-1"
-                         ariaLabel="Registrar inasistencia" size="sm" type="warning" icon="account-remove"
-                         (click)="eventosTurno('sacarAsistencia')" tooltip="Registrar inasistencia"
-                         tooltipPosition="top">
+                ariaLabel="Registrar inasistencia" size="sm" type="warning" icon="account-remove"
+                (click)="eventosTurno('sacarAsistencia')" tooltip="Registrar inasistencia" tooltipPosition="top">
             </plex-button>
             <plex-button *ngIf="botones.darAsistencia && turnosSeleccionados?.length" class="mr-1"
-                         ariaLabel="Registrar asistencia" size="sm" type="success" icon="account-check"
-                         (click)="eventosTurno('darAsistencia')" tooltip="Registrar asistencia" tooltipPosition="top">
+                ariaLabel="Registrar asistencia" size="sm" type="success" icon="account-check"
+                (click)="eventosTurno('darAsistencia')" tooltip="Registrar asistencia" tooltipPosition="top">
             </plex-button>
 
             <plex-help *ngIf="botones.nota && turnosSeleccionados?.length" class="mr-1" type="info"
-                       icon="comment-outline" tooltip="Agregar nota" tooltipPosition="top">
+                icon="comment-outline" tooltip="Agregar nota" tooltipPosition="top">
                 <agregar-nota-turno [agenda]="agenda" [turnosSeleccionados]="turnosSeleccionados"
-                                    (saveAgregarNotaTurno)="saveAgregarNotaTurno()">
+                    (saveAgregarNotaTurno)="saveAgregarNotaTurno()">
                 </agregar-nota-turno>
             </plex-help>
-            <plex-help *ngIf="botones.suspender" class="mr-1" btnType="danger" icon="stop" tooltip="Suspender turnos"
-                       tooltipPosition="left">
+
+            <plex-help *ngIf="puedeSuspenderTurno(botones.suspender)" class="mr-1" btnType="danger" icon="stop"
+                tooltip="Suspender turnos" tooltipPosition="left">
                 <suspender-turno [agenda]="agenda" [accion]="'suspenderTurno'"
-                                 [turnosSeleccionados]="turnosSeleccionados" (saveSuspenderTurno)="saveSuspenderTurno()"
-                                 (reasignarTurnoSuspendido)="reasignarTurnoSuspendido($event)">
+                    [turnosSeleccionados]="turnosSeleccionados" (saveSuspenderTurno)="saveSuspenderTurno()"
+                    (reasignarTurnoSuspendido)="reasignarTurnoSuspendido($event)">
                 </suspender-turno>
             </plex-help>
             <plex-button *ngIf="botones.cambiarDisponible  && turnosSeleccionados?.length" class="mr-1" type="warning"
-                         size="sm" icon="undo" tooltip="Cambiar a disponible" tooltipPosition="top"
-                         (click)="cambiarADisponible()">
+                size="sm" icon="undo" tooltip="Cambiar a disponible" tooltipPosition="top"
+                (click)="cambiarADisponible()">
             </plex-button>
         </ng-container>
         <plex-help *ngIf="!agenda.dinamica" type="help" icon="cog">
@@ -123,19 +123,19 @@
                 <div class="d-flex flex-column align-items-start ml-1">
                     <div class="d-flex flex-rows">
                         <plex-badge *ngIf="turno?.estado !== 'disponible' && turno?.estado !== 'turnoDoble'" size="sm"
-                                    type="default">
+                            type="default">
                             <shared-popover-audit placement="right" [data]="turno" [showUpdate]="true">
                             </shared-popover-audit>
                         </plex-badge>
                         <plex-badge *ngIf="turno.tipoTurno === 'profesional' && turno.estado === 'asignado'"
-                                    type="warning">
+                            type="warning">
                             Autocitado</plex-badge>
                         <plex-badge *ngIf="turno.tipoTurno === 'gestion' && turno.estado === 'asignado'" type="warning">
                             Con
                             llave
                         </plex-badge>
                         <plex-badge *ngIf="turno.tipoTurno === 'programado' && turno.estado === 'asignado'"
-                                    type="warning">
+                            type="warning">
                             Programado</plex-badge>
                         <plex-badge *ngIf="turno.reasignado?.anterior" type="info">Reasignado
                         </plex-badge>
@@ -150,7 +150,7 @@
                         <plex-badge *ngIf="!turno?.paciente?.id && turno?.estado === 'suspendido'" type="danger">
                             suspendido(sin paciente)</plex-badge>
                         <plex-help *ngIf="turno?.nota" type="info" icon="message" tooltip="Ver nota"
-                                   tooltipPosition="right" size="sm" cardSize="half">
+                            tooltipPosition="right" size="sm" cardSize="half">
                             <div class="nota-inline">
                                 {{ turno.nota }}
                             </div>
@@ -158,10 +158,10 @@
 
                     </div>
                     <plex-label *ngIf="!agenda.dinamica && !turno?.paciente?.id" size="sm"
-                                titulo="{{ turno.horaInicio | date: 'HH:mm' }}hs">
+                        titulo="{{ turno.horaInicio | date: 'HH:mm' }}hs">
                     </plex-label>
                     <plex-label *ngIf="turno?.paciente?.id" size="sm"
-                                titulo="{{turno.horaInicio | date: 'HH:mm' }}hs | {{turno.paciente | nombre }}">
+                        titulo="{{turno.horaInicio | date: 'HH:mm' }}hs | {{turno.paciente | nombre }}">
                     </plex-label>
                     <small>
                         <span *ngIf="turno?.paciente?.id">
@@ -178,61 +178,63 @@
             </td>
             <td *plTableCol="'acciones'">
                 <plex-badge *ngIf="turno?.paciente?.id && turno?.estado === 'suspendido' && turno.reasignado?.siguiente"
-                            class="mr-1" size="sm" type="info" tooltip="Ya reasignado" tooltipPosition="left">
+                    class="mr-1" size="sm" type="info" tooltip="Ya reasignado" tooltipPosition="left">
                     <plex-icon name="account-check"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="turno?.paciente?.id && turno.asistencia === 'asistio' && turno.estado !== 'suspendido'"
-                            class="mr-1" size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="turno?.paciente?.id && turno.asistencia === 'asistio' && turno.estado !== 'suspendido'"
+                    class="mr-1" size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
                     <plex-icon name="account-check"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="turno?.paciente?.id && turno.asistencia === 'noAsistio' && turno.estado !== 'suspendido'"
-                            class="mr-1" size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="turno?.paciente?.id && turno.asistencia === 'noAsistio' && turno.estado !== 'suspendido'"
+                    class="mr-1" size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
                     <plex-icon name="account-remove"></plex-icon>
                 </plex-badge>
                 <plex-badge *ngIf="turno?.paciente?.id && turno.confirmedAt" class="mr-1" title="Confirmó asistencia">
                     <plex-icon name="emoticon-happy"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="turno?.paciente?.id && turno?.estado === 'suspendido' && !turno.reasignado?.siguiente"
-                            class="mr-1" size="sm" type="danger" tooltip="Aun no reasignado" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="turno?.paciente?.id && turno?.estado === 'suspendido' && !turno.reasignado?.siguiente"
+                    class="mr-1" size="sm" type="danger" tooltip="Aun no reasignado" tooltipPosition="left">
                     <plex-icon name="account-alert"></plex-icon>
                 </plex-badge>
                 <plex-badge *ngIf="turno.estado ==='suspendido' && turno.avisoSuspension === 'no enviado'" type="info"
-                            title="Notificación pendiente" class="mr-1" tooltipPosition="left">
+                    title="Notificación pendiente" class="mr-1" tooltipPosition="left">
                     <plex-icon name="message-processing"></plex-icon>
                 </plex-badge>
                 <plex-badge *ngIf="turno.estado ==='suspendido' && turno.avisoSuspension ==='enviado'" type="info"
-                            title="Notificación enviada">
+                    title="Notificación enviada">
                     <plex-icon name="message-text-outline"></plex-icon>
                 </plex-badge>
                 <ng-container *ngIf="agenda | botonesTurnos:turnosSeleccionados as botones">
                     <plex-button *ngIf="botones.turnoDoble && turnosSeleccionados[0]?.id === turno.id"
-                                 ariaLabel="Turno doble" size="sm" type="default" icon="numeric-2-box-multiple-outline"
-                                 (click)="asignarTurnoDoble('darTurnoDoble')" tooltip="Turno doble"
-                                 tooltipPosition="top">
+                        ariaLabel="Turno doble" size="sm" type="default" icon="numeric-2-box-multiple-outline"
+                        (click)="asignarTurnoDoble('darTurnoDoble')" tooltip="Turno doble" tooltipPosition="top">
                     </plex-button>
                     <plex-button *ngIf="botones.quitarTurnoDoble && turnosSeleccionados[0]?.id === turno.id"
-                                 ariaLabel="Quitar Turno doble" size="sm" type="default" icon="numeric-1-box-outline"
-                                 (click)="eventosTurno('quitarTurnoDoble', agenda)" tooltip="Quitar Turno doble"
-                                 tooltipPosition="top">
+                        ariaLabel="Quitar Turno doble" size="sm" type="default" icon="numeric-1-box-outline"
+                        (click)="eventosTurno('quitarTurnoDoble', agenda)" tooltip="Quitar Turno doble"
+                        tooltipPosition="top">
                     </plex-button>
                     <plex-help *ngIf="botones.editarCarpeta && turnosSeleccionados[0]?.id === turno.id" type="info"
-                               btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
+                        btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
                         <plex-title size="sm" titulo="Editar carpeta"></plex-title>
                         <plex-label class="text-white" titulo="Paciente"
-                                    subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
+                            subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
                         </plex-label>
                         <carpeta-paciente class="text-white" [turnoSeleccionado]="turnosSeleccionados[0] "
-                                          (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
-                                          (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
+                            (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
+                            (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
                         </carpeta-paciente>
                     </plex-help>
-                    <plex-help *ngIf="botones.liberar && turnosSeleccionados[0]?.id === turno.id"
-                               class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
-                               tooltip="Liberar turnos" tooltipPosition="left">
+                    <plex-help *ngIf="puedeLiberarTurno(botones.liberar, turnosSeleccionados[0], turno)"
+                        class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
+                        tooltip="Liberar turnos" tooltipPosition="left">
                         <liberar-turno [agenda]="agenda" [turnosSeleccionados]="turnosSeleccionados"
-                                       [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
-                                       (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
-                                       (cancelaLiberarTurno)="cancelaLiberarTurno()">
+                            [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
+                            (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
+                            (cancelaLiberarTurno)="cancelaLiberarTurno()">
                         </liberar-turno>
                     </plex-help>
                 </ng-container>
@@ -257,7 +259,7 @@
                 <div class="d-flex flex-column align-items-start ml-1">
                     <div class="d-flex flex-rows">
                         <plex-badge *ngIf="sobreturno?.estado !== 'disponible' && sobreturno?.estado !== 'turnoDoble'"
-                                    size="sm" type="default">
+                            size="sm" type="default">
                             <shared-popover-audit placement="right" [data]="sobreturno" [showUpdate]="true">
                             </shared-popover-audit>
                         </plex-badge>
@@ -267,12 +269,12 @@
                         <plex-badge *ngIf="sobreturno && sobreturno.estado === 'suspendido'" type="danger">
                             Suspendido</plex-badge>
                         <plex-badge *ngIf="sobreturno?.nota" size="sm" type="warning" tooltip="{{sobreturno.nota}}"
-                                    tooltipPosition="right">
+                            tooltipPosition="right">
                             <plex-icon name="message"></plex-icon>
                         </plex-badge>
                     </div>
                     <plex-label *ngIf="sobreturno?.paciente?.id" size="md"
-                                titulo="{{sobreturno.horaInicio | date: 'HH:mm' }}hs | {{sobreturno.paciente | nombre }}">
+                        titulo="{{sobreturno.horaInicio | date: 'HH:mm' }}hs | {{sobreturno.paciente | nombre }}">
                     </plex-label>
                     <small>
                         <span *ngIf="sobreturno?.paciente?.id">
@@ -289,34 +291,36 @@
             </td>
 
             <td *plTableCol="'acciones'">
-                <plex-badge *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'asistio' && sobreturno.estado !== 'suspendido'"
-                            size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'asistio' && sobreturno.estado !== 'suspendido'"
+                    size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
                     <plex-icon name="account-check"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'noAsistio' && sobreturno.estado !== 'suspendido'"
-                            size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'noAsistio' && sobreturno.estado !== 'suspendido'"
+                    size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
                     <plex-icon name="account-remove"></plex-icon>
                 </plex-badge>
 
                 <ng-container *ngIf="agenda | botonesTurnos:turnosSeleccionados as botones">
                     <plex-help *ngIf="botones.editarCarpeta && turnosSeleccionados[0]?.id === sobreturno.id" type="info"
-                               btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
+                        btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
                         <plex-title size="sm" titulo="Editar carpeta"></plex-title>
                         <plex-label class="text-white" titulo="Paciente"
-                                    subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
+                            subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
                         </plex-label>
                         <carpeta-paciente class="text-white" [turnoSeleccionado]="turnosSeleccionados[0] "
-                                          (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
-                                          (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
+                            (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
+                            (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
                         </carpeta-paciente>
                     </plex-help>
-                    <plex-help *ngIf="botones.liberar && turnosSeleccionados[0]?.id === sobreturno.id"
-                               class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
-                               tooltip="Liberar turnos" tooltipPosition="left">
+                    <plex-help *ngIf="puedeLiberarSobreturno(botones.liberar, turnosSeleccionados[0], sobreturno)"
+                        class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
+                        tooltip="Liberar turnos" tooltipPosition="left">
                         <liberar-turno [agenda]="agenda" [turnosSeleccionados]="turnosSeleccionados"
-                                       [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
-                                       (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
-                                       (cancelaLiberarTurno)="cancelaLiberarTurno()">
+                            [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
+                            (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
+                            (cancelaLiberarTurno)="cancelaLiberarTurno()">
                         </liberar-turno>
                     </plex-help>
                 </ng-container>

--- a/src/app/components/turnos/gestor-agendas/turnos.html
+++ b/src/app/components/turnos/gestor-agendas/turnos.html
@@ -14,39 +14,39 @@
             <plex-label align="center" size="md" titulo="Con llave" subtitulo="{{countBloques[mostrar]?.gestion}}">
             </plex-label>
             <plex-label align="center" size="md" titulo="Profesional"
-                        subtitulo="{{countBloques[mostrar]?.profesional}}">
+                subtitulo="{{countBloques[mostrar]?.profesional}}">
             </plex-label>
         </plex-grid>
     </ng-container>
     <plex-title class="titulo-bloque" size="sm"
-                titulo="BLOQUE | {{ bloqueSelected.horaInicio | date: 'HH:mm'}} a {{ bloqueSelected.horaFin |date:'HH:mm'}} hs">
+        titulo="BLOQUE | {{ bloqueSelected.horaInicio | date: 'HH:mm'}} a {{ bloqueSelected.horaFin |date:'HH:mm'}} hs">
         <ng-container *ngIf="agenda | botonesTurnos:turnosSeleccionados as botones">
             <plex-button *ngIf="botones.sacarAsistencia && turnosSeleccionados?.length" class="mr-1"
-                         ariaLabel="Registrar inasistencia" size="sm" type="warning" icon="account-remove"
-                         (click)="eventosTurno('sacarAsistencia')" tooltip="Registrar inasistencia"
-                         tooltipPosition="top">
+                ariaLabel="Registrar inasistencia" size="sm" type="warning" icon="account-remove"
+                (click)="eventosTurno('sacarAsistencia')" tooltip="Registrar inasistencia" tooltipPosition="top">
             </plex-button>
             <plex-button *ngIf="botones.darAsistencia && turnosSeleccionados?.length" class="mr-1"
-                         ariaLabel="Registrar asistencia" size="sm" type="success" icon="account-check"
-                         (click)="eventosTurno('darAsistencia')" tooltip="Registrar asistencia" tooltipPosition="top">
+                ariaLabel="Registrar asistencia" size="sm" type="success" icon="account-check"
+                (click)="eventosTurno('darAsistencia')" tooltip="Registrar asistencia" tooltipPosition="top">
             </plex-button>
 
             <plex-help *ngIf="botones.nota && turnosSeleccionados?.length" class="mr-1" type="info"
-                       icon="comment-outline" tooltip="Agregar nota" tooltipPosition="top">
+                icon="comment-outline" tooltip="Agregar nota" tooltipPosition="top">
                 <agregar-nota-turno [agenda]="agenda" [turnosSeleccionados]="turnosSeleccionados"
-                                    (saveAgregarNotaTurno)="saveAgregarNotaTurno()">
+                    (saveAgregarNotaTurno)="saveAgregarNotaTurno()">
                 </agregar-nota-turno>
             </plex-help>
-            <plex-help *ngIf="botones.suspender" class="mr-1" btnType="danger" icon="stop" tooltip="Suspender turnos"
-                       tooltipPosition="left">
+
+            <plex-help *ngIf="puedeSuspenderTurno(botones.suspender)" class="mr-1" btnType="danger" icon="stop"
+                tooltip="Suspender turnos" tooltipPosition="left">
                 <suspender-turno [agenda]="agenda" [accion]="'suspenderTurno'"
-                                 [turnosSeleccionados]="turnosSeleccionados" (saveSuspenderTurno)="saveSuspenderTurno()"
-                                 (reasignarTurnoSuspendido)="reasignarTurnoSuspendido($event)">
+                    [turnosSeleccionados]="turnosSeleccionados" (saveSuspenderTurno)="saveSuspenderTurno()"
+                    (reasignarTurnoSuspendido)="reasignarTurnoSuspendido($event)">
                 </suspender-turno>
             </plex-help>
             <plex-button *ngIf="botones.cambiarDisponible  && turnosSeleccionados?.length" class="mr-1" type="warning"
-                         size="sm" icon="undo" tooltip="Cambiar a disponible" tooltipPosition="top"
-                         (click)="cambiarADisponible()">
+                size="sm" icon="undo" tooltip="Cambiar a disponible" tooltipPosition="top"
+                (click)="cambiarADisponible()">
             </plex-button>
         </ng-container>
         <plex-help *ngIf="!agenda.dinamica" type="help" icon="cog">
@@ -135,19 +135,19 @@
                 <div class="d-flex flex-column align-items-start ml-1">
                     <div class="d-flex flex-rows">
                         <plex-badge *ngIf="turno?.estado !== 'disponible' && turno?.estado !== 'turnoDoble'" size="sm"
-                                    type="default">
+                            type="default">
                             <shared-popover-audit placement="right" [data]="turno" [showUpdate]="true">
                             </shared-popover-audit>
                         </plex-badge>
                         <plex-badge *ngIf="turno.tipoTurno === 'profesional' && turno.estado === 'asignado'"
-                                    type="warning">
+                            type="warning">
                             Autocitado</plex-badge>
                         <plex-badge *ngIf="turno.tipoTurno === 'gestion' && turno.estado === 'asignado'" type="warning">
                             Con
                             llave
                         </plex-badge>
                         <plex-badge *ngIf="turno.tipoTurno === 'programado' && turno.estado === 'asignado'"
-                                    type="warning">
+                            type="warning">
                             Programado</plex-badge>
                         <plex-badge *ngIf="turno.reasignado?.anterior" type="info">Reasignado
                         </plex-badge>
@@ -162,7 +162,7 @@
                         <plex-badge *ngIf="!turno?.paciente?.id && turno?.estado === 'suspendido'" type="danger">
                             suspendido(sin paciente)</plex-badge>
                         <plex-help *ngIf="turno?.nota" type="info" icon="message" tooltip="Ver nota"
-                                   tooltipPosition="right" size="sm" cardSize="half">
+                            tooltipPosition="right" size="sm" cardSize="half">
                             <div class="nota-inline">
                                 {{ turno.nota }}
                             </div>
@@ -170,10 +170,10 @@
 
                     </div>
                     <plex-label *ngIf="!agenda.dinamica && !turno?.paciente?.id" size="sm"
-                                titulo="{{ turno.horaInicio | date: 'HH:mm' }}hs">
+                        titulo="{{ turno.horaInicio | date: 'HH:mm' }}hs">
                     </plex-label>
                     <plex-label *ngIf="turno?.paciente?.id" size="sm"
-                                titulo="{{turno.horaInicio | date: 'HH:mm' }}hs | {{turno.paciente | nombre }}">
+                        titulo="{{turno.horaInicio | date: 'HH:mm' }}hs | {{turno.paciente | nombre }}">
                     </plex-label>
                     <small>
                         <span *ngIf="turno?.paciente?.id">
@@ -190,61 +190,63 @@
             </td>
             <td *plTableCol="'acciones'">
                 <plex-badge *ngIf="turno?.paciente?.id && turno?.estado === 'suspendido' && turno.reasignado?.siguiente"
-                            class="mr-1" size="sm" type="info" tooltip="Ya reasignado" tooltipPosition="left">
+                    class="mr-1" size="sm" type="info" tooltip="Ya reasignado" tooltipPosition="left">
                     <plex-icon name="account-check"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="turno?.paciente?.id && turno.asistencia === 'asistio' && turno.estado !== 'suspendido'"
-                            class="mr-1" size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="turno?.paciente?.id && turno.asistencia === 'asistio' && turno.estado !== 'suspendido'"
+                    class="mr-1" size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
                     <plex-icon name="account-check"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="turno?.paciente?.id && turno.asistencia === 'noAsistio' && turno.estado !== 'suspendido'"
-                            class="mr-1" size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="turno?.paciente?.id && turno.asistencia === 'noAsistio' && turno.estado !== 'suspendido'"
+                    class="mr-1" size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
                     <plex-icon name="account-remove"></plex-icon>
                 </plex-badge>
                 <plex-badge *ngIf="turno?.paciente?.id && turno.confirmedAt" class="mr-1" title="Confirmó asistencia">
                     <plex-icon name="emoticon-happy"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="turno?.paciente?.id && turno?.estado === 'suspendido' && !turno.reasignado?.siguiente"
-                            class="mr-1" size="sm" type="danger" tooltip="Aun no reasignado" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="turno?.paciente?.id && turno?.estado === 'suspendido' && !turno.reasignado?.siguiente"
+                    class="mr-1" size="sm" type="danger" tooltip="Aun no reasignado" tooltipPosition="left">
                     <plex-icon name="account-alert"></plex-icon>
                 </plex-badge>
                 <plex-badge *ngIf="turno.estado ==='suspendido' && turno.avisoSuspension === 'no enviado'" type="info"
-                            title="Notificación pendiente" class="mr-1" tooltipPosition="left">
+                    title="Notificación pendiente" class="mr-1" tooltipPosition="left">
                     <plex-icon name="message-processing"></plex-icon>
                 </plex-badge>
                 <plex-badge *ngIf="turno.estado ==='suspendido' && turno.avisoSuspension ==='enviado'" type="info"
-                            title="Notificación enviada">
+                    title="Notificación enviada">
                     <plex-icon name="message-text-outline"></plex-icon>
                 </plex-badge>
                 <ng-container *ngIf="agenda | botonesTurnos:turnosSeleccionados as botones">
                     <plex-button *ngIf="botones.turnoDoble && turnosSeleccionados[0]?.id === turno.id"
-                                 ariaLabel="Turno doble" size="sm" type="default" icon="numeric-2-box-multiple-outline"
-                                 (click)="asignarTurnoDoble('darTurnoDoble')" tooltip="Turno doble"
-                                 tooltipPosition="top">
+                        ariaLabel="Turno doble" size="sm" type="default" icon="numeric-2-box-multiple-outline"
+                        (click)="asignarTurnoDoble('darTurnoDoble')" tooltip="Turno doble" tooltipPosition="top">
                     </plex-button>
                     <plex-button *ngIf="botones.quitarTurnoDoble && turnosSeleccionados[0]?.id === turno.id"
-                                 ariaLabel="Quitar Turno doble" size="sm" type="default" icon="numeric-1-box-outline"
-                                 (click)="eventosTurno('quitarTurnoDoble', agenda)" tooltip="Quitar Turno doble"
-                                 tooltipPosition="top">
+                        ariaLabel="Quitar Turno doble" size="sm" type="default" icon="numeric-1-box-outline"
+                        (click)="eventosTurno('quitarTurnoDoble', agenda)" tooltip="Quitar Turno doble"
+                        tooltipPosition="top">
                     </plex-button>
                     <plex-help *ngIf="botones.editarCarpeta && turnosSeleccionados[0]?.id === turno.id" type="info"
-                               btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
+                        btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
                         <plex-title size="sm" titulo="Editar carpeta"></plex-title>
                         <plex-label class="text-white" titulo="Paciente"
-                                    subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
+                            subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
                         </plex-label>
                         <carpeta-paciente class="text-white" [turnoSeleccionado]="turnosSeleccionados[0] "
-                                          (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
-                                          (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
+                            (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
+                            (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
                         </carpeta-paciente>
                     </plex-help>
-                    <plex-help *ngIf="botones.liberar && turnosSeleccionados[0]?.id === turno.id"
-                               class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
-                               tooltip="Liberar turnos" tooltipPosition="left">
+                    <plex-help *ngIf="puedeLiberarTurno(botones.liberar, turnosSeleccionados[0], turno)"
+                        class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
+                        tooltip="Liberar turnos" tooltipPosition="left">
                         <liberar-turno [agenda]="agenda" [turnosSeleccionados]="turnosSeleccionados"
-                                       [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
-                                       (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
-                                       (cancelaLiberarTurno)="cancelaLiberarTurno()">
+                            [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
+                            (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
+                            (cancelaLiberarTurno)="cancelaLiberarTurno()">
                         </liberar-turno>
                     </plex-help>
                 </ng-container>
@@ -269,7 +271,7 @@
                 <div class="d-flex flex-column align-items-start ml-1">
                     <div class="d-flex flex-rows">
                         <plex-badge *ngIf="sobreturno?.estado !== 'disponible' && sobreturno?.estado !== 'turnoDoble'"
-                                    size="sm" type="default">
+                            size="sm" type="default">
                             <shared-popover-audit placement="right" [data]="sobreturno" [showUpdate]="true">
                             </shared-popover-audit>
                         </plex-badge>
@@ -279,12 +281,12 @@
                         <plex-badge *ngIf="sobreturno && sobreturno.estado === 'suspendido'" type="danger">
                             Suspendido</plex-badge>
                         <plex-badge *ngIf="sobreturno?.nota" size="sm" type="warning" tooltip="{{sobreturno.nota}}"
-                                    tooltipPosition="right">
+                            tooltipPosition="right">
                             <plex-icon name="message"></plex-icon>
                         </plex-badge>
                     </div>
                     <plex-label *ngIf="sobreturno?.paciente?.id" size="md"
-                                titulo="{{sobreturno.horaInicio | date: 'HH:mm' }}hs | {{sobreturno.paciente | nombre }}">
+                        titulo="{{sobreturno.horaInicio | date: 'HH:mm' }}hs | {{sobreturno.paciente | nombre }}">
                     </plex-label>
                     <small>
                         <span *ngIf="sobreturno?.paciente?.id">
@@ -301,34 +303,36 @@
             </td>
 
             <td *plTableCol="'acciones'">
-                <plex-badge *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'asistio' && sobreturno.estado !== 'suspendido'"
-                            size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'asistio' && sobreturno.estado !== 'suspendido'"
+                    size="sm" type="success" tooltip="Asistió" tooltipPosition="left">
                     <plex-icon name="account-check"></plex-icon>
                 </plex-badge>
-                <plex-badge *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'noAsistio' && sobreturno.estado !== 'suspendido'"
-                            size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
+                <plex-badge
+                    *ngIf="sobreturno?.paciente?.id && sobreturno.asistencia === 'noAsistio' && sobreturno.estado !== 'suspendido'"
+                    size="sm" type="danger" tooltip="No asistió" tooltipPosition="left">
                     <plex-icon name="account-remove"></plex-icon>
                 </plex-badge>
 
                 <ng-container *ngIf="agenda | botonesTurnos:turnosSeleccionados as botones">
                     <plex-help *ngIf="botones.editarCarpeta && turnosSeleccionados[0]?.id === sobreturno.id" type="info"
-                               btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
+                        btnType="info" icon="folder-account" tooltip="Editar Carpeta" tooltipPosition="top">
                         <plex-title size="sm" titulo="Editar carpeta"></plex-title>
                         <plex-label class="text-white" titulo="Paciente"
-                                    subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
+                            subtitulo="{{turnosSeleccionados[0].paciente | nombre }}" icon="paciente">
                         </plex-label>
                         <carpeta-paciente class="text-white" [turnoSeleccionado]="turnosSeleccionados[0] "
-                                          (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
-                                          (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
+                            (guardarCarpetaEmit)="afterComponenteCarpeta($event)"
+                            (cancelarCarpetaEmit)="afterComponenteCarpeta($event)">
                         </carpeta-paciente>
                     </plex-help>
-                    <plex-help *ngIf="botones.liberar && turnosSeleccionados[0]?.id === sobreturno.id"
-                               class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
-                               tooltip="Liberar turnos" tooltipPosition="left">
+                    <plex-help *ngIf="puedeLiberarSobreturno(botones.liberar, turnosSeleccionados[0], sobreturno)"
+                        class="help-liberar-turnos" type="info" btnType="danger" icon="account-off"
+                        tooltip="Liberar turnos" tooltipPosition="left">
                         <liberar-turno [agenda]="agenda" [turnosSeleccionados]="turnosSeleccionados"
-                                       [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
-                                       (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
-                                       (cancelaLiberarTurno)="cancelaLiberarTurno()">
+                            [desdeAgenda]="true" (saveLiberarTurno)="saveLiberarTurno($event)"
+                            (reasignarTurnoLiberado)="reasignarTurnoLiberado($event)"
+                            (cancelaLiberarTurno)="cancelaLiberarTurno()">
                         </liberar-turno>
                     </plex-help>
                 </ng-container>


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/RUP-521

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se quita el boton de suspender y liberar turno/sobreturno cuando el mismo tiene una prestación asociada. 


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si   https://github.com/andes/api/pull/2201
- [ ] No

> [!NOTE]
> Para poder probarlo se crea una nueva agenda con turnos del día, luego vamos a ventanillas citas y le asignamos un turno a cualquier paciente. Nos dirigimos a rup y buscamos al paciente que tiene un turno y le iniciamos la prestación, pero no la validamos (ya que solamente funciona para pestaciones en ejecución. Para prestaciones validadas se considera que el paciente asistió al mismo con lo cual los botones suspender/liberar desaparecen). Por ultimo nos vamos al gestor de agendas y ahí podemos ver que si el turno tiene una prestación iniciada no se visualizarán los botones mencionados anteriormente. 

<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
