### PR TITLE
CIT - Visualizar motivo de liberación de turno

### DIFF
--- a/src/app/components/turnos/dashboard/estadisticas-pacientes.component.ts
+++ b/src/app/components/turnos/dashboard/estadisticas-pacientes.component.ts
@@ -159,9 +159,4 @@ export class EstadisticasPacientesComponent implements OnInit {
         this.demandaCerrada.emit();
     }
 
-    motivoLiberado(turno) {
-        const fechaModificacion = turno.createdAt ? moment(turno.createdAt) : moment(turno.updatedAt);
-        const usuarioModificacion = turno.createdBy?.email ? turno.createdBy.nombre : turno.createdBy.nombreCompleto;
-        return `Por ${usuarioModificacion} el ${moment(fechaModificacion).format('DD/MM/YYYY')} a las ${moment(fechaModificacion).format('HH:mm')}`;
-    }
 }

--- a/src/app/components/turnos/dashboard/estadisticas-pacientes.html
+++ b/src/app/components/turnos/dashboard/estadisticas-pacientes.html
@@ -10,7 +10,7 @@
     </plex-tab>
     <plex-tab icon="clock" label="Turnos">
         <turnos-paciente [paciente]='paciente' [turnos]="turnosPaciente$ | async" [operacion]="'operacionTurnos'"
-                         (turnosPacienteChanged)="refresh()" *plTab>
+            (turnosPacienteChanged)="refresh()" *plTab>
         </turnos-paciente>
         <ng-container *ngIf="demandaInsatisfecha">
             <demandaInsatisfecha (demandaCerrada)="cerrarDemandaInsatisfecha()" [paciente]='paciente'>
@@ -22,27 +22,27 @@
             <plex-title size="sm" titulo="Historial de turnos"></plex-title>
             <plex-wrapper>
                 <plex-datetime grow="1" type="date" [(ngModel)]="fechaDesde" name="fechaDesde" [debounce]="600"
-                               label="Fecha desde" class="fechas" (change)="filtrar()" [max]="fechaHasta">
+                    label="Fecha desde" class="fechas" (change)="filtrar()" [max]="fechaHasta">
                 </plex-datetime>
                 <plex-datetime grow="1" type="date" [(ngModel)]="fechaHasta" name="fechaHasta" [debounce]="600"
-                               label="Fecha hasta" class="fechas" (change)="filtrar()" [min]="fechaDesde">
+                    label="Fecha hasta" class="fechas" (change)="filtrar()" [min]="fechaDesde">
                 </plex-datetime>
                 <plex-select [(ngModel)]="estadoTurno" name="estadoTurno" label="Estado" [data]="estados"
-                             (change)="filtrar()"></plex-select>
+                    (change)="filtrar()"></plex-select>
                 <plex-select label="Prestación" name="prestacion" [(ngModel)]="prestacion" labelField="term"
-                             tmPrestaciones="rup:tipoPrestacion:?" [preload]="true" (change)="filtrar()">
+                    tmPrestaciones="rup:tipoPrestacion:?" [preload]="true" (change)="filtrar()">
                 </plex-select>
             </plex-wrapper>
 
             <ng-container *ngIf="(ultimosTurnos$ | async) as ultimosTurnos">
                 <div class="contenedor-turnos-vacio" *ngIf="!ultimosTurnos?.length" justify="center">
                     <plex-label class="label-turnos-vacio" icon="turno-bold" type="info" size="lg" direction="column"
-                                titulo="No se han encontrado turnos registrados para el paciente.">
+                        titulo="No se han encontrado turnos registrados para el paciente.">
                     </plex-label>
                 </div>
                 <ng-container *ngIf="ultimosTurnos?.length">
                     <plex-table [columns]="columns" #table="plTable" (scroll)="onScroll()" [height]="580"
-                                [headOpacity]="10">
+                        [headOpacity]="10">
                         <plex-table-columns>
                         </plex-table-columns>
 
@@ -69,18 +69,40 @@
                             </td>
                             <td *plTableCol="'estado'">
                                 <plex-badge *ngIf="turno.asistencia === 'noAsistio' && turno.estado !== 'suspendido'"
-                                            type="danger">NO ASISTIÓ</plex-badge>
+                                    type="danger">NO ASISTIÓ</plex-badge>
                                 <plex-badge *ngIf="turno.estado === 'fuera-agenda'" type="warning">
                                     FUERA DE AGENDA</plex-badge>
-                                <plex-badge *ngIf="turno.asistencia !== 'noAsistio' && (turno.estado === 'asignado' || turno.estado === 'turnoDoble')"
-                                            type="success">
+                                <plex-badge
+                                    *ngIf="turno.asistencia !== 'noAsistio' && (turno.estado === 'asignado' || turno.estado === 'turnoDoble')"
+                                    type="success">
                                     ASIGNADO</plex-badge>
-                                <plex-badge *ngIf="turno.estado === 'liberado' || turno.estado === 'suspendido'"
-                                            type="danger"
-                                            [hint]="turno.estado === 'liberado' ? motivoLiberado(turno) : (turno.reasignado) ? 'Reasignado' : null"
-                                            hintType="danger" detach="top">
-                                    {{ turno.estado | uppercase }}
-                                </plex-badge>
+                                <div class="d-flex align-items-center">
+                                    <plex-badge *ngIf="turno.estado === 'liberado' || turno.estado === 'suspendido'"
+                                        type="danger" [hint]="(turno.reasignado) ? 'Reasignado' : null"
+                                        hintType="danger">
+                                        {{ turno.estado | uppercase }}
+                                    </plex-badge>
+                                    <plex-help *ngIf="turno.estado === 'liberado'" class="ml-1"
+                                        icon="information-variant" btnType="danger">
+                                        <plex-title size="sm" titulo="Datos del turno"></plex-title>
+                                        <div class="row">
+                                            <div class="col-12">
+                                                <label>Liberado por </label> {{ turno.updatedBy | nombre }}
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-12">
+                                                <label>Fecha y hora de liberación </label> {{ turno.updatedAt |
+                                                date:'dd/MM/yyyy HH:mm'}}
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-12">
+                                                <label>Motivo de liberación </label> {{ turno.observaciones }}
+                                            </div>
+                                        </div>
+                                    </plex-help>
+                                </div>
                             </td>
                         </tr>
                     </plex-table>


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/CIT-408

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se remplaza hint por un plex-help para mostrar los datos necesarios sobre la liberación de un turno.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [X] Si   https://github.com/andes/api/pull/2216
- [ ] No

> [!NOTE]
> Solo basta con dirigirse a la ventanilla de citas y seleccionar un paciente para luego filtrar por los turnos liberados. En caso de querer completar todos los datos sobre este, se tiene que cargar un turno a un paciente para luego liberarlo. De esta forma vamos a poder cargarle cualquier tipo de motivo para luego visualizarlo dentro del plex-help. 
