### PR TITLE
CIT - Ventanilla: No es posible dar turno del dia

### DIFF
--- a/src/app/components/turnos/dar-turnos/calendario-dia.class.ts
+++ b/src/app/components/turnos/dar-turnos/calendario-dia.class.ts
@@ -63,11 +63,14 @@ export class CalendarioDia {
                            - Tengan turnos del dia o programados disponibles
                         */
                         const exclusivosGestion = this.bloquesExclusivosGestion(unaAgenda);
-                        if (exclusivosGestion.length) {
-                            this.estado = (exclusivosGestion.some(bloque => bloque.restantesGestion > 0) ? 'disponible' : 'ocupado');
+                        const tieneGestion = exclusivosGestion.some(bloque => bloque.restantesGestion > 0);
+                        if (exclusivosGestion.length && tieneGestion) {
+                            this.estado = 'disponible';
                             this.turnosDisponibles += exclusivosGestion.map(bloque => bloque.restantesGestion).reduce((a, b) => a + b, 0);
+                        } else if (this.delDiaDisponibles > 0) {
+                            this.estado = 'disponible';
                         } else {
-                            this.estado = (this.delDiaDisponibles > 0 && this.gestionDisponibles === 0) ? 'disponible' : 'ocupado';
+                            this.estado = 'ocupado';
                         }
 
                     } else {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/CIT-415
GLPI asociado: https://glpi.andes.gob.ar/front/ticket.form.php?id=6265
https://glpi.andes.gob.ar/front/ticket.form.php?id=6296
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
#### Problema
La interfaz de "Selección horario" y la grilla de turnos no se mostraban para agendas del día que tenían turnos "Del Día" disponibles, si la agenda contenía al menos un bloque exclusivo de gestión sin turnos restantes.

**Condiciones para reproducir:**
1. La agenda es del día de hoy y se encuentra en estado `disponible`.
2. La agenda tiene turnos "Del Día" disponibles en alguno de sus bloques (`restantesDelDia > 0`).
3. La agenda tiene al menos un bloque "exclusivo de gestión" (`reservadoGestion > 0`, `accesoDirectoDelDia === 0`, `accesoDirectoProgramado === 0`).
4. Ese bloque de gestión ya consumió todos sus turnos (`restantesGestion === 0`).

En la clase `CalendarioDia` (`calendario-dia.class.ts`), la lógica que determina si un día tiene disponibilidad priorizaba estrictamente la existencia de bloques exclusivos de gestión. 

Se corrigió la validación en `CalendarioDia` para que contemple ambas disponibilidades (Gestión o Del Día) en agendas con bloques mixtos:


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->
<img width="1719" height="777" alt="image" src="https://github.com/user-attachments/assets/3c97ffcb-f995-488e-8b8d-8b7892895c2e" />




<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
