### PR TITLE
MPI - Resolver el escaneo de nuevos DNIs

### DIFF
--- a/src/app/core/mpi/services/paciente-buscar.service.ts
+++ b/src/app/core/mpi/services/paciente-buscar.service.ts
@@ -86,13 +86,16 @@ export class PacienteBuscarService {
     public findByScan(pacienteEscaneado: PacienteEscaneado) {
         const textoLibre = pacienteEscaneado.scan;
         // 1. Busca por documento escaneado (simplequery)
-        return this.pacienteService.get({
+        const query: any = {
             apellido: pacienteEscaneado.apellido,
             nombre: pacienteEscaneado.nombre,
             documento: pacienteEscaneado.documento,
-            sexo: pacienteEscaneado.sexo,
             activo: true
-        }).pipe(
+        };
+        if (pacienteEscaneado.sexo) {
+            query.sexo = pacienteEscaneado.sexo;
+        }
+        return this.pacienteService.get(query).pipe(
             map(resultado => {
                 return resultado.length ? { scan: textoLibre, pacientes: resultado, err: null } : null;
             }),
@@ -103,13 +106,16 @@ export class PacienteBuscarService {
                 }
 
                 // 1.3. Si no encontró el paciente escaneado, busca uno similar (suggest)
-                return this.pacienteService.match({
+                const querySuggest: any = {
                     apellido: pacienteEscaneado.apellido,
                     nombre: pacienteEscaneado.nombre,
                     documento: pacienteEscaneado.documento,
-                    sexo: pacienteEscaneado.sexo,
                     fechaNacimiento: pacienteEscaneado.fechaNacimiento
-                }).pipe(
+                };
+                if (pacienteEscaneado.sexo) {
+                    querySuggest.sexo = pacienteEscaneado.sexo;
+                }
+                return this.pacienteService.match(querySuggest).pipe(
                     map((resultadoSuggest: any) => {
                         // 1.3.1. Si no encontró ninguno, retorna un array vacio
                         if (!resultadoSuggest.length) {
@@ -230,6 +236,17 @@ export const DocumentoEscaneados: DocumentoEscaneado[] = [
         grupoNombre: 2,
         grupoSexo: 3,
         grupoFechaNacimiento: 5
+    },
+
+    // DNI Argentino versión 2026 (sin sexo)
+    // Formato: NroTramite@Apellido@NombreCompleto@NroDni@Ejemplar@FechaNacimiento@FechaEmision@TokenValidacion
+    {
+        regEx: /([0-9]+)@([a-zA-ZñÑáéíóúÁÉÍÓÚÜü'\-\s]+)@([a-zA-ZñÑáéíóúÁÉÍÓÚÜü'\-\s]+)@([0-9]+)@([A-Z]+)@([0-9]{2}\/[0-9]{2}\/[0-9]{2,4})@([0-9]{2}\/[0-9]{2}\/[0-9]{2,4})@(.*)/i,
+        grupoNumeroDocumento: 4,
+        grupoApellido: 2,
+        grupoNombre: 3,
+        grupoSexo: 0,
+        grupoFechaNacimiento: 6
     },
 
     // QR ACTA DE NACIMIENTO

--- a/src/app/modules/mpi/components/paciente-buscar.component.ts
+++ b/src/app/modules/mpi/components/paciente-buscar.component.ts
@@ -4,16 +4,6 @@ import { PacienteBuscarResultado } from '../interfaces/PacienteBuscarResultado.i
 import { PacienteBuscarService } from '../../../core/mpi/services/paciente-buscar.service';
 import { Subscription } from 'rxjs';
 import { PacienteCacheService } from 'src/app/core/mpi/services/pacienteCache.service';
-
-interface PacienteEscaneado {
-    documento: string;
-    apellido: string;
-    nombre: string;
-    sexo: string;
-    fechaNacimiento: Date;
-    scan: string;
-}
-
 @Component({
     selector: 'paciente-buscar',
     templateUrl: 'paciente-buscar.html',


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/MPI-472

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega funcionalidad para contemplar los nuevos formatos de dni's
2. En el archivo paciente-buscar.ts, se elimina linea de creacion de una interface sin uso.

>[!NOTE]
>### SUGERENCIA DE CASOS PARA REPRODUCIR:
>1. Probar con formato: NroTramite@Apellido@NombreCompleto@NroDni@Ejemplar@FechaNacimiento@FechaEmision@TokenValidacion.
>2. Ejemplo TokenValidacion: 2026. 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
