### PR TITLE
Visualizar camas prestadas

### DIFF
--- a/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/item-cama/item-cama.component.html
+++ b/src/app/apps/rup/mapa-camas/views/mapa-camas-capa/item-cama/item-cama.component.html
@@ -79,6 +79,10 @@
             <plex-badge [type]="estadoCama?.color">
                 {{estadoCama?.label}}
             </plex-badge>
+            <plex-badge *ngIf="cama.unidadOrganizativa?.id !== cama.unidadOrganizativaOriginal?.id"
+                        tooltip="Cama prestada" type="info" class="ml-1">
+                <plex-icon name="cama"></plex-icon>
+            </plex-badge>
             <plex-badge *ngIf="cama.sala" type="info" class="ml-1" tooltip="Sala común con varios pacientes">
                 <plex-icon name="paciente-medico"></plex-icon>
             </plex-badge>


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/IN-686

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega un nuevo icono al listado de internaciones para informar a los usuarios de que la cama se encuentra prestada.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [X] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [X] No

>[!TIP]
> Para prestar una cama, nos dirigimos a una que se encuentre disponible (sin pacientes internados) y dentro del sidebar hay un botón llamado prestar. Una vez prestada buscarla dentro del listado y ahí se debería ver el nuevo icono con su respectivo tooltip. 
