### PR TITLE
REC - Andes: mejoras Insumos/dispositivos

### DIFF
--- a/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
+++ b/src/app/modules/rup/components/ejecucion/hudsBusqueda.component.ts
@@ -347,10 +347,11 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
         { id: 'insumo', nombre: 'Dispositivos / Insumos' },
         { id: 'alimentacion', nombre: 'Alimentación' }
     ];
-    public tipoPrescripcionSeleccionado = this.tiposPrescripcion[0];
-    private ultimoTipoCargado = 'medicamento';
+    public tipoPrescripcionSeleccionado = null;
+    private ultimoTipoCargado = null;
     public fechaInicioRecetas;
     public fechaFinRecetas;
+    public cantidadTotalRecetas = 0;
 
     toogleFiltros() {
         this.showFiltros = !this.showFiltros;
@@ -874,7 +875,7 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
             case 'solicitudes':
                 return this.solicitudesMezcladas.length;
             case 'recetas':
-                return this.busquedaRecetasOriginal?.length;
+                return this.cantidadTotalRecetas;
             case 'registro':
                 return this.registrosTotalesCopia.registro.length;
         }
@@ -1173,6 +1174,7 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
                             conceptId: receta.insumo?.id || receta.insumo?.concepto?.conceptId || '',
                             semanticTag: 'producto'
                         },
+                        tipoReceta: receta.tipoReceta || 'simple',
                         tratamientoProlongado: receta.insumo?.tratamientoProlongado,
                         tiempoTratamiento: receta.insumo?.tiempoTratamiento,
                         cantidad: receta.insumo?.cantidad,
@@ -1194,6 +1196,7 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
                             conceptId: receta.insumo?.id || receta.insumo?.concepto?.conceptId || '',
                             semanticTag: 'producto'
                         },
+                        tipoReceta: receta.tipoReceta || 'simple',
                         tratamientoProlongado: receta.insumo?.tratamientoProlongado,
                         tiempoTratamiento: receta.insumo?.tiempoTratamiento,
                         cantidad: receta.insumo?.cantidad,
@@ -1219,6 +1222,7 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
                             conceptId: receta.insumo?.id || receta.insumo?.concepto?.conceptId || '',
                             semanticTag: 'producto'
                         },
+                        tipoReceta: receta.tipoReceta || 'simple',
                         tratamientoProlongado: receta.insumo?.tratamientoProlongado,
                         tiempoTratamiento: receta.insumo?.tiempoTratamiento,
                         cantidad: receta.insumo?.cantidad,
@@ -1246,6 +1250,9 @@ export class HudsBusquedaComponent implements AfterContentInit, OnInit, OnDestro
                 }))
             );
             this.busquedaRecetasOriginal = this.busquedaRecetas;
+            if (!tipo) {
+                this.cantidadTotalRecetas = this.busquedaRecetasOriginal.length;
+            }
             this.filtrarRecetas();
         });
     }

--- a/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
+++ b/src/app/modules/rup/components/ejecucion/prestacionEjecucion.component.ts
@@ -104,7 +104,7 @@ export class PrestacionEjecucionComponent implements OnInit, OnDestroy {
 
     public conceptosAsociados;
 
-    public alerta = 'Este registro no puede modificarse, si necesita cambiar una medicación prescripta puede suspender desde la HUDS y registrar una nueva.';
+    public alerta = 'Este registro no puede modificarse, si necesita cambiar alguna prescripción puede suspenderla desde la HUDS y registrarla nuevamente.';
 
     private soloValores = ['33633005', '313047003', '1217195001', '1217196000'];
 
@@ -1008,7 +1008,7 @@ export class PrestacionEjecucionComponent implements OnInit, OnDestroy {
                 return false;
             }
 
-            const valido = this.ejecucionService.validarConcepto(registro.concepto);
+            const valido = this.ejecucionService.validarConcepto(registro.concepto, registro);
 
             return !valido;
         }

--- a/src/app/modules/rup/components/elementos/prescripcionInsumo.component.ts
+++ b/src/app/modules/rup/components/elementos/prescripcionInsumo.component.ts
@@ -44,7 +44,10 @@ export class PrescripcionInsumoComponent extends RUPComponent implements OnInit 
         if (!this.registro.valor.insumos) {
             this.registro.valor.insumos = [];
         }
-        this.registros = this.prestacion.ejecucion.registros.filter(reg => reg.id !== this.registro.id).map(reg => reg.concepto);
+        const conceptosPrescripcion = ['16076005', '33633005', '313047003', '1217195001', '1217196000'];
+        this.registros = this.prestacion.ejecucion.registros
+            .filter(reg => reg.id !== this.registro.id && !conceptosPrescripcion.includes(reg.concepto.conceptId))
+            .map(reg => reg.concepto);
         this.buscarDiagnosticosConTrastornos();
 
         this.ejecucionService?.hasActualizacion().subscribe(async (estado) => {
@@ -84,9 +87,10 @@ export class PrescripcionInsumoComponent extends RUPComponent implements OnInit 
     }
 
     loadRegistros() {
+        const conceptosPrescripcion = ['16076005', '33633005', '313047003', '1217195001', '1217196000'];
         this.registros = [
             ...this.prestacion.ejecucion.registros
-                .filter(reg => reg.id !== this.registro.id && (reg.concepto.semanticTag === 'procedimiento'
+                .filter(reg => reg.id !== this.registro.id && !conceptosPrescripcion.includes(reg.concepto.conceptId) && (reg.concepto.semanticTag === 'procedimiento'
                     || reg.concepto.semanticTag === 'hallazgo' || reg.concepto.semanticTag === 'trastorno'))
                 .map(reg => reg.concepto),
             ...this.recetasConFiltros

--- a/src/app/modules/rup/components/huds/vistaReceta.html
+++ b/src/app/modules/rup/components/huds/vistaReceta.html
@@ -15,7 +15,7 @@
                     <plex-badge *ngIf="checkDispensaAnticipada(recetaPrincipal)" size="sm" type="warning">
                         {{ checkDispensaAnticipada(recetaPrincipal) }}
                     </plex-badge>
-                    <plex-badge *ngIf="recetaPrincipal.medicamento" size="sm" type="default">
+                    <plex-badge *ngIf="recetaPrincipal.medicamento?.tipoReceta && recetaPrincipal.insumo?.tipo !== 'dispositivo' && recetaPrincipal.insumo?.tipo !== 'nutricion'" size="sm" type="default">
                         {{ recetaPrincipal.medicamento.tipoReceta }}
                     </plex-badge>
                 </div>

--- a/src/app/modules/rup/interfaces/prestacion.estado.interface.ts
+++ b/src/app/modules/rup/interfaces/prestacion.estado.interface.ts
@@ -14,4 +14,5 @@ export interface IPrestacionEstado {
             nombre: string;
         };
     };
+    createdAt?: Date;
 }

--- a/src/app/modules/rup/services/ejecucion.service.ts
+++ b/src/app/modules/rup/services/ejecucion.service.ts
@@ -85,9 +85,9 @@ export class RupEjecucionService {
         this.sugeridos.next(conceptos);
     }
 
-    public validarConcepto(concepto: ISnomedConcept): boolean {
+    public validarConcepto(concepto: ISnomedConcept, registro?: any): boolean {
         const registros = this.getPrestacionRegistro();
-        const conceptoExistente = registros.find(registro => registro.concepto.conceptId === concepto.conceptId);
+        const conceptoExistente = registros.find(r => r.concepto.conceptId === concepto.conceptId);
 
         if (!conceptoExistente) {
             return true;
@@ -96,13 +96,19 @@ export class RupEjecucionService {
         const validacionRota = this.checkValidacionRota();
 
         if (validacionRota) {
-            if (conceptoExistente) {
+            const validadaState = [...(this.prestacion.estados || [])]
+                .reverse()
+                .find(estado => estado.tipo === 'validada');
+
+            if (validadaState) {
+                if (registro) {
+                    if (registro.createdAt) {
+                        return new Date(registro.createdAt).getTime() > new Date(validadaState.createdAt).getTime();
+                    }
+                    return true;
+                }
                 return false;
             }
-        }
-
-        if (validacionRota && concepto.conceptId === '33633005') {
-            return false;
         }
 
         return true;
@@ -154,8 +160,11 @@ export class RupEjecucionService {
         const registros = this.getPrestacionRegistro();
         const registoExiste = registros.find(registro => registro.concepto.conceptId === concepto.conceptId);
         if (registoExiste) {
-            this.plex.toast('warning', 'El elemento seleccionado ya se encuentra registrado.');
-            return false;
+            const isEditable = this.validarConcepto(concepto, registoExiste);
+            if (isEditable) {
+                this.plex.toast('warning', 'El elemento seleccionado ya se encuentra registrado.');
+                return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->
https://proyectos.andes.gob.ar/browse/REC-252
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Cuando la validación de una prestación se rompe (pasa de "validada" a "ejecución"), ahora el sistema compara la fecha de creación del registro (createdAt) con la fecha de la última validación (validadaState.createdAt):
Permite edición: Si el registro fue creado después del estado validada (en la nueva etapa de ejecución), se puede editar o eliminar.
Bloquea edición: Si fue creado antes, se mantiene bloqueado para preservar el registro validado original.
Flexibilidad al agregar duplicados: Al intentar agregar un concepto repetido, si el registro existente no es editable (porque ya fue validado), ahora el sistema sí permite agregar uno nuevo en lugar de bloquear la acción con un aviso de que ya se encuentra registrado.
Actualización de mensaje de alerta: Se actualizó el texto de advertencia en la ejecución de la prestación para abarcar cualquier tipo de prescripción (medicamentos, insumos, etc.):
Antes: "...si necesita cambiar una medicación prescripta..."
Ahora: "...si necesita cambiar alguna prescripción..."

2. Mejoras en la Búsqueda y Filtros de la HUDS (hudsBusqueda.component.ts)
Mapeo de Tipo de Receta: Se añade el campo tipoReceta (por defecto 'simple') al mapear los distintos tipos de prescripciones en el listado de búsquedas.
Corrección en Contadores: Se introduce la variable cantidadTotalRecetas para reflejar la cantidad total de recetas reales en el contador de la pestaña, evitando que el número cambie o se pierda al aplicar filtros específicos por tipo de prescripción.

3. Visualización de Recetas (vistaReceta.html)
Badge del tipo de receta: Se ajustó la condición para mostrar el badge con el tipo de receta. Ahora se oculta para prescripciones que correspondan a dispositivos o nutrición, mostrándose únicamente para medicamentos.

4. Selección de Relaciones en Prescripción de Insumos (prescripcionInsumo.component.ts)
Exclusión de conceptos de prescripción: Se agregaron filtros para que los conceptos de prescripción ('16076005', '33633005', '313047003', '1217195001', '1217196000') no se listen como registros asociables dentro del componente de prescripción de insumos

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
